### PR TITLE
Add MIT license and update repo reference

### DIFF
--- a/GitHubOpsReference.md
+++ b/GitHubOpsReference.md
@@ -9,7 +9,8 @@ This file is the working reference for future GitHub-related tasks in this repos
 - Remote: `origin`
 - URL: `https://github.com/ATAC-Helicopter/Blueprints`
 - Default branch: `main`
-- Visibility: `private` for now
+- Visibility: `public`
+- License: `MIT`
 
 ## Branch Strategy
 
@@ -178,9 +179,9 @@ gh repo edit ATAC-Helicopter/Blueprints --description "Repository description"
 
 ## Public Release Readiness Checklist
 
-Before switching the repository to public:
+For public maintenance:
 
-- choose and add a license
+- confirm the current license still matches project intent
 - review `README.md`
 - review `SECURITY.md`
 - confirm issue and PR templates are correct
@@ -188,13 +189,12 @@ Before switching the repository to public:
 - confirm no sensitive data or secrets were committed
 - review topics, labels, milestones, and release notes
 - decide whether Discussions should stay disabled
-- decide whether branch protection rules should be added
+- review whether admin bypass should remain allowed
 
 ## Safe Defaults For Future GitHub Tasks
 
 Unless there is a strong reason otherwise:
 
-- keep the repository private until licensing and public docs are ready
 - prefer draft prereleases before publishing anything final
 - keep merge commits disabled
 - use squash or rebase merge only
@@ -419,7 +419,22 @@ Update if needed:
 - verify there are no secrets or unsafe artifacts
 - apply branch protection once available
 
-### 14. After Any GitHub/Admin Task
+### 14. Protected Branches
+
+Check:
+
+- whether `main` and `develop` are still protected
+- whether required checks still match the actual CI workflow names
+- whether review requirements are still appropriate for the maintainer model
+- whether admin bypass should remain enabled
+
+Update if needed:
+
+- adjust branch protection when CI names change
+- tighten admin enforcement only when maintainer coverage makes it safe
+- avoid deadlocking the repo with protection rules that nobody can satisfy
+
+### 15. After Any GitHub/Admin Task
 
 Always do:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ATAC-Helicopter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add the MIT license file
- update the GitHub operations reference for the public/licensed repo state

## Verification
- documentation and repository metadata only

## Notes
- this clears the licensing blocker for public maintenance and future releases