### PR TITLE
Add DPAPI-backed local identity management

### DIFF
--- a/Blueprints.App/Services/AppEnvironment.cs
+++ b/Blueprints.App/Services/AppEnvironment.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.App.Services;
+
+public static class AppEnvironment
+{
+    public static string GetIdentityRoot()
+    {
+        var appDataRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(appDataRoot, "Blueprints", "Identities");
+    }
+}

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using Blueprints.Collaboration.Enums;
 using Blueprints.Collaboration.Models;
 using Blueprints.Core.Enums;
 using Blueprints.Core.Models;
+using Blueprints.Security.Abstractions;
 using Blueprints.Security.Models;
 using Blueprints.Security.Services;
 
@@ -10,8 +11,12 @@ namespace Blueprints.App.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
-    public MainWindowViewModel()
+    public MainWindowViewModel(IIdentityService identityService)
     {
+        ArgumentNullException.ThrowIfNull(identityService);
+
+        var identity = identityService.GetOrCreateDefaultIdentity("Local Admin");
+
         CurrentProject = new ProjectSummary(
             "VaultSync",
             "VS",
@@ -19,9 +24,9 @@ public partial class MainWindowViewModel : ViewModelBase
             @"\\NAS\Blueprints\VaultSync");
 
         Identity = new IdentitySummary(
-            "Flavio",
-            "b2d53ce4-f2e2-4ec5-b0ed-31fd2049d7f8",
-            "DPAPI");
+            identity.Profile.DisplayName,
+            identity.Profile.UserId.ToString(),
+            identity.Profile.KeyStorageProvider);
 
         Sync = new SyncSummary(
             SyncHealth.Ready,
@@ -42,6 +47,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ProjectSummary CurrentProject { get; }
 
     public IdentitySummary Identity { get; }
+
+    public string IdentityId => Identity.UserId;
 
     public SyncSummary Sync { get; }
 

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -60,6 +60,10 @@
           <TextBlock Text="{Binding Identity.KeyStorageProvider}"
                      Foreground="#CFE2D8"
                      HorizontalAlignment="Right" />
+          <TextBlock Text="{Binding IdentityId}"
+                     Foreground="#9DB7AA"
+                     FontSize="11"
+                     HorizontalAlignment="Right" />
         </StackPanel>
       </Grid>
     </Border>

--- a/Blueprints.Security/Abstractions/IIdentityService.cs
+++ b/Blueprints.Security/Abstractions/IIdentityService.cs
@@ -1,0 +1,10 @@
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Abstractions;
+
+public interface IIdentityService
+{
+    StoredIdentity GetOrCreateDefaultIdentity(string displayName);
+
+    IReadOnlyList<IdentityProfile> ListProfiles();
+}

--- a/Blueprints.Security/Abstractions/IIdentityStore.cs
+++ b/Blueprints.Security/Abstractions/IIdentityStore.cs
@@ -1,0 +1,10 @@
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Abstractions;
+
+public interface IIdentityStore
+{
+    StoredIdentity Create(string displayName);
+
+    StoredIdentity Load(Guid userId);
+}

--- a/Blueprints.Security/Abstractions/IPrivateKeyProtector.cs
+++ b/Blueprints.Security/Abstractions/IPrivateKeyProtector.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.Security.Abstractions;
+
+public interface IPrivateKeyProtector
+{
+    string ProviderName { get; }
+
+    byte[] Protect(ReadOnlySpan<byte> privateKeyBytes);
+
+    byte[] Unprotect(ReadOnlySpan<byte> protectedPrivateKeyBytes);
+}

--- a/Blueprints.Security/Blueprints.Security.csproj
+++ b/Blueprints.Security/Blueprints.Security.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blueprints.Security/Models/IdentityProfile.cs
+++ b/Blueprints.Security/Models/IdentityProfile.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.Security.Models;
+
+public sealed record IdentityProfile(
+    Guid UserId,
+    string DisplayName,
+    string KeyId,
+    string PublicKeyBase64,
+    string KeyStorageProvider,
+    DateTimeOffset CreatedUtc);

--- a/Blueprints.Security/Models/StoredIdentity.cs
+++ b/Blueprints.Security/Models/StoredIdentity.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.Security.Models;
+
+public sealed record StoredIdentity(
+    IdentityProfile Profile,
+    SignatureKeyMaterial SigningKey,
+    SignaturePublicKey PublicKey);

--- a/Blueprints.Security/Models/StoredIdentityRecord.cs
+++ b/Blueprints.Security/Models/StoredIdentityRecord.cs
@@ -1,0 +1,5 @@
+namespace Blueprints.Security.Models;
+
+public sealed record StoredIdentityRecord(
+    IdentityProfile Profile,
+    string ProtectedPrivateKeyFileName);

--- a/Blueprints.Security/Services/DpapiPrivateKeyProtector.cs
+++ b/Blueprints.Security/Services/DpapiPrivateKeyProtector.cs
@@ -1,0 +1,40 @@
+using System.Security.Cryptography;
+using System.Runtime.Versioning;
+using System.Text;
+using Blueprints.Security.Abstractions;
+
+namespace Blueprints.Security.Services;
+
+[SupportedOSPlatform("windows")]
+public sealed class DpapiPrivateKeyProtector : IPrivateKeyProtector
+{
+    private static readonly byte[] OptionalEntropy = Encoding.UTF8.GetBytes("Blueprints.PrivateKey.v1");
+
+    public string ProviderName => "DPAPI";
+
+    public byte[] Protect(ReadOnlySpan<byte> privateKeyBytes)
+    {
+        if (privateKeyBytes.IsEmpty)
+        {
+            throw new ArgumentException("Private key payload must not be empty.", nameof(privateKeyBytes));
+        }
+
+        return ProtectedData.Protect(
+            privateKeyBytes.ToArray(),
+            OptionalEntropy,
+            DataProtectionScope.CurrentUser);
+    }
+
+    public byte[] Unprotect(ReadOnlySpan<byte> protectedPrivateKeyBytes)
+    {
+        if (protectedPrivateKeyBytes.IsEmpty)
+        {
+            throw new ArgumentException("Protected private key payload must not be empty.", nameof(protectedPrivateKeyBytes));
+        }
+
+        return ProtectedData.Unprotect(
+            protectedPrivateKeyBytes.ToArray(),
+            OptionalEntropy,
+            DataProtectionScope.CurrentUser);
+    }
+}

--- a/Blueprints.Security/Services/FileSystemIdentityStore.cs
+++ b/Blueprints.Security/Services/FileSystemIdentityStore.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using System.Text.Json;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Services;
+
+public sealed class FileSystemIdentityStore : IIdentityStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly string _rootDirectory;
+    private readonly IKeyPairGenerator _keyPairGenerator;
+    private readonly IPrivateKeyProtector _privateKeyProtector;
+
+    public FileSystemIdentityStore(
+        string rootDirectory,
+        IKeyPairGenerator keyPairGenerator,
+        IPrivateKeyProtector privateKeyProtector)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
+
+        _rootDirectory = rootDirectory;
+        _keyPairGenerator = keyPairGenerator;
+        _privateKeyProtector = privateKeyProtector;
+    }
+
+    public StoredIdentity Create(string displayName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+
+        var userId = Guid.NewGuid();
+        var keyId = userId.ToString("N");
+        var keyPair = _keyPairGenerator.Generate(keyId);
+        var profile = new IdentityProfile(
+            UserId: userId,
+            DisplayName: displayName.Trim(),
+            KeyId: keyPair.KeyId,
+            PublicKeyBase64: Convert.ToBase64String(keyPair.PublicKeyBytes),
+            KeyStorageProvider: _privateKeyProtector.ProviderName,
+            CreatedUtc: DateTimeOffset.UtcNow);
+
+        var identityDirectory = GetIdentityDirectory(userId);
+        Directory.CreateDirectory(identityDirectory);
+
+        var protectedPrivateKeyBytes = _privateKeyProtector.Protect(keyPair.PrivateKeyBytes);
+
+        File.WriteAllText(
+            GetProfilePath(userId),
+            JsonSerializer.Serialize(profile, SerializerOptions),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        File.WriteAllBytes(GetProtectedPrivateKeyPath(userId), protectedPrivateKeyBytes);
+
+        return new StoredIdentity(
+            profile,
+            new SignatureKeyMaterial(profile.KeyId, keyPair.PrivateKeyBytes),
+            new SignaturePublicKey(profile.KeyId, keyPair.PublicKeyBytes));
+    }
+
+    public StoredIdentity Load(Guid userId)
+    {
+        var profilePath = GetProfilePath(userId);
+        var privateKeyPath = GetProtectedPrivateKeyPath(userId);
+
+        if (!File.Exists(profilePath))
+        {
+            throw new FileNotFoundException("Identity profile was not found.", profilePath);
+        }
+
+        if (!File.Exists(privateKeyPath))
+        {
+            throw new FileNotFoundException("Protected private key was not found.", privateKeyPath);
+        }
+
+        var profileJson = File.ReadAllText(profilePath, Encoding.UTF8);
+        var profile = JsonSerializer.Deserialize<IdentityProfile>(profileJson, SerializerOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize identity profile.");
+
+        var protectedPrivateKeyBytes = File.ReadAllBytes(privateKeyPath);
+        var privateKeyBytes = _privateKeyProtector.Unprotect(protectedPrivateKeyBytes);
+        var publicKeyBytes = Convert.FromBase64String(profile.PublicKeyBase64);
+
+        return new StoredIdentity(
+            profile,
+            new SignatureKeyMaterial(profile.KeyId, privateKeyBytes),
+            new SignaturePublicKey(profile.KeyId, publicKeyBytes));
+    }
+
+    private string GetIdentityDirectory(Guid userId) =>
+        Path.Combine(_rootDirectory, userId.ToString("N"));
+
+    private string GetProfilePath(Guid userId) =>
+        Path.Combine(GetIdentityDirectory(userId), "identity.json");
+
+    private string GetProtectedPrivateKeyPath(Guid userId) =>
+        Path.Combine(GetIdentityDirectory(userId), "private.key.protected");
+}

--- a/Blueprints.Security/Services/IdentityService.cs
+++ b/Blueprints.Security/Services/IdentityService.cs
@@ -1,0 +1,64 @@
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Services;
+
+public sealed class IdentityService : IIdentityService
+{
+    private readonly string _rootDirectory;
+    private readonly IIdentityStore _identityStore;
+
+    public IdentityService(string rootDirectory, IIdentityStore identityStore)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
+
+        _rootDirectory = rootDirectory;
+        _identityStore = identityStore;
+    }
+
+    public StoredIdentity GetOrCreateDefaultIdentity(string displayName)
+    {
+        var existingProfile = ListProfiles()
+            .OrderBy(static profile => profile.CreatedUtc)
+            .FirstOrDefault();
+
+        return existingProfile is null
+            ? _identityStore.Create(displayName)
+            : _identityStore.Load(existingProfile.UserId);
+    }
+
+    public IReadOnlyList<IdentityProfile> ListProfiles()
+    {
+        if (!Directory.Exists(_rootDirectory))
+        {
+            return [];
+        }
+
+        var profiles = new List<IdentityProfile>();
+
+        foreach (var identityDirectory in Directory.EnumerateDirectories(_rootDirectory))
+        {
+            var profilePath = Path.Combine(identityDirectory, "identity.json");
+            if (!File.Exists(profilePath))
+            {
+                continue;
+            }
+
+            var profile = System.Text.Json.JsonSerializer.Deserialize<IdentityProfile>(
+                File.ReadAllText(profilePath),
+                new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+                });
+
+            if (profile is not null)
+            {
+                profiles.Add(profile);
+            }
+        }
+
+        return profiles
+            .OrderBy(static profile => profile.CreatedUtc)
+            .ToArray();
+    }
+}

--- a/Blueprints.Tests/DpapiPrivateKeyProtectorTests.cs
+++ b/Blueprints.Tests/DpapiPrivateKeyProtectorTests.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Versioning;
+using Blueprints.Security.Services;
+
+namespace Blueprints.Tests;
+
+[SupportedOSPlatform("windows")]
+public sealed class DpapiPrivateKeyProtectorTests
+{
+    [Fact]
+    public void ProtectAndUnprotect_RoundTripsPrivateKeyPayload()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var protector = new DpapiPrivateKeyProtector();
+        var original = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+        var protectedBytes = protector.Protect(original);
+        var unprotectedBytes = protector.Unprotect(protectedBytes);
+
+        Assert.NotEqual(original, protectedBytes);
+        Assert.Equal(original, unprotectedBytes);
+    }
+}

--- a/Blueprints.Tests/FileSystemIdentityStoreTests.cs
+++ b/Blueprints.Tests/FileSystemIdentityStoreTests.cs
@@ -1,0 +1,47 @@
+using System.Runtime.Versioning;
+using Blueprints.Security.Services;
+
+namespace Blueprints.Tests;
+
+[SupportedOSPlatform("windows")]
+public sealed class FileSystemIdentityStoreTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "IdentityStore",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void CreateAndLoad_RoundTripsIdentityThroughProtectedFilesystemStorage()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_rootDirectory);
+
+        var store = new FileSystemIdentityStore(
+            _rootDirectory,
+            new Ed25519KeyPairGenerator(),
+            new DpapiPrivateKeyProtector());
+
+        var createdIdentity = store.Create("Flavio");
+        var loadedIdentity = store.Load(createdIdentity.Profile.UserId);
+
+        Assert.Equal("Flavio", loadedIdentity.Profile.DisplayName);
+        Assert.Equal("DPAPI", loadedIdentity.Profile.KeyStorageProvider);
+        Assert.Equal(createdIdentity.Profile.KeyId, loadedIdentity.Profile.KeyId);
+        Assert.Equal(createdIdentity.SigningKey.PrivateKeyBytes, loadedIdentity.SigningKey.PrivateKeyBytes);
+        Assert.Equal(createdIdentity.PublicKey.PublicKeyBytes, loadedIdentity.PublicKey.PublicKeyBytes);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}

--- a/Blueprints.Tests/IdentityServiceTests.cs
+++ b/Blueprints.Tests/IdentityServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Runtime.Versioning;
+using Blueprints.Security.Services;
+
+namespace Blueprints.Tests;
+
+[SupportedOSPlatform("windows")]
+public sealed class IdentityServiceTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "IdentityService",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void GetOrCreateDefaultIdentity_CreatesThenReloadsSameIdentity()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_rootDirectory);
+
+        var store = new FileSystemIdentityStore(
+            _rootDirectory,
+            new Ed25519KeyPairGenerator(),
+            new DpapiPrivateKeyProtector());
+
+        var service = new IdentityService(_rootDirectory, store);
+
+        var first = service.GetOrCreateDefaultIdentity("Flavio");
+        var second = service.GetOrCreateDefaultIdentity("Ignored Second Name");
+
+        Assert.Equal(first.Profile.UserId, second.Profile.UserId);
+        Assert.Equal("Flavio", second.Profile.DisplayName);
+        Assert.Single(service.ListProfiles());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DPAPI-backed private key protection for Windows-first identity storage
- add filesystem-backed identity create/load services
- wire the Avalonia shell to create/load a real local identity on startup
- add tests for DPAPI, identity storage, and identity service behavior

## Verification
- [x] dotnet build Blueprints.sln
- [x] dotnet test Blueprints.sln

## Notes
- this closes the core implementation work for issue #8
- the shell now uses a real local identity path, but project/workspace persistence is still separate work