### PR TITLE
Add signed workspace persistence store

### DIFF
--- a/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
@@ -1,0 +1,16 @@
+using Blueprints.Security.Models;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.Storage.Abstractions;
+
+public interface IProjectWorkspaceStore
+{
+    void Save(
+        string workspaceRoot,
+        ProjectWorkspaceSnapshot workspace,
+        SignatureKeyMaterial signingKey);
+
+    ProjectWorkspaceLoadResult Load(
+        string workspaceRoot,
+        SignaturePublicKey publicKey);
+}

--- a/Blueprints.Storage/Models/ProjectWorkspaceLoadResult.cs
+++ b/Blueprints.Storage/Models/ProjectWorkspaceLoadResult.cs
@@ -1,0 +1,7 @@
+using Blueprints.Security.Models;
+
+namespace Blueprints.Storage.Models;
+
+public sealed record ProjectWorkspaceLoadResult(
+    ProjectWorkspaceSnapshot Workspace,
+    TrustReport TrustReport);

--- a/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
+++ b/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
@@ -1,0 +1,8 @@
+using Blueprints.Core.Models;
+
+namespace Blueprints.Storage.Models;
+
+public sealed record ProjectWorkspaceSnapshot(
+    ProjectConfigurationDocument Project,
+    MemberDocument Members,
+    IReadOnlyList<VersionWorkspaceSnapshot> Versions);

--- a/Blueprints.Storage/Models/VersionWorkspaceSnapshot.cs
+++ b/Blueprints.Storage/Models/VersionWorkspaceSnapshot.cs
@@ -1,0 +1,7 @@
+using Blueprints.Core.Models;
+
+namespace Blueprints.Storage.Models;
+
+public sealed record VersionWorkspaceSnapshot(
+    VersionDocument Version,
+    IReadOnlyList<ItemDocument> Items);

--- a/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
@@ -1,0 +1,180 @@
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+using Blueprints.Security.Models;
+using Blueprints.Storage.Abstractions;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.Storage.Services;
+
+public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
+{
+    private readonly ISignedDocumentStore _signedDocumentStore;
+
+    public FileSystemProjectWorkspaceStore(ISignedDocumentStore signedDocumentStore)
+    {
+        _signedDocumentStore = signedDocumentStore;
+    }
+
+    public ProjectWorkspaceLoadResult Load(
+        string workspaceRoot,
+        SignaturePublicKey publicKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+
+        try
+        {
+            var projectResult = _signedDocumentStore.Read<ProjectConfigurationDocument>(
+                GetProjectDocumentPath(workspaceRoot),
+                publicKey);
+            var membersResult = _signedDocumentStore.Read<MemberDocument>(
+                GetMembersDocumentPath(workspaceRoot),
+                publicKey);
+
+            var versionSnapshots = new List<VersionWorkspaceSnapshot>();
+            var allSignaturesValid = projectResult.IsSignatureValid && membersResult.IsSignatureValid;
+            var totalDocuments = 2;
+            var invalidSignatures = allSignaturesValid ? 0 : CountInvalid(projectResult.IsSignatureValid, membersResult.IsSignatureValid);
+
+            var versionsRoot = GetVersionsRoot(workspaceRoot);
+            if (Directory.Exists(versionsRoot))
+            {
+                foreach (var versionDirectory in Directory.EnumerateDirectories(versionsRoot).OrderBy(static path => path, StringComparer.Ordinal))
+                {
+                    var versionResult = _signedDocumentStore.Read<VersionDocument>(
+                        GetVersionDocumentPath(versionDirectory),
+                        publicKey);
+
+                    totalDocuments++;
+                    if (!versionResult.IsSignatureValid)
+                    {
+                        invalidSignatures++;
+                        allSignaturesValid = false;
+                    }
+
+                    var items = new List<ItemDocument>();
+                    var itemsRoot = GetItemsRoot(versionDirectory);
+                    if (Directory.Exists(itemsRoot))
+                    {
+                        foreach (var itemPath in Directory.EnumerateFiles(itemsRoot, "*.json").OrderBy(static path => path, StringComparer.Ordinal))
+                        {
+                            var itemResult = _signedDocumentStore.Read<ItemDocument>(itemPath, publicKey);
+                            totalDocuments++;
+                            if (!itemResult.IsSignatureValid)
+                            {
+                                invalidSignatures++;
+                                allSignaturesValid = false;
+                            }
+
+                            items.Add(itemResult.Document);
+                        }
+                    }
+
+                    versionSnapshots.Add(new VersionWorkspaceSnapshot(versionResult.Document, items));
+                }
+            }
+
+            var trustState = allSignaturesValid ? TrustState.Trusted : TrustState.Untrusted;
+            var summary = allSignaturesValid
+                ? $"Validated {totalDocuments} signed documents."
+                : $"Validated {totalDocuments} signed documents with {invalidSignatures} invalid signatures.";
+
+            return new ProjectWorkspaceLoadResult(
+                new ProjectWorkspaceSnapshot(projectResult.Document, membersResult.Document, versionSnapshots),
+                new TrustReport(trustState, summary, DateTimeOffset.UtcNow));
+        }
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException or InvalidOperationException)
+        {
+            return new ProjectWorkspaceLoadResult(
+                EmptyWorkspace(),
+                new TrustReport(
+                    TrustState.Corrupt,
+                    $"Workspace load failed: {exception.Message}",
+                    DateTimeOffset.UtcNow));
+        }
+    }
+
+    public void Save(
+        string workspaceRoot,
+        ProjectWorkspaceSnapshot workspace,
+        SignatureKeyMaterial signingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(workspace);
+
+        Directory.CreateDirectory(workspaceRoot);
+        Directory.CreateDirectory(GetProjectRoot(workspaceRoot));
+        Directory.CreateDirectory(GetVersionsRoot(workspaceRoot));
+
+        _signedDocumentStore.Write(
+            GetProjectDocumentPath(workspaceRoot),
+            workspace.Project,
+            signingKey);
+        _signedDocumentStore.Write(
+            GetMembersDocumentPath(workspaceRoot),
+            workspace.Members,
+            signingKey);
+
+        foreach (var versionSnapshot in workspace.Versions)
+        {
+            var versionDirectory = GetVersionDirectory(workspaceRoot, versionSnapshot.Version.VersionId);
+            Directory.CreateDirectory(versionDirectory);
+            Directory.CreateDirectory(GetItemsRoot(versionDirectory));
+
+            _signedDocumentStore.Write(
+                GetVersionDocumentPath(versionDirectory),
+                versionSnapshot.Version,
+                signingKey);
+
+            foreach (var item in versionSnapshot.Items)
+            {
+                _signedDocumentStore.Write(
+                    GetItemDocumentPath(versionDirectory, item.ItemId),
+                    item,
+                    signingKey);
+            }
+        }
+    }
+
+    private static ProjectWorkspaceSnapshot EmptyWorkspace() =>
+        new(
+            new ProjectConfigurationDocument(
+                0,
+                Guid.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                DateTimeOffset.MinValue,
+                [],
+                new Dictionary<string, ItemTypeDefinition>(),
+                new Dictionary<string, ItemKeyRule>(),
+                new ChangelogRules(false, false, false, false)),
+            new MemberDocument(0, Guid.Empty, 0, []),
+            []);
+
+    private static int CountInvalid(params bool[] values) =>
+        values.Count(static value => !value);
+
+    private static string GetProjectRoot(string workspaceRoot) =>
+        Path.Combine(workspaceRoot, "project");
+
+    private static string GetVersionsRoot(string workspaceRoot) =>
+        Path.Combine(workspaceRoot, "versions");
+
+    private static string GetProjectDocumentPath(string workspaceRoot) =>
+        Path.Combine(GetProjectRoot(workspaceRoot), "project.json");
+
+    private static string GetMembersDocumentPath(string workspaceRoot) =>
+        Path.Combine(GetProjectRoot(workspaceRoot), "members.json");
+
+    private static string GetVersionDirectory(string workspaceRoot, Guid versionId) =>
+        Path.Combine(GetVersionsRoot(workspaceRoot), versionId.ToString("N"));
+
+    private static string GetVersionDocumentPath(string versionDirectory) =>
+        Path.Combine(versionDirectory, "version.json");
+
+    private static string GetItemsRoot(string versionDirectory) =>
+        Path.Combine(versionDirectory, "items");
+
+    private static string GetItemDocumentPath(string versionDirectory, Guid itemId) =>
+        Path.Combine(GetItemsRoot(versionDirectory), $"{itemId:N}.json");
+}

--- a/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
+++ b/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
@@ -1,0 +1,150 @@
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+using Blueprints.Security.Models;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemProjectWorkspaceStoreTests : IDisposable
+{
+    private readonly string _workspaceRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "WorkspaceStore",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void SaveAndLoad_RoundTripsWorkspaceWithTrustedState()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var serializer = new CanonicalJsonSerializer();
+        var signatureService = new Ed25519SignatureService();
+        var signedStore = new FileSystemSignedDocumentStore(serializer, signatureService);
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+
+        var workspace = CreateWorkspaceSnapshot();
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace,
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Trusted, result.TrustReport.State);
+        Assert.Equal(workspace.Project.ProjectCode, result.Workspace.Project.ProjectCode);
+        Assert.Single(result.Workspace.Versions);
+        Assert.Single(result.Workspace.Versions[0].Items);
+    }
+
+    [Fact]
+    public void Load_ReturnsUntrusted_WhenSignedDocumentIsTampered()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var serializer = new CanonicalJsonSerializer();
+        var signatureService = new Ed25519SignatureService();
+        var signedStore = new FileSystemSignedDocumentStore(serializer, signatureService);
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+
+        var workspace = CreateWorkspaceSnapshot();
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace,
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var projectPath = Path.Combine(_workspaceRoot, "project", "project.json");
+        File.AppendAllText(projectPath, " ");
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Untrusted, result.TrustReport.State);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workspaceRoot))
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+    }
+
+    private static Storage.Models.ProjectWorkspaceSnapshot CreateWorkspaceSnapshot()
+    {
+        var projectId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        return new Storage.Models.ProjectWorkspaceSnapshot(
+            new ProjectConfigurationDocument(
+                1,
+                projectId,
+                "VaultSync",
+                "VS",
+                "SemVer",
+                DateTimeOffset.UtcNow,
+                [new CategoryDefinition("added", "Added")],
+                new Dictionary<string, ItemTypeDefinition>
+                {
+                    ["feature"] = new("feature", "Feature"),
+                },
+                new Dictionary<string, ItemKeyRule>
+                {
+                    ["feature"] = new("VS", ItemKeyScope.Version),
+                },
+                new ChangelogRules(false, true, false, false)),
+            new MemberDocument(
+                1,
+                projectId,
+                1,
+                [
+                    new ProjectMember(
+                        Guid.NewGuid(),
+                        "Flavio",
+                        "public-key",
+                        MemberRole.Admin,
+                        DateTimeOffset.UtcNow,
+                        true),
+                ]),
+            [
+                new Storage.Models.VersionWorkspaceSnapshot(
+                    new VersionDocument(
+                        1,
+                        projectId,
+                        versionId,
+                        "1.0.0",
+                        ReleaseStatus.InProgress,
+                        DateTimeOffset.UtcNow,
+                        null,
+                        null,
+                        [itemId]),
+                    [
+                        new ItemDocument(
+                            1,
+                            projectId,
+                            versionId,
+                            itemId,
+                            "VS-1001",
+                            "feature",
+                            "added",
+                            "Create signed workspace persistence",
+                            null,
+                            false,
+                            [],
+                            DateTimeOffset.UtcNow,
+                            DateTimeOffset.UtcNow,
+                            Guid.NewGuid(),
+                            "Flavio"),
+                    ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a filesystem-backed project workspace store for project, member, version, and item documents
- validate signed documents during load and produce a trust report
- add tests for trusted round-trip load/save and tamper detection

## Verification
- [x] dotnet build Blueprints.sln
- [x] dotnet test Blueprints.sln

## Notes
- this closes the core persistence pipeline work for issue #7
- UI consumption of this workspace data remains separate work under issue #11