### PR TITLE
Wire app shell to live workspace state

### DIFF
--- a/Blueprints.App/Models/LocalWorkspaceSession.cs
+++ b/Blueprints.App/Models/LocalWorkspaceSession.cs
@@ -1,0 +1,9 @@
+using Blueprints.Security.Models;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.App.Models;
+
+public sealed record LocalWorkspaceSession(
+    StoredIdentity Identity,
+    string WorkspaceRoot,
+    ProjectWorkspaceLoadResult LoadResult);

--- a/Blueprints.App/Services/AppEnvironment.cs
+++ b/Blueprints.App/Services/AppEnvironment.cs
@@ -2,9 +2,17 @@ namespace Blueprints.App.Services;
 
 public static class AppEnvironment
 {
-    public static string GetIdentityRoot()
+    public static string GetAppRoot()
     {
         var appDataRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(appDataRoot, "Blueprints", "Identities");
+        return Path.Combine(appDataRoot, "Blueprints");
     }
+
+    public static string GetIdentityRoot()
+    {
+        return Path.Combine(GetAppRoot(), "Identities");
+    }
+
+    public static string GetWorkspaceRoot() =>
+        Path.Combine(GetAppRoot(), "Workspace", "default");
 }

--- a/Blueprints.App/Services/LocalWorkspaceService.cs
+++ b/Blueprints.App/Services/LocalWorkspaceService.cs
@@ -1,0 +1,162 @@
+using Blueprints.App.Models;
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+using Blueprints.Core.Services;
+using Blueprints.Security.Models;
+using Blueprints.Storage.Abstractions;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class LocalWorkspaceService
+{
+    private const int CurrentSchemaVersion = 1;
+    private readonly string _workspaceRoot;
+    private readonly IProjectWorkspaceStore _workspaceStore;
+
+    public LocalWorkspaceService(
+        string workspaceRoot,
+        IProjectWorkspaceStore workspaceStore)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(workspaceStore);
+
+        _workspaceRoot = workspaceRoot;
+        _workspaceStore = workspaceStore;
+    }
+
+    public LocalWorkspaceSession GetOrCreateDefaultWorkspace(StoredIdentity identity)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        if (!WorkspaceExists(_workspaceRoot))
+        {
+            _workspaceStore.Save(_workspaceRoot, CreateStarterWorkspace(identity), identity.SigningKey);
+        }
+
+        var loadResult = _workspaceStore.Load(_workspaceRoot, identity.PublicKey);
+        return new LocalWorkspaceSession(identity, _workspaceRoot, loadResult);
+    }
+
+    private static ProjectWorkspaceSnapshot CreateStarterWorkspace(StoredIdentity identity)
+    {
+        var createdUtc = DateTimeOffset.UtcNow;
+        var projectId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var featureItemId = Guid.NewGuid();
+        var bugItemId = Guid.NewGuid();
+        var issueItemId = Guid.NewGuid();
+
+        var project = new ProjectConfigurationDocument(
+            CurrentSchemaVersion,
+            projectId,
+            "Blueprints",
+            "BP",
+            "SemVer",
+            createdUtc,
+            [
+                new CategoryDefinition("feature", "Feature"),
+                new CategoryDefinition("bug", "Bug"),
+                new CategoryDefinition("issue", "Issue"),
+            ],
+            new Dictionary<string, ItemTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["feature"] = new("feature", "Feature"),
+                ["bug"] = new("bug", "Bug"),
+                ["issue"] = new("issue", "Issue"),
+            },
+            new Dictionary<string, ItemKeyRule>(StringComparer.Ordinal)
+            {
+                ["feature"] = new("BP", ItemKeyScope.Version),
+                ["bug"] = new("BUG", ItemKeyScope.Project),
+                ["issue"] = new("ISS", ItemKeyScope.Project),
+            },
+            new ChangelogRules(false, true, false, false));
+
+        var members = new MemberDocument(
+            CurrentSchemaVersion,
+            projectId,
+            1,
+            [
+                new ProjectMember(
+                    identity.Profile.UserId,
+                    identity.Profile.DisplayName,
+                    Convert.ToBase64String(identity.PublicKey.PublicKeyBytes),
+                    MemberRole.Admin,
+                    createdUtc,
+                    true),
+            ]);
+
+        var version = new VersionDocument(
+            CurrentSchemaVersion,
+            projectId,
+            versionId,
+            "1.0.0",
+            ReleaseStatus.InProgress,
+            createdUtc,
+            null,
+            "Starter workspace created from the signed local bootstrap flow.",
+            [featureItemId, bugItemId, issueItemId]);
+
+        return new ProjectWorkspaceSnapshot(
+            project,
+            members,
+            [
+                new VersionWorkspaceSnapshot(
+                    version,
+                    [
+                        new ItemDocument(
+                            CurrentSchemaVersion,
+                            projectId,
+                            versionId,
+                            featureItemId,
+                            ItemKeyFormatter.FormatVersionScoped(project.ProjectCode, 1, 0, 1),
+                            "feature",
+                            "feature",
+                            "Wire the shell to signed workspace state",
+                            "Replace the static dashboard with live project, trust, and version summaries.",
+                            true,
+                            ["starter", "ui"],
+                            createdUtc,
+                            createdUtc,
+                            identity.Profile.UserId,
+                            identity.Profile.DisplayName),
+                        new ItemDocument(
+                            CurrentSchemaVersion,
+                            projectId,
+                            versionId,
+                            bugItemId,
+                            ItemKeyFormatter.FormatProjectScoped("BUG", 1),
+                            "bug",
+                            "bug",
+                            "Detect signature tampering during workspace load",
+                            "Loading should surface untrusted state instead of silently accepting modified files.",
+                            true,
+                            ["trust"],
+                            createdUtc,
+                            createdUtc,
+                            identity.Profile.UserId,
+                            identity.Profile.DisplayName),
+                        new ItemDocument(
+                            CurrentSchemaVersion,
+                            projectId,
+                            versionId,
+                            issueItemId,
+                            ItemKeyFormatter.FormatProjectScoped("ISS", 1),
+                            "issue",
+                            "issue",
+                            "Implement shared-folder sync",
+                            "Shared-folder publish and import is the next planned feature branch after live workspace wiring.",
+                            false,
+                            ["sync", "next"],
+                            createdUtc,
+                            createdUtc,
+                            identity.Profile.UserId,
+                            identity.Profile.DisplayName),
+                    ]),
+            ]);
+    }
+
+    private static bool WorkspaceExists(string workspaceRoot) =>
+        File.Exists(Path.Combine(workspaceRoot, "project", "project.json"));
+}

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -1,45 +1,62 @@
 using System.Collections.ObjectModel;
+using System.Linq;
+using Blueprints.App.Models;
 using Blueprints.Collaboration.Enums;
 using Blueprints.Collaboration.Models;
 using Blueprints.Core.Enums;
 using Blueprints.Core.Models;
-using Blueprints.Security.Abstractions;
 using Blueprints.Security.Models;
 using Blueprints.Security.Services;
+using Blueprints.Storage.Models;
 
 namespace Blueprints.App.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
-    public MainWindowViewModel(IIdentityService identityService)
+    public MainWindowViewModel()
+        : this(CreateDesignSession())
     {
-        ArgumentNullException.ThrowIfNull(identityService);
+    }
 
-        var identity = identityService.GetOrCreateDefaultIdentity("Local Admin");
+    public MainWindowViewModel(LocalWorkspaceSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var workspace = session.LoadResult.Workspace;
+        var project = workspace.Project;
 
         CurrentProject = new ProjectSummary(
-            "VaultSync",
-            "VS",
-            TrustState.Trusted,
-            @"\\NAS\Blueprints\VaultSync");
+            project.Name,
+            project.ProjectCode,
+            session.LoadResult.TrustReport.State,
+            session.WorkspaceRoot);
 
         Identity = new IdentitySummary(
-            identity.Profile.DisplayName,
-            identity.Profile.UserId.ToString(),
-            identity.Profile.KeyStorageProvider);
+            session.Identity.Profile.DisplayName,
+            session.Identity.Profile.UserId.ToString(),
+            session.Identity.Profile.KeyStorageProvider);
 
         Sync = new SyncSummary(
-            SyncHealth.Ready,
-            PendingOutgoingChanges: 3,
-            PendingIncomingChanges: 1,
+            SyncHealth.Idle,
+            0,
+            0,
             ConflictCount: 0);
 
-        Versions = new ObservableCollection<VersionSummary>
-        {
-            new("1.6.0", ReleaseStatus.InProgress, 14, 9),
-            new("1.5.0", ReleaseStatus.Frozen, 22, 22),
-            new("1.4.3", ReleaseStatus.Released, 8, 8),
-        };
+        Versions = new ObservableCollection<VersionSummary>(
+            workspace.Versions
+                .OrderByDescending(static version => version.Version.CreatedUtc)
+                .Select(static version => new VersionSummary(
+                    version.Version.Name,
+                    version.Version.Status,
+                    version.Items.Count,
+                    version.Items.Count(static item => item.IsDone))));
+
+        TrustSummary = session.LoadResult.TrustReport.Summary;
+        WorkspacePath = session.WorkspaceRoot;
+        VersioningScheme = project.VersioningScheme;
+        VersionCount = workspace.Versions.Count;
+        ItemCount = workspace.Versions.Sum(static version => version.Items.Count);
+        ActiveMemberCount = workspace.Members.Members.Count(static member => member.IsActive);
+        MembershipRevision = workspace.Members.MembershipRevision;
     }
 
     public string Title => $"{CurrentProject.Name} ({CurrentProject.Code})";
@@ -54,6 +71,20 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public ObservableCollection<VersionSummary> Versions { get; }
 
+    public string TrustSummary { get; }
+
+    public string WorkspacePath { get; }
+
+    public string VersioningScheme { get; }
+
+    public int VersionCount { get; }
+
+    public int ItemCount { get; }
+
+    public int ActiveMemberCount { get; }
+
+    public int MembershipRevision { get; }
+
     public string TrustBadge => TrustStatePresenter.ToDisplayText(CurrentProject.TrustState);
 
     public string SyncStatus =>
@@ -61,6 +92,95 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             SyncHealth.Ready => $"{Sync.PendingOutgoingChanges} outgoing, {Sync.PendingIncomingChanges} incoming",
             SyncHealth.NeedsAttention => $"{Sync.ConflictCount} conflicts need attention",
-            _ => "Idle",
+            _ => "Local workspace ready",
         };
+
+    private static LocalWorkspaceSession CreateDesignSession()
+    {
+        var createdUtc = DateTimeOffset.Parse("2026-02-28T12:00:00Z");
+        var projectId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var versionId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var userId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+        return new LocalWorkspaceSession(
+            new StoredIdentity(
+                new IdentityProfile(
+                    userId,
+                    "Local Admin",
+                    "design-key",
+                    Convert.ToBase64String([4, 5, 6]),
+                    "Windows DPAPI",
+                    createdUtc),
+                new SignatureKeyMaterial("design-key", [1, 2, 3]),
+                new SignaturePublicKey("design-key", [4, 5, 6])),
+            @"C:\Users\Example\AppData\Local\Blueprints\Workspace\default",
+            new ProjectWorkspaceLoadResult(
+                new ProjectWorkspaceSnapshot(
+                    new ProjectConfigurationDocument(
+                        1,
+                        projectId,
+                        "Blueprints",
+                        "BP",
+                        "SemVer",
+                        createdUtc,
+                        [
+                            new CategoryDefinition("feature", "Feature"),
+                            new CategoryDefinition("bug", "Bug"),
+                            new CategoryDefinition("issue", "Issue"),
+                        ],
+                        new Dictionary<string, ItemTypeDefinition>(StringComparer.Ordinal)
+                        {
+                            ["feature"] = new("feature", "Feature"),
+                        },
+                        new Dictionary<string, ItemKeyRule>(StringComparer.Ordinal)
+                        {
+                            ["feature"] = new("BP", ItemKeyScope.Version),
+                        },
+                        new ChangelogRules(false, true, false, false)),
+                    new MemberDocument(
+                        1,
+                        projectId,
+                        1,
+                        [
+                            new ProjectMember(
+                                userId,
+                                "Local Admin",
+                                "design-public-key",
+                                MemberRole.Admin,
+                                createdUtc,
+                                true),
+                        ]),
+                    [
+                        new VersionWorkspaceSnapshot(
+                            new VersionDocument(
+                                1,
+                                projectId,
+                                versionId,
+                                "1.0.0",
+                                ReleaseStatus.InProgress,
+                                createdUtc,
+                                null,
+                                null,
+                                []),
+                            [
+                                new ItemDocument(
+                                    1,
+                                    projectId,
+                                    versionId,
+                                    Guid.Parse("44444444-4444-4444-4444-444444444444"),
+                                    "BP-1001",
+                                    "feature",
+                                    "feature",
+                                    "Starter item",
+                                    null,
+                                    true,
+                                    [],
+                                    createdUtc,
+                                    createdUtc,
+                                    userId,
+                                    "Local Admin"),
+                            ]),
+                    ]),
+                new TrustReport(TrustState.Trusted, "Validated 4 signed documents.", createdUtc)));
+    }
 }

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -85,10 +85,10 @@
                 BorderBrush="#D7CCB5"
                 BorderThickness="1">
           <StackPanel Spacing="6">
-            <TextBlock Text="Shared Sync Source"
+            <TextBlock Text="Local Workspace Root"
                        FontWeight="SemiBold"
                        Foreground="#17322C" />
-            <TextBlock Text="{Binding CurrentProject.SharedFolderPath}"
+            <TextBlock Text="{Binding WorkspacePath}"
                        TextWrapping="Wrap"
                        Foreground="#574E43" />
           </StackPanel>
@@ -98,13 +98,17 @@
                 CornerRadius="14"
                 Padding="14">
           <StackPanel Spacing="4">
-            <TextBlock Text="v1.0 Focus"
+            <TextBlock Text="Workspace Profile"
                        Foreground="#CFE2D8" />
-            <TextBlock Text="Local-first release planning with signed sync."
+            <TextBlock Text="{Binding VersioningScheme, StringFormat='Versioning: {0}'}"
                        TextWrapping="Wrap"
                        FontSize="18"
                        FontWeight="SemiBold"
                        Foreground="#F6F1E8" />
+            <TextBlock Text="{Binding ActiveMemberCount, StringFormat='Active members: {0}'}"
+                       Foreground="#CFE2D8" />
+            <TextBlock Text="{Binding MembershipRevision, StringFormat='Membership revision: {0}'}"
+                       Foreground="#CFE2D8" />
           </StackPanel>
         </Border>
       </StackPanel>
@@ -168,11 +172,11 @@
             BorderThickness="0,1,0,0">
       <Grid RowDefinitions="Auto,Auto,*" RowSpacing="18">
         <StackPanel Spacing="6">
-          <TextBlock Text="Implementation Starter"
+          <TextBlock Text="Live Workspace"
                      FontSize="28"
                      FontWeight="SemiBold"
                      Foreground="#17322C" />
-          <TextBlock Text="The solution is scaffolded for Core, Storage, Security, Collaboration, and an Avalonia desktop shell."
+          <TextBlock Text="{Binding TrustSummary}"
                      TextWrapping="Wrap"
                      Foreground="#574E43" />
         </StackPanel>
@@ -185,10 +189,10 @@
                   BorderBrush="#D7CCB5"
                   BorderThickness="1">
             <StackPanel Spacing="4">
-              <TextBlock Text="Project Model"
+              <TextBlock Text="Versions"
                          FontWeight="SemiBold"
                          Foreground="#17322C" />
-              <TextBlock Text="Signed configuration, version-centric planning, customizable project labels."
+              <TextBlock Text="{Binding VersionCount, StringFormat='Tracked versions: {0}'}"
                          TextWrapping="Wrap"
                          Foreground="#574E43" />
             </StackPanel>
@@ -201,10 +205,10 @@
                   BorderBrush="#D7CCB5"
                   BorderThickness="1">
             <StackPanel Spacing="4">
-              <TextBlock Text="Trust Layer"
+              <TextBlock Text="Items"
                          FontWeight="SemiBold"
                          Foreground="#17322C" />
-              <TextBlock Text="Detached signatures, membership revisions, trust-state evaluation."
+              <TextBlock Text="{Binding ItemCount, StringFormat='Total items: {0}'}"
                          TextWrapping="Wrap"
                          Foreground="#574E43" />
             </StackPanel>
@@ -216,10 +220,10 @@
                   BorderBrush="#D7CCB5"
                   BorderThickness="1">
             <StackPanel Spacing="4">
-              <TextBlock Text="Sync Layer"
+              <TextBlock Text="Identity"
                          FontWeight="SemiBold"
                          Foreground="#17322C" />
-              <TextBlock Text="Local workspaces, shared-folder sync, atomic batch publishing."
+              <TextBlock Text="{Binding Identity.DisplayName}"
                          TextWrapping="Wrap"
                          Foreground="#574E43" />
             </StackPanel>
@@ -231,17 +235,15 @@
                 CornerRadius="18"
                 Padding="20">
           <StackPanel Spacing="12">
-            <TextBlock Text="Next Steps"
+            <TextBlock Text="Current Trust State"
                        FontSize="18"
                        FontWeight="SemiBold"
                        Foreground="#F6F1E8" />
-            <TextBlock Text="1. Build domain entities and project configuration schema."
+            <TextBlock Text="{Binding TrustSummary}"
+                       TextWrapping="Wrap"
                        Foreground="#CFE2D8" />
-            <TextBlock Text="2. Implement canonical JSON serialization and signature services."
-                       Foreground="#CFE2D8" />
-            <TextBlock Text="3. Add workspace persistence and shared sync manifest handling."
-                       Foreground="#CFE2D8" />
-            <TextBlock Text="4. Replace sample dashboard data with live project state."
+            <TextBlock Text="Shared-folder sync is still pending, so this shell currently reflects the signed local workspace only."
+                       TextWrapping="Wrap"
                        Foreground="#CFE2D8" />
           </StackPanel>
         </Border>

--- a/Blueprints.Tests/Blueprints.Tests.csproj
+++ b/Blueprints.Tests/Blueprints.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Blueprints.App\Blueprints.App.csproj" />
     <ProjectReference Include="..\Blueprints.Core\Blueprints.Core.csproj" />
     <ProjectReference Include="..\Blueprints.Security\Blueprints.Security.csproj" />
     <ProjectReference Include="..\Blueprints.Storage\Blueprints.Storage.csproj" />

--- a/Blueprints.Tests/LocalWorkspaceServiceTests.cs
+++ b/Blueprints.Tests/LocalWorkspaceServiceTests.cs
@@ -1,0 +1,87 @@
+using Blueprints.App.Services;
+using Blueprints.Core.Enums;
+using Blueprints.Security.Models;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class LocalWorkspaceServiceTests : IDisposable
+{
+    private readonly string _workspaceRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "LocalWorkspaceService",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void GetOrCreateDefaultWorkspace_CreatesTrustedStarterWorkspace()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var identity = new StoredIdentity(
+            new IdentityProfile(
+                Guid.NewGuid(),
+                "Flavio",
+                keyPair.KeyId,
+                Convert.ToBase64String(keyPair.PublicKeyBytes),
+                "Test Provider",
+                DateTimeOffset.UtcNow),
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes),
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var service = new LocalWorkspaceService(_workspaceRoot, workspaceStore);
+
+        var session = service.GetOrCreateDefaultWorkspace(identity);
+
+        Assert.Equal(TrustState.Trusted, session.LoadResult.TrustReport.State);
+        Assert.Equal("Blueprints", session.LoadResult.Workspace.Project.Name);
+        Assert.Equal("BP", session.LoadResult.Workspace.Project.ProjectCode);
+        Assert.Single(session.LoadResult.Workspace.Members.Members);
+        Assert.Single(session.LoadResult.Workspace.Versions);
+        Assert.Equal(3, session.LoadResult.Workspace.Versions[0].Items.Count);
+    }
+
+    [Fact]
+    public void GetOrCreateDefaultWorkspace_ReusesExistingWorkspace()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var identity = new StoredIdentity(
+            new IdentityProfile(
+                Guid.NewGuid(),
+                "Flavio",
+                keyPair.KeyId,
+                Convert.ToBase64String(keyPair.PublicKeyBytes),
+                "Test Provider",
+                DateTimeOffset.UtcNow),
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes),
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var service = new LocalWorkspaceService(_workspaceRoot, workspaceStore);
+
+        var first = service.GetOrCreateDefaultWorkspace(identity);
+        var second = service.GetOrCreateDefaultWorkspace(identity);
+
+        Assert.Equal(first.LoadResult.Workspace.Project.ProjectId, second.LoadResult.Workspace.Project.ProjectId);
+        Assert.Equal(first.LoadResult.Workspace.Versions[0].Version.VersionId, second.LoadResult.Workspace.Versions[0].Version.VersionId);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workspaceRoot))
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n- add a local workspace bootstrap service that creates or loads the signed default workspace\n- wire Avalonia startup and the main window view model to live workspace, identity, and trust data\n- add coverage for first-run local workspace creation and reuse\n\n## Verification\n- dotnet build Blueprints.sln\n- dotnet test Blueprints.sln\n\nRelated to #11