### PR TITLE
Implement membership invitation and management

### DIFF
--- a/Blueprints.App/Models/MemberInviteRequest.cs
+++ b/Blueprints.App/Models/MemberInviteRequest.cs
@@ -1,0 +1,9 @@
+using Blueprints.Core.Enums;
+
+namespace Blueprints.App.Models;
+
+public sealed record MemberInviteRequest(
+    string UserId,
+    string DisplayName,
+    string PublicKey,
+    MemberRole Role);

--- a/Blueprints.App/Models/MemberUpdateRequest.cs
+++ b/Blueprints.App/Models/MemberUpdateRequest.cs
@@ -1,0 +1,9 @@
+using Blueprints.Core.Enums;
+
+namespace Blueprints.App.Models;
+
+public sealed record MemberUpdateRequest(
+    Guid UserId,
+    string DisplayName,
+    MemberRole Role,
+    bool IsActive);

--- a/Blueprints.App/Models/WorkspaceMemberCard.cs
+++ b/Blueprints.App/Models/WorkspaceMemberCard.cs
@@ -1,0 +1,11 @@
+using Blueprints.Core.Enums;
+
+namespace Blueprints.App.Models;
+
+public sealed record WorkspaceMemberCard(
+    Guid UserId,
+    string DisplayName,
+    string PublicKey,
+    MemberRole Role,
+    bool IsActive,
+    bool IsCurrentIdentity);

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -219,7 +219,7 @@
 
     <Grid Grid.Row="1"
           IsVisible="{Binding HasActiveSession}"
-          ColumnDefinitions="240,320,*"
+          ColumnDefinitions="240,320,340,*"
           Margin="0">
       <Border Background="#EFE7D7"
               Padding="20"
@@ -339,6 +339,134 @@
       </Border>
 
       <Border Grid.Column="2"
+              Background="#F2EBDB"
+              Padding="20"
+              BorderBrush="#D7CCB5"
+              BorderThickness="0,1,1,0">
+        <Grid RowDefinitions="Auto,Auto,*"
+              RowSpacing="14">
+          <StackPanel Spacing="6">
+            <TextBlock Text="Membership"
+                       FontSize="18"
+                       FontWeight="SemiBold"
+                       Foreground="#17322C" />
+            <TextBlock Text="{Binding MembershipRevision, StringFormat='Revision: {0}'}"
+                       Foreground="#574E43" />
+          </StackPanel>
+
+          <StackPanel Grid.Row="1"
+                      Spacing="10">
+            <TextBlock Text="Identity Bundle"
+                       FontWeight="SemiBold"
+                       Foreground="#17322C" />
+            <TextBox Text="{Binding IdentityBundle}"
+                     AcceptsReturn="True"
+                     IsReadOnly="True"
+                     Height="72"
+                     TextWrapping="Wrap" />
+          </StackPanel>
+
+          <Grid Grid.Row="2"
+                RowDefinitions="Auto,Auto,*"
+                RowSpacing="12">
+            <Border Background="#FFFFFF"
+                    CornerRadius="14"
+                    Padding="14"
+                    BorderBrush="#D7CCB5"
+                    BorderThickness="1">
+              <StackPanel Spacing="8">
+                <TextBlock Text="Invite Member"
+                           FontWeight="SemiBold"
+                           Foreground="#17322C" />
+                <TextBox Watermark="Invitee user ID"
+                         Text="{Binding InviteUserId}"
+                         IsEnabled="{Binding CanManageMembers}" />
+                <TextBox Watermark="Invitee display name"
+                         Text="{Binding InviteDisplayName}"
+                         IsEnabled="{Binding CanManageMembers}" />
+                <ComboBox ItemsSource="{Binding AvailableMemberRoles}"
+                          SelectedItem="{Binding InviteRole}"
+                          IsEnabled="{Binding CanManageMembers}" />
+                <TextBox Watermark="Invitee public key (Base64)"
+                         Text="{Binding InvitePublicKey}"
+                         AcceptsReturn="True"
+                         Height="72"
+                         TextWrapping="Wrap"
+                         IsEnabled="{Binding CanManageMembers}" />
+                <Button Content="Invite Member"
+                        Command="{Binding InviteMemberCommand}"
+                        Padding="14,8"
+                        HorizontalAlignment="Left"
+                        IsEnabled="{Binding CanManageMembers}" />
+              </StackPanel>
+            </Border>
+
+            <Border Grid.Row="1"
+                    Background="#FFFFFF"
+                    CornerRadius="14"
+                    Padding="14"
+                    BorderBrush="#D7CCB5"
+                    BorderThickness="1">
+              <StackPanel Spacing="8">
+                <TextBlock Text="Member Editor"
+                           FontWeight="SemiBold"
+                           Foreground="#17322C" />
+                <TextBox Watermark="Display name"
+                         Text="{Binding MemberEditorDisplayName}"
+                         IsEnabled="{Binding CanEditSelectedMember}" />
+                <ComboBox ItemsSource="{Binding AvailableMemberRoles}"
+                          SelectedItem="{Binding MemberEditorRole}"
+                          IsEnabled="{Binding CanEditSelectedMember}" />
+                <CheckBox Content="Active member"
+                          IsChecked="{Binding MemberEditorIsActive}"
+                          IsEnabled="{Binding CanEditSelectedMember}" />
+                <Button Content="Save Member"
+                        Command="{Binding SaveMemberDetailsCommand}"
+                        Padding="14,8"
+                        HorizontalAlignment="Left"
+                        IsEnabled="{Binding CanEditSelectedMember}" />
+                <TextBlock Text="{Binding SelectedMemberStateSummary}"
+                           TextWrapping="Wrap"
+                           Foreground="#574E43" />
+              </StackPanel>
+            </Border>
+
+            <ListBox Grid.Row="2"
+                     ItemsSource="{Binding Members}"
+                     SelectedItem="{Binding SelectedMember}">
+              <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="appModels:WorkspaceMemberCard">
+                  <Border Margin="0,0,0,10"
+                          Background="#FFFFFF"
+                          CornerRadius="12"
+                          Padding="12"
+                          BorderBrush="#D7CCB5"
+                          BorderThickness="1">
+                    <StackPanel Spacing="4">
+                      <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{Binding DisplayName}"
+                                   FontWeight="SemiBold"
+                                   Foreground="#17322C" />
+                        <TextBlock Grid.Column="1"
+                                   Text="{Binding Role}"
+                                   Foreground="#574E43" />
+                      </Grid>
+                      <TextBlock Text="{Binding UserId}"
+                                 FontFamily="Cascadia Mono"
+                                 FontSize="11"
+                                 Foreground="#574E43" />
+                      <TextBlock Text="{Binding IsActive, StringFormat='Active: {0}'}"
+                                 Foreground="#574E43" />
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Grid>
+      </Border>
+
+      <Border Grid.Column="3"
               Background="#F6F1E8"
               Padding="24"
               BorderBrush="#D7CCB5"


### PR DESCRIPTION
## Summary
- add signed membership invite and member update workflows with admin-only safeguards
- surface member management, identity bundle sharing, and membership revision data in the Avalonia shell
- add coordinator tests for membership revision changes and admin protection rules

Closes #28