### PR TITLE
Implement conflict resolution and read-only UX

### DIFF
--- a/Blueprints.App/Models/ConflictResolutionChoice.cs
+++ b/Blueprints.App/Models/ConflictResolutionChoice.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public enum ConflictResolutionChoice
+{
+    KeepLocal = 0,
+    AcceptShared = 1,
+}

--- a/Blueprints.App/Models/ConflictResolutionResult.cs
+++ b/Blueprints.App/Models/ConflictResolutionResult.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.App.Models;
+
+public sealed record ConflictResolutionResult(
+    string DocumentPath,
+    ConflictResolutionChoice Choice,
+    string Summary);

--- a/Blueprints.App/Models/LocalWorkspaceSession.cs
+++ b/Blueprints.App/Models/LocalWorkspaceSession.cs
@@ -8,4 +8,5 @@ public sealed record LocalWorkspaceSession(
     StoredIdentity Identity,
     WorkspacePaths Paths,
     ProjectWorkspaceLoadResult LoadResult,
-    SyncSummary Sync);
+    SyncSummary Sync,
+    IReadOnlyList<string> ConflictPaths);

--- a/Blueprints.App/Services/LocalWorkspaceService.cs
+++ b/Blueprints.App/Services/LocalWorkspaceService.cs
@@ -42,7 +42,8 @@ public sealed class LocalWorkspaceService
             identity,
             WorkspacePathResolver.Create(_workspaceRoot, _workspaceRoot),
             loadResult,
-            new SyncSummary(SyncHealth.Idle, 0, 0, 0));
+            new SyncSummary(SyncHealth.Idle, 0, 0, 0),
+            []);
     }
 
     private static ProjectWorkspaceSnapshot CreateStarterWorkspace(StoredIdentity identity)

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -297,10 +297,12 @@
                       HorizontalAlignment="Right">
             <TextBox Width="130"
                      Watermark="1.0.0"
-                     Text="{Binding NewVersionName}" />
+                     Text="{Binding NewVersionName}"
+                     IsEnabled="{Binding CanMutateWorkspace}" />
             <Button Content="New Version"
                     Command="{Binding CreateVersionCommand}"
-                    Padding="12,6" />
+                    Padding="12,6"
+                    IsEnabled="{Binding CanMutateWorkspace}" />
           </StackPanel>
         </Grid>
 
@@ -515,6 +517,9 @@
                 <TextBlock Text="{Binding ItemCount, StringFormat='Items tracked: {0}'}"
                            TextWrapping="Wrap"
                            Foreground="#574E43" />
+                <TextBlock Text="{Binding WorkspaceModeSummary}"
+                           TextWrapping="Wrap"
+                           Foreground="#574E43" />
               </StackPanel>
             </Border>
 
@@ -572,7 +577,8 @@
                           Content="Export Changelog"
                           Command="{Binding ExportSelectedVersionChangelogCommand}"
                           Padding="14,8"
-                          HorizontalAlignment="Left" />
+                          HorizontalAlignment="Left"
+                          IsEnabled="{Binding IsWorkspaceTrusted}" />
                 </Grid>
 
                 <TextBlock Text="{Binding SelectedVersionStateSummary}"
@@ -592,6 +598,11 @@
                 <TextBlock Text="{Binding TrustSummary}"
                            TextWrapping="Wrap"
                            Foreground="#CFE2D8" />
+
+                <Button Content="Refresh Workspace"
+                        Command="{Binding RefreshWorkspaceCommand}"
+                        Padding="14,8"
+                        HorizontalAlignment="Left" />
               </StackPanel>
             </Border>
 
@@ -672,6 +683,39 @@
                     </DataTemplate>
                   </ListBox.ItemTemplate>
                 </ListBox>
+
+                <Border Grid.Row="2"
+                        Background="#FFF4E8"
+                        CornerRadius="12"
+                        Padding="12"
+                        BorderBrush="#D9B48C"
+                        BorderThickness="1"
+                        Margin="0,220,0,0"
+                        IsVisible="{Binding HasConflicts}">
+                  <StackPanel Spacing="8">
+                    <TextBlock Text="Conflict Resolution"
+                               FontWeight="SemiBold"
+                               Foreground="#17322C" />
+                    <TextBlock Text="{Binding WorkspaceModeSummary}"
+                               TextWrapping="Wrap"
+                               Foreground="#574E43" />
+                    <ListBox ItemsSource="{Binding Conflicts}"
+                             SelectedItem="{Binding SelectedConflictPath}"
+                             MaxHeight="120" />
+                    <Grid ColumnDefinitions="Auto,Auto"
+                          ColumnSpacing="10">
+                      <Button Content="Keep Local"
+                              Command="{Binding ResolveConflictKeepLocalCommand}"
+                              Padding="14,8"
+                              IsEnabled="{Binding CanResolveSelectedConflict}" />
+                      <Button Grid.Column="1"
+                              Content="Accept Shared"
+                              Command="{Binding ResolveConflictAcceptSharedCommand}"
+                              Padding="14,8"
+                              IsEnabled="{Binding CanResolveSelectedConflict}" />
+                    </Grid>
+                  </StackPanel>
+                </Border>
               </Grid>
             </Border>
           </Grid>


### PR DESCRIPTION
## Summary
- add trusted-workspace mutation gating and explicit local/shared conflict resolution in the coordinator
- surface conflict lists, read-only state, and refresh actions in the Avalonia shell
- add coordinator tests for trust-gated writes and conflict resolution behavior

Closes #27