### PR TITLE
Promote the .NET 10 and Avalonia 12 baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,6 @@ updates:
     groups:
       nuget-minor-patch:
         update-types: [minor, patch]
-    ignore:
-      - dependency-name: "Avalonia*"
-        update-types: ["version-update:semver-major"]
-
   - package-ecosystem: github-actions
     directory: /
     target-branch: develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
           cache: true
           cache-dependency-path: |
             **/*.csproj
@@ -54,7 +54,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
           cache: true
           cache-dependency-path: |
             **/*.csproj

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   package:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Publish
         shell: pwsh
@@ -68,6 +68,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - name: Download packages
         uses: actions/download-artifact@v8
@@ -75,6 +79,11 @@ jobs:
           path: artifacts
           pattern: Blueprints-*
           merge-multiple: true
+
+      - name: Attest release packages
+        uses: actions/attest@v4
+        with:
+          subject-path: artifacts/*.zip
 
       - name: Create prerelease
         env:

--- a/Blueprints.App/Blueprints.App.csproj
+++ b/Blueprints.App/Blueprints.App.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\blueprints.ico</ApplicationIcon>
@@ -14,16 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.15" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.15">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -248,7 +248,7 @@
                   <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                     <TextBlock Text="Versions" FontSize="20" FontWeight="Bold" VerticalAlignment="Center" />
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-                      <TextBox Width="120" Watermark="1.0.0" Text="{Binding NewVersionName}" IsEnabled="{Binding CanMutateWorkspace}" />
+                      <TextBox Width="120" PlaceholderText="1.0.0" Text="{Binding NewVersionName}" IsEnabled="{Binding CanMutateWorkspace}" />
                       <Button Content="New"
                               Command="{Binding CreateVersionCommand}"
                               IsEnabled="{Binding CanMutateWorkspace}"
@@ -286,10 +286,10 @@
                       <TextBlock Text="Version Editor" FontSize="20" FontWeight="Bold" />
                       <TextBlock Text="{Binding SelectedVersionStateSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
                       <Grid ColumnDefinitions="*,160" ColumnSpacing="10">
-                        <TextBox Watermark="Select a version" Text="{Binding VersionEditorName}" IsEnabled="{Binding CanEditSelectedVersion}" />
+                        <TextBox PlaceholderText="Select a version" Text="{Binding VersionEditorName}" IsEnabled="{Binding CanEditSelectedVersion}" />
                         <ComboBox Grid.Column="1" ItemsSource="{Binding AvailableStatuses}" SelectedItem="{Binding VersionEditorStatus}" IsEnabled="{Binding CanEditSelectedVersion}" />
                       </Grid>
-                      <TextBox Watermark="Version notes" Text="{Binding VersionEditorNotes}" AcceptsReturn="True" Height="76" IsEnabled="{Binding CanEditSelectedVersion}" />
+                      <TextBox PlaceholderText="Version notes" Text="{Binding VersionEditorNotes}" AcceptsReturn="True" Height="76" IsEnabled="{Binding CanEditSelectedVersion}" />
                       <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Content="Save Version" Command="{Binding SaveVersionDetailsCommand}" IsEnabled="{Binding CanEditSelectedVersion}" Background="#17211D" Foreground="#F8F2E8" />
                         <Button Content="Release" Command="{Binding ReleaseSelectedVersionCommand}" IsEnabled="{Binding CanReleaseSelectedVersion}" Background="#A85332" Foreground="#FFFFFF" />
@@ -327,8 +327,8 @@
                       <TextBlock Text="Item Editor" FontSize="20" FontWeight="Bold" />
                       <ComboBox ItemsSource="{Binding AvailableItemTypes}" SelectedItem="{Binding SelectedItemTypeId}" IsEnabled="{Binding CanEditItems}" />
                       <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding SelectedCategoryId}" IsEnabled="{Binding CanEditItems}" />
-                      <TextBox Watermark="Item title" Text="{Binding ItemEditorTitle}" IsEnabled="{Binding CanEditItems}" />
-                      <TextBox Watermark="Description" Text="{Binding ItemEditorDescription}" AcceptsReturn="True" Height="86" IsEnabled="{Binding CanEditItems}" />
+                      <TextBox PlaceholderText="Item title" Text="{Binding ItemEditorTitle}" IsEnabled="{Binding CanEditItems}" />
+                      <TextBox PlaceholderText="Description" Text="{Binding ItemEditorDescription}" AcceptsReturn="True" Height="86" IsEnabled="{Binding CanEditItems}" />
                       <CheckBox Content="Done" IsChecked="{Binding ItemEditorIsDone}" IsEnabled="{Binding CanEditItems}" />
                       <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Content="Add Item" Command="{Binding AddItemCommand}" IsEnabled="{Binding CanEditItems}" Background="#17211D" Foreground="#F8F2E8" />
@@ -372,10 +372,10 @@
                 <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Spacing="10">
                     <TextBlock Text="Invite Member" FontSize="18" FontWeight="Bold" />
-                    <TextBox Watermark="Invitee user ID" Text="{Binding InviteUserId}" IsEnabled="{Binding CanManageMembers}" />
-                    <TextBox Watermark="Invitee display name" Text="{Binding InviteDisplayName}" IsEnabled="{Binding CanManageMembers}" />
+                    <TextBox PlaceholderText="Invitee user ID" Text="{Binding InviteUserId}" IsEnabled="{Binding CanManageMembers}" />
+                    <TextBox PlaceholderText="Invitee display name" Text="{Binding InviteDisplayName}" IsEnabled="{Binding CanManageMembers}" />
                     <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding InviteRole}" IsEnabled="{Binding CanManageMembers}" />
-                    <TextBox Watermark="Invitee public key (Base64)" Text="{Binding InvitePublicKey}" AcceptsReturn="True" Height="86" TextWrapping="Wrap" IsEnabled="{Binding CanManageMembers}" />
+                    <TextBox PlaceholderText="Invitee public key (Base64)" Text="{Binding InvitePublicKey}" AcceptsReturn="True" Height="86" TextWrapping="Wrap" IsEnabled="{Binding CanManageMembers}" />
                     <Button Content="Invite Member" Command="{Binding InviteMemberCommand}" HorizontalAlignment="Left" IsEnabled="{Binding CanManageMembers}" Background="#17211D" Foreground="#F8F2E8" />
                   </StackPanel>
                 </Border>
@@ -408,7 +408,7 @@
                   <StackPanel Spacing="10">
                     <TextBlock Text="Member Editor" FontSize="18" FontWeight="Bold" />
                     <TextBlock Text="{Binding SelectedMemberStateSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    <TextBox Watermark="Display name" Text="{Binding MemberEditorDisplayName}" IsEnabled="{Binding CanEditSelectedMember}" />
+                    <TextBox PlaceholderText="Display name" Text="{Binding MemberEditorDisplayName}" IsEnabled="{Binding CanEditSelectedMember}" />
                     <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding MemberEditorRole}" IsEnabled="{Binding CanEditSelectedMember}" />
                     <CheckBox Content="Active member" IsChecked="{Binding MemberEditorIsActive}" IsEnabled="{Binding CanEditSelectedMember}" />
                     <Button Content="Save Member" Command="{Binding SaveMemberDetailsCommand}" HorizontalAlignment="Left" IsEnabled="{Binding CanEditSelectedMember}" Background="#17211D" Foreground="#F8F2E8" />
@@ -568,7 +568,7 @@
                 <Border Grid.Row="1" Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="12">
                   <Grid ColumnDefinitions="160,*,Auto,Auto" ColumnSpacing="10">
                     <TextBlock Text="Local Git Repository" FontWeight="Bold" VerticalAlignment="Center" />
-                    <TextBox Grid.Column="1" Text="{Binding LocalGitRepositoryPath}" Watermark="/path/to/repository" />
+                    <TextBox Grid.Column="1" Text="{Binding LocalGitRepositoryPath}" PlaceholderText="/path/to/repository" />
                     <Button Grid.Column="2" Content="Save" Command="{Binding SaveLocalGitRepositoryPathCommand}" Background="#17211D" Foreground="#F8F2E8" />
                     <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshIntegrationStatusesCommand}" Background="#F8F2E8" Foreground="#17211D" />
                   </Grid>

--- a/Blueprints.Security/Blueprints.Security.csproj
+++ b/Blueprints.Security/Blueprints.Security.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
+    <PackageReference Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blueprints.Tests/Blueprints.Tests.csproj
+++ b/Blueprints.Tests/Blueprints.Tests.csproj
@@ -4,10 +4,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - A milestone-based product roadmap.
 - Blueprints visual identity and application icon.
 - Cross-platform CI, CodeQL, dependency review, release packaging, PR labels, and community templates.
+- Build-provenance attestations for tagged release packages.
 
 ### Changed
 
-- Restored the Avalonia dependency family to the consistent 11.3.15 line for reproducible builds.
+- Upgraded the application to .NET 10 LTS, Avalonia 12.1.1, and the latest stable direct dependencies.
 - Made command feedback visible across the active workspace.
 - Clarified local-workspace and shared-exchange terminology.
 - Moved superseded planning and handoff documents into `docs/archive`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
-    <RollForward>Major</RollForward>
+    <RollForward>LatestPatch</RollForward>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/ATAC-Helicopter/Blueprints/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/ATAC-Helicopter/Blueprints/actions/workflows/ci.yml/badge.svg?branch=develop"></a>
   <a href="https://github.com/ATAC-Helicopter/Blueprints/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/ATAC-Helicopter/Blueprints/actions/workflows/codeql.yml/badge.svg?branch=develop"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-2f6f5e"></a>
-  <img alt=".NET 8" src="https://img.shields.io/badge/.NET-8.0-512BD4">
+  <img alt=".NET 10" src="https://img.shields.io/badge/.NET-10.0-512BD4">
 </p>
 
 > [!IMPORTANT]
@@ -50,7 +50,7 @@ The canonical delivery plan is [ROADMAP.md](Roadmap.md). Older planning files re
 
 Prerequisites:
 
-- the .NET 8 SDK, or a newer SDK allowed by `global.json`;
+- the .NET 10 SDK (`10.0.300` or a newer patch);
 - Git, if you want local source-change diagnostics.
 
 ```sh

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -19,6 +19,7 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 
 - [x] Restore a reproducible local build and executable helper scripts.
 - [x] Establish public-project documentation, templates, automation, and visual identity.
+- [x] Move the supported runtime to .NET 10 LTS and Avalonia 12.
 - [ ] Split the main window and view model into feature-sized components.
 - [ ] Add folder pickers and validation instead of requiring raw paths.
 - [ ] Add first-run identity setup instead of silently creating a default identity.
@@ -108,6 +109,22 @@ Goal: supported installers and documented recovery for small teams.
 - executing arbitrary repository hooks or scripts;
 - silent automatic conflict merging;
 - storing private signing keys in project or shared folders.
+
+## Continuous security assurance
+
+Security work is a release requirement across every milestone, not a one-time feature:
+
+- [ ] maintain an attacker-focused threat model for every trust boundary;
+- [ ] add adversarial tests for malformed, replayed, rolled-back, partially written, and maliciously signed input;
+- [ ] define key rotation, revocation, recovery, and platform keystore integration;
+- [ ] make workspace updates atomic and recoverable;
+- [ ] generate an SBOM for every published package;
+- [x] generate a provenance attestation for every tagged release package;
+- [ ] commission an independent security review before a stable release;
+- [ ] publish supported-version and vulnerability-response targets;
+- [ ] never describe a release as audited unless its exact source and artifacts were reviewed.
+
+No release can guarantee that every user is always safe. Blueprints instead aims to make its trust boundaries explicit, minimize sensitive state, fail closed when integrity cannot be established, and respond transparently when a weakness is found.
 
 ## How roadmap work becomes issues
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## System shape
 
-Blueprints is a layered .NET 8 desktop application.
+Blueprints is a layered .NET 10 desktop application.
 
 ```text
 Blueprints.App

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,10 +3,10 @@
 ## Prerequisites
 
 - Git
-- .NET 8 SDK or a newer compatible SDK
+- .NET 10 SDK `10.0.300` or a newer patch
 - Windows, macOS, or Linux for build and tests
 
-`global.json` prefers SDK `8.0.413` and permits newer major SDKs. CI always installs .NET 8.
+`global.json` selects the .NET 10 `10.0.3xx` feature band and accepts its latest installed patch. CI installs the latest .NET 10 SDK.
 
 ## Build and test
 
@@ -78,6 +78,6 @@ dotnet --list-sdks
 dotnet --version
 ```
 
-Install .NET 8 or a newer stable SDK. Do not edit a parent-directory `global.json`; this repository has its own pin.
+Install .NET 10 SDK `10.0.300` or a newer patch in the same feature band. Do not edit a parent-directory `global.json`; this repository has its own pin.
 
 If restore is slow on first use, let NuGet finish populating its cache. Subsequent builds should be much faster.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,7 +28,13 @@ git tag -s v0.2.0-alpha.1 -m "Blueprints v0.2.0-alpha.1"
 git push origin v0.2.0-alpha.1
 ```
 
-The release workflow publishes platform archives and generates checksums for `v*` tags. It can also be started manually for packaging verification without creating a public release.
+The release workflow publishes platform archives, generates SHA-256 checksums, and records signed build-provenance attestations for `v*` tags. It can also be started manually for packaging verification without creating a public release.
+
+Verify a downloaded archive against the repository’s GitHub attestation:
+
+```sh
+gh attestation verify Blueprints-<runtime>.zip --repo ATAC-Helicopter/Blueprints
+```
 
 ## Release notes
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.413",
-    "rollForward": "latestMajor",
+    "version": "10.0.300",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Promotion

Promotes the exact upgrade already merged and verified on `develop` in #49. This branch is rooted directly at `main` because the earlier squash-promotion histories prevent GitHub from constructing a direct `develop` → `main` merge.

The resulting file tree is identical to `develop`.

Included:

- .NET 10 LTS / C# 14 baseline
- Avalonia 12.1.1
- latest stable direct NuGet dependencies
- .NET 10 CI, CodeQL, and release packaging
- signed build-provenance attestations for tagged releases
- updated development, release, architecture, changelog, and security-roadmap documentation

## Verification

- formatting clean
- Release build: 0 warnings, 0 errors
- 47/47 tests passing
- Windows, Linux, and macOS CI passing
- CodeQL passing
- no outdated direct packages
- no known vulnerable direct or transitive packages
- successful self-contained publish for `win-x64`, `linux-x64`, `osx-x64`, and `osx-arm64`

No workspace-format or signature-algorithm changes are included.