### PR TITLE
Rework Blueprints around an interactive project map

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,98 +1,54 @@
-name: Release
+name: Milestone Release
 
 on:
   push:
-    tags: ["v*"]
-  workflow_dispatch:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 permissions:
   contents: read
 
 jobs:
-  package:
-    name: ${{ matrix.runtime }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runtime: win-x64
-            os: windows-latest
-          - runtime: linux-x64
-            os: ubuntu-latest
-          - runtime: osx-x64
-            os: macos-latest
-          - runtime: osx-arm64
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Publish
-        shell: pwsh
-        run: |
-          dotnet publish Blueprints.App/Blueprints.App.csproj `
-            --configuration Release `
-            --runtime "${{ matrix.runtime }}" `
-            --self-contained true `
-            --output "artifacts/${{ matrix.runtime }}" `
-            -p:PublishSingleFile=true `
-            -p:DebugType=None `
-            -p:DebugSymbols=false
-
-      - name: Create archive and checksum
-        shell: pwsh
-        run: |
-          $archive = "Blueprints-${{ matrix.runtime }}.zip"
-          Compress-Archive -Path "artifacts/${{ matrix.runtime }}/*" -DestinationPath $archive
-          $hash = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-          "$hash  $archive" | Set-Content "$archive.sha256"
-
-      - name: Upload package
-        uses: actions/upload-artifact@v7
-        with:
-          name: Blueprints-${{ matrix.runtime }}
-          path: |
-            Blueprints-${{ matrix.runtime }}.zip
-            Blueprints-${{ matrix.runtime }}.zip.sha256
-          if-no-files-found: error
-
-  github-release:
-    name: GitHub prerelease
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: package
+  record:
+    name: Record milestone
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
-      attestations: write
       contents: write
-      id-token: write
     steps:
-      - name: Download packages
-        uses: actions/download-artifact@v8
+      - name: Checkout tag history
+        uses: actions/checkout@v7
         with:
-          path: artifacts
-          pattern: Blueprints-*
-          merge-multiple: true
+          fetch-depth: 0
 
-      - name: Attest release packages
-        uses: actions/attest@v4
-        with:
-          subject-path: artifacts/*.zip
+      - name: Verify milestone record
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          tagged_commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git fetch origin main
+          git merge-base --is-ancestor "$tagged_commit" origin/main
+          grep -Eq "^## ${version}([[:space:]]|$)" CHANGELOG.md
 
-      - name: Create prerelease
+      - name: Extract accomplishments
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v heading="## ${version}" '
+            index($0, heading) == 1 { capture = 1; next }
+            capture && /^## / { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+
+      - name: Publish milestone record
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: >-
           gh release create "${{ github.ref_name }}"
-          artifacts/*
           --verify-tag
-          --generate-notes
+          --notes-file release-notes.md
           --prerelease
           --title "Blueprints ${{ github.ref_name }}"

--- a/Blueprints.App/App.axaml
+++ b/Blueprints.App/App.axaml
@@ -1,15 +1,135 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="Blueprints.App.App"
              xmlns:local="using:Blueprints.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+             x:Class="Blueprints.App.App"
+             RequestedThemeVariant="Light">
+  <Application.DataTemplates>
+    <local:ViewLocator />
+  </Application.DataTemplates>
 
-    <Application.DataTemplates>
-        <local:ViewLocator/>
-    </Application.DataTemplates>
-  
-    <Application.Styles>
-        <FluentTheme />
-    </Application.Styles>
+  <Application.Resources>
+    <Color x:Key="BlueprintInk">#102A43</Color>
+    <Color x:Key="BlueprintBlue">#0B4F8A</Color>
+    <Color x:Key="BlueprintBright">#168AD0</Color>
+    <Color x:Key="BlueprintCyan">#54C8E8</Color>
+    <Color x:Key="BlueprintPaper">#F2F8FC</Color>
+    <Color x:Key="BlueprintLine">#BED8E8</Color>
+    <Color x:Key="BlueprintMuted">#58758A</Color>
+    <SolidColorBrush x:Key="InkBrush" Color="{StaticResource BlueprintInk}" />
+    <SolidColorBrush x:Key="BlueBrush" Color="{StaticResource BlueprintBlue}" />
+    <SolidColorBrush x:Key="BrightBrush" Color="{StaticResource BlueprintBright}" />
+    <SolidColorBrush x:Key="PaperBrush" Color="{StaticResource BlueprintPaper}" />
+    <SolidColorBrush x:Key="LineBrush" Color="{StaticResource BlueprintLine}" />
+    <SolidColorBrush x:Key="MutedBrush" Color="{StaticResource BlueprintMuted}" />
+  </Application.Resources>
+
+  <Application.Styles>
+    <FluentTheme />
+
+    <Style Selector="TextBlock">
+      <Setter Property="FontFamily" Value="avares://Avalonia.Fonts.Inter#Inter" />
+      <Setter Property="Foreground" Value="{StaticResource InkBrush}" />
+    </Style>
+    <Style Selector="TextBlock.mono">
+      <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
+    </Style>
+    <Style Selector="TextBlock.eyebrow">
+      <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontWeight" Value="Bold" />
+      <Setter Property="Foreground" Value="{StaticResource BrightBrush}" />
+      <Setter Property="LetterSpacing" Value="1.4" />
+    </Style>
+    <Style Selector="TextBlock.muted">
+      <Setter Property="Foreground" Value="{StaticResource MutedBrush}" />
+    </Style>
+
+    <Style Selector="TextBox">
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="11,9" />
+      <Setter Property="MinHeight" Value="40" />
+      <Setter Property="Background" Value="#F9FCFE" />
+      <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="TextBox:focus">
+      <Setter Property="BorderBrush" Value="{StaticResource BrightBrush}" />
+      <Setter Property="BorderThickness" Value="2" />
+    </Style>
+    <Style Selector="ComboBox">
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="MinHeight" Value="40" />
+      <Setter Property="Background" Value="#F9FCFE" />
+      <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
+    </Style>
+    <Style Selector="Button">
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="14,9" />
+      <Setter Property="MinHeight" Value="40" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="Button.primary">
+      <Setter Property="Background" Value="{StaticResource BlueBrush}" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.primary:pointerover">
+      <Setter Property="Background" Value="#0D66A8" />
+    </Style>
+    <Style Selector="Button.secondary">
+      <Setter Property="Background" Value="#E5F2F9" />
+      <Setter Property="Foreground" Value="{StaticResource BlueprintBlue}" />
+      <Setter Property="BorderBrush" Value="{StaticResource BlueprintLine}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="Button.danger">
+      <Setter Property="Background" Value="#A63D40" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.compact">
+      <Setter Property="Padding" Value="10,6" />
+      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="FontSize" Value="12" />
+    </Style>
+    <Style Selector="Button.nav">
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="#A9C8DC" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="12,9" />
+      <Setter Property="Margin" Value="0,0,0,4" />
+    </Style>
+    <Style Selector="Button.nav:pointerover">
+      <Setter Property="Background" Value="#103B5D" />
+    </Style>
+    <Style Selector="Button.nav.active">
+      <Setter Property="Background" Value="#0F4F7A" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+
+    <Style Selector="Border.card">
+      <Setter Property="Background" Value="#FFFFFF" />
+      <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="6" />
+      <Setter Property="Padding" Value="18" />
+    </Style>
+    <Style Selector="Border.blueprint-card">
+      <Setter Property="Background" Value="#F8FCFF" />
+      <Setter Property="BorderBrush" Value="#80B8D8" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="16" />
+    </Style>
+    <Style Selector="Border.dark-card">
+      <Setter Property="Background" Value="#0B2D49" />
+      <Setter Property="BorderBrush" Value="#245A7D" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="5" />
+      <Setter Property="Padding" Value="16" />
+    </Style>
+    <Style Selector="ListBox">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+  </Application.Styles>
 </Application>

--- a/Blueprints.App/Models/WorkspaceSection.cs
+++ b/Blueprints.App/Models/WorkspaceSection.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.App.Models;
+
+public enum WorkspaceSection
+{
+    Overview,
+    Releases,
+    Team,
+    Sync,
+    Trust,
+    Integrations,
+}

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -72,6 +72,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _selectedConflictSharedPreview = string.Empty;
     private string _localGitRepositoryPath = string.Empty;
     private string _integrationMessage = string.Empty;
+    private WorkspaceSection _selectedWorkspaceSection = WorkspaceSection.Overview;
 
     public MainWindowViewModel()
     {
@@ -261,6 +262,61 @@ public partial class MainWindowViewModel : ViewModelBase
         get => _workspaceMessage;
         private set => SetProperty(ref _workspaceMessage, value);
     }
+
+    public WorkspaceSection SelectedWorkspaceSection
+    {
+        get => _selectedWorkspaceSection;
+        private set
+        {
+            if (SetProperty(ref _selectedWorkspaceSection, value))
+            {
+                OnPropertyChanged(nameof(IsOverviewSelected));
+                OnPropertyChanged(nameof(IsReleasesSelected));
+                OnPropertyChanged(nameof(IsTeamSelected));
+                OnPropertyChanged(nameof(IsSyncSelected));
+                OnPropertyChanged(nameof(IsTrustSelected));
+                OnPropertyChanged(nameof(IsIntegrationsSelected));
+                OnPropertyChanged(nameof(SelectedWorkspaceSectionTitle));
+                OnPropertyChanged(nameof(SelectedWorkspaceSectionDescription));
+            }
+        }
+    }
+
+    public bool IsOverviewSelected => SelectedWorkspaceSection == WorkspaceSection.Overview;
+
+    public bool IsReleasesSelected => SelectedWorkspaceSection == WorkspaceSection.Releases;
+
+    public bool IsTeamSelected => SelectedWorkspaceSection == WorkspaceSection.Team;
+
+    public bool IsSyncSelected => SelectedWorkspaceSection == WorkspaceSection.Sync;
+
+    public bool IsTrustSelected => SelectedWorkspaceSection == WorkspaceSection.Trust;
+
+    public bool IsIntegrationsSelected => SelectedWorkspaceSection == WorkspaceSection.Integrations;
+
+    public string SelectedWorkspaceSectionTitle =>
+        SelectedWorkspaceSection switch
+        {
+            WorkspaceSection.Overview => "Project overview",
+            WorkspaceSection.Releases => "Release drafting board",
+            WorkspaceSection.Team => "Team and signing identities",
+            WorkspaceSection.Sync => "Workspace exchange",
+            WorkspaceSection.Trust => "Trust and audit",
+            WorkspaceSection.Integrations => "Connected systems",
+            _ => "Project overview",
+        };
+
+    public string SelectedWorkspaceSectionDescription =>
+        SelectedWorkspaceSection switch
+        {
+            WorkspaceSection.Overview => "Read the project map, spot blockers, and choose the next action.",
+            WorkspaceSection.Releases => "Plan versions, connect work items, preview notes, and mark milestones complete.",
+            WorkspaceSection.Team => "Review signed membership and manage the people allowed to contribute.",
+            WorkspaceSection.Sync => "Compare local and shared state before moving signed changes.",
+            WorkspaceSection.Trust => "Inspect validation results, conflicts, and the audit boundary.",
+            WorkspaceSection.Integrations => "Connect source history without making a provider authoritative.",
+            _ => string.Empty,
+        };
 
     public string CreateProjectName
     {
@@ -634,6 +690,30 @@ public partial class MainWindowViewModel : ViewModelBase
             _ when HasConflicts => "Workspace has unresolved sync conflicts. Resolve them before editing.",
             _ => "Workspace is trusted and editable.",
         };
+
+    [RelayCommand]
+    private void NavigateToOverview() =>
+        SelectedWorkspaceSection = WorkspaceSection.Overview;
+
+    [RelayCommand]
+    private void NavigateToReleases() =>
+        SelectedWorkspaceSection = WorkspaceSection.Releases;
+
+    [RelayCommand]
+    private void NavigateToTeam() =>
+        SelectedWorkspaceSection = WorkspaceSection.Team;
+
+    [RelayCommand]
+    private void NavigateToSync() =>
+        SelectedWorkspaceSection = WorkspaceSection.Sync;
+
+    [RelayCommand]
+    private void NavigateToTrust() =>
+        SelectedWorkspaceSection = WorkspaceSection.Trust;
+
+    [RelayCommand]
+    private void NavigateToIntegrations() =>
+        SelectedWorkspaceSection = WorkspaceSection.Integrations;
 
     [RelayCommand]
     private void CreateProject()
@@ -1080,6 +1160,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private void ApplySession(LocalWorkspaceSession session)
     {
+        var wasActiveSession = HasActiveSession;
         _currentSession = session;
 
         var workspace = session.LoadResult.Workspace;
@@ -1171,6 +1252,10 @@ public partial class MainWindowViewModel : ViewModelBase
         ChangelogPreview = string.Empty;
         LastChangelogExportPath = string.Empty;
         GitChangelogSummary = string.Empty;
+        if (!wasActiveSession)
+        {
+            SelectedWorkspaceSection = WorkspaceSection.Overview;
+        }
 
         if (previousSelectedVersionId is Guid selectedVersionId)
         {
@@ -1249,6 +1334,7 @@ public partial class MainWindowViewModel : ViewModelBase
         LastChangelogExportPath = string.Empty;
         GitChangelogSummary = string.Empty;
         IdentityPublicKey = string.Empty;
+        SelectedWorkspaceSection = WorkspaceSection.Overview;
         ClearInviteEditor();
         ClearMemberEditor();
         HasActiveSession = false;

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -1,0 +1,78 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.IntegrationsView"
+             x:DataType="vm:MainWindowViewModel">
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="14">
+    <Border Classes="card">
+      <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="10">
+        <StackPanel Margin="0,0,10,0" VerticalAlignment="Center">
+          <TextBlock Classes="eyebrow" Text="LOCAL SOURCE" />
+          <TextBlock Text="Git repository" FontWeight="Bold" />
+        </StackPanel>
+        <TextBox Grid.Column="1" Text="{Binding LocalGitRepositoryPath}" PlaceholderText="/path/to/repository" />
+        <Button Grid.Column="2" Classes="primary" Content="Save connection" Command="{Binding SaveLocalGitRepositoryPathCommand}" />
+        <Button Grid.Column="3" Classes="secondary" Content="Refresh all" Command="{Binding RefreshIntegrationStatusesCommand}" />
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="1" Background="#E8F4FA" BorderBrush="#9AC7DE" BorderThickness="1,0,0,0" Padding="12,9">
+      <TextBlock Text="{Binding IntegrationMessage}" Foreground="#214A64" TextWrapping="Wrap" />
+    </Border>
+
+    <ListBox Grid.Row="2" ItemsSource="{Binding Integrations}">
+      <ListBox.ItemsPanel>
+        <ItemsPanelTemplate>
+          <WrapPanel />
+        </ItemsPanelTemplate>
+      </ListBox.ItemsPanel>
+      <ListBox.ItemTemplate>
+        <DataTemplate x:DataType="models:IntegrationStatusCard">
+          <Border Classes="card" Width="500" MinHeight="250" Margin="0,0,12,12">
+            <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+              <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Spacing="3">
+                  <TextBlock Classes="eyebrow" Text="{Binding Provider}" />
+                  <TextBlock Text="{Binding DisplayName}" FontSize="21" FontWeight="Bold" />
+                </StackPanel>
+                <Border Grid.Column="1" Background="#DDEFF8" CornerRadius="12" Padding="10,4" VerticalAlignment="Top">
+                  <TextBlock Text="{Binding State}" Foreground="#0B4F8A" FontSize="12" FontWeight="Bold" />
+                </Border>
+              </Grid>
+
+              <StackPanel Grid.Row="1" Spacing="3">
+                <TextBlock Text="{Binding Target}" Classes="mono" FontWeight="Bold" TextWrapping="Wrap" />
+                <TextBlock Text="{Binding CheckedAtSummary}" Classes="muted" FontSize="11" />
+              </StackPanel>
+
+              <StackPanel Grid.Row="2" Spacing="7">
+                <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+                <TextBlock Text="{Binding Guidance}" Classes="muted" TextWrapping="Wrap" />
+                <TextBlock Text="{Binding RecentChangeSummary}" FontWeight="Bold" />
+                <ItemsControl ItemsSource="{Binding RecentChanges}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="models:SourceChangeSummary">
+                      <Grid ColumnDefinitions="72,*,110" ColumnSpacing="8" Margin="0,3,0,0">
+                        <TextBlock Classes="mono muted" Text="{Binding ShortHash}" />
+                        <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
+                        <TextBlock Grid.Column="2" Text="{Binding ItemKeySummary}" Classes="muted" />
+                      </Grid>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+
+              <Border Grid.Row="3" Background="#F1F8FC" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="10">
+                <StackPanel Spacing="3">
+                  <TextBlock Classes="eyebrow" Text="AUTHORITY BOUNDARY" />
+                  <TextBlock Text="{Binding TrustBoundary}" Foreground="#214A64" TextWrapping="Wrap" FontSize="12" />
+                </StackPanel>
+              </Border>
+            </Grid>
+          </Border>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+  </Grid>
+</UserControl>

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml.cs
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class IntegrationsView : UserControl
+{
+    public IntegrationsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -1,0 +1,133 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             x:Class="Blueprints.App.Views.Components.OverviewView"
+             x:DataType="vm:MainWindowViewModel">
+  <ScrollViewer>
+    <StackPanel Spacing="18">
+      <UniformGrid Columns="4">
+        <Border Classes="blueprint-card" Margin="0,0,12,0">
+          <StackPanel Spacing="5">
+            <TextBlock Classes="eyebrow" Text="VERSIONS" />
+            <TextBlock Text="{Binding VersionCount}" FontSize="30" FontWeight="Black" />
+            <TextBlock Text="Release plans on the map" Classes="muted" />
+          </StackPanel>
+        </Border>
+        <Border Classes="blueprint-card" Margin="0,0,12,0">
+          <StackPanel Spacing="5">
+            <TextBlock Classes="eyebrow" Text="WORK ITEMS" />
+            <TextBlock Text="{Binding ItemCount}" FontSize="30" FontWeight="Black" />
+            <TextBlock Text="Tracked accomplishments" Classes="muted" />
+          </StackPanel>
+        </Border>
+        <Border Classes="blueprint-card" Margin="0,0,12,0">
+          <StackPanel Spacing="5">
+            <TextBlock Classes="eyebrow" Text="ACTIVE MEMBERS" />
+            <TextBlock Text="{Binding ActiveMemberCount}" FontSize="30" FontWeight="Black" />
+            <TextBlock Text="{Binding MembershipRevision, StringFormat='Membership revision {0}'}" Classes="muted" />
+          </StackPanel>
+        </Border>
+        <Border Classes="blueprint-card">
+          <StackPanel Spacing="5">
+            <TextBlock Classes="eyebrow" Text="SYNC STATE" />
+            <TextBlock Text="{Binding SyncStatus}" FontSize="17" FontWeight="Bold" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding TrustBadge, StringFormat='Trust: {0}'}" Classes="muted" />
+          </StackPanel>
+        </Border>
+      </UniformGrid>
+
+      <Grid ColumnDefinitions="1.35*,0.65*" ColumnSpacing="18">
+        <Border Classes="card">
+          <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="18">
+            <StackPanel Spacing="4">
+              <TextBlock Classes="eyebrow" Text="INTERACTIVE PROJECT MAP" />
+              <TextBlock Text="From idea to milestone record" FontSize="24" FontWeight="Bold" />
+              <TextBlock Text="Each node opens the workspace responsible for that part of the release."
+                         Classes="muted"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+
+            <Grid Grid.Row="1" ColumnDefinitions="*,48,*,48,*,48,*" VerticalAlignment="Center">
+              <Button Classes="secondary" Command="{Binding NavigateToReleasesCommand}" Padding="14">
+                <StackPanel Spacing="6">
+                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
+                    <TextBlock Text="01" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
+                  </Border>
+                  <TextBlock Text="Draft" FontSize="17" FontWeight="Bold" />
+                  <TextBlock Text="Versions and items" Classes="muted" FontSize="12" />
+                </StackPanel>
+              </Button>
+              <Border Grid.Column="1" Height="1" Background="#80B8D8" Margin="8,0" />
+              <Button Grid.Column="2" Classes="secondary" Command="{Binding NavigateToIntegrationsCommand}" Padding="14">
+                <StackPanel Spacing="6">
+                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
+                    <TextBlock Text="02" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
+                  </Border>
+                  <TextBlock Text="Connect" FontSize="17" FontWeight="Bold" />
+                  <TextBlock Text="Source evidence" Classes="muted" FontSize="12" />
+                </StackPanel>
+              </Button>
+              <Border Grid.Column="3" Height="1" Background="#80B8D8" Margin="8,0" />
+              <Button Grid.Column="4" Classes="secondary" Command="{Binding NavigateToTrustCommand}" Padding="14">
+                <StackPanel Spacing="6">
+                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
+                    <TextBlock Text="03" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
+                  </Border>
+                  <TextBlock Text="Verify" FontSize="17" FontWeight="Bold" />
+                  <TextBlock Text="Trust and audit" Classes="muted" FontSize="12" />
+                </StackPanel>
+              </Button>
+              <Border Grid.Column="5" Height="1" Background="#80B8D8" Margin="8,0" />
+              <Button Grid.Column="6" Classes="secondary" Command="{Binding NavigateToSyncCommand}" Padding="14">
+                <StackPanel Spacing="6">
+                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
+                    <TextBlock Text="04" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
+                  </Border>
+                  <TextBlock Text="Exchange" FontSize="17" FontWeight="Bold" />
+                  <TextBlock Text="Signed handoff" Classes="muted" FontSize="12" />
+                </StackPanel>
+              </Button>
+            </Grid>
+
+            <Border Grid.Row="2" Background="#E8F4FA" BorderBrush="#9AC7DE" BorderThickness="1,0,0,0" Padding="14,10">
+              <TextBlock Text="{Binding WorkspaceModeSummary}" TextWrapping="Wrap" Foreground="#214A64" />
+            </Border>
+          </Grid>
+        </Border>
+
+        <StackPanel Grid.Column="1" Spacing="18">
+          <Border Classes="dark-card">
+            <StackPanel Spacing="10">
+              <TextBlock Classes="eyebrow" Text="NEXT ACTIONS" Foreground="#62D3F0" />
+              <Button Classes="primary" Content="Open release board" Command="{Binding NavigateToReleasesCommand}" HorizontalContentAlignment="Left" />
+              <Button Classes="secondary" Content="Inspect trust report" Command="{Binding NavigateToTrustCommand}" HorizontalContentAlignment="Left" />
+              <Button Classes="secondary" Content="Review sync state" Command="{Binding NavigateToSyncCommand}" HorizontalContentAlignment="Left" />
+            </StackPanel>
+          </Border>
+
+          <Border Classes="card">
+            <StackPanel Spacing="7">
+              <TextBlock Classes="eyebrow" Text="WORKSPACE ROUTES" />
+              <TextBlock Text="Local source" FontWeight="Bold" />
+              <TextBlock Text="{Binding WorkspacePath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+              <Border Height="1" Background="#D5E6F0" Margin="0,4" />
+              <TextBlock Text="Shared exchange" FontWeight="Bold" />
+              <TextBlock Text="{Binding SharedSyncPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Grid>
+
+      <Border Classes="card">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+          <StackPanel Spacing="4">
+            <TextBlock Classes="eyebrow" Text="CURRENT SIGNAL" />
+            <TextBlock Text="{Binding WorkspaceMessage}" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding TrustSummary}" Classes="muted" TextWrapping="Wrap" />
+          </StackPanel>
+          <Button Grid.Column="1" Classes="secondary" Content="Refresh project map" Command="{Binding RefreshWorkspaceCommand}" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class OverviewView : UserControl
+{
+    public OverviewView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml
@@ -1,0 +1,187 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.ReleasePlannerView"
+             x:DataType="vm:MainWindowViewModel">
+  <Grid ColumnDefinitions="300,*" ColumnSpacing="16">
+    <Border Classes="card">
+      <Grid RowDefinitions="Auto,Auto,*" RowSpacing="12">
+        <StackPanel Spacing="3">
+          <TextBlock Classes="eyebrow" Text="VERSION INDEX" />
+          <TextBlock Text="Milestone drafts" FontSize="21" FontWeight="Bold" />
+        </StackPanel>
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+          <TextBox PlaceholderText="0.2.0" Text="{Binding NewVersionName}" IsEnabled="{Binding CanMutateWorkspace}" />
+          <Button Grid.Column="1" Classes="primary" Content="+ Add" Command="{Binding CreateVersionCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+        </Grid>
+        <ListBox Grid.Row="2" ItemsSource="{Binding Versions}" SelectedItem="{Binding SelectedVersion}">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="models:WorkspaceVersionCard">
+              <Border Classes="blueprint-card" Margin="0,0,0,9">
+                <StackPanel Spacing="6">
+                  <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Classes="mono" Text="{Binding Name}" FontSize="17" FontWeight="Bold" />
+                    <Border Grid.Column="1" Background="#DDEFF8" CornerRadius="10" Padding="8,3">
+                      <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#0B4F8A" />
+                    </Border>
+                  </Grid>
+                  <TextBlock Text="{Binding Notes}" Classes="muted" TextWrapping="Wrap" MaxHeight="44" />
+                  <Grid ColumnDefinitions="*,*">
+                    <TextBlock Text="{Binding CompletedItemCount, StringFormat='✓ {0} done'}" FontSize="12" Foreground="#277A67" />
+                    <TextBlock Grid.Column="1" Text="{Binding ItemCount, StringFormat='Total: {0}'}" Classes="muted" FontSize="12" HorizontalAlignment="Right" />
+                  </Grid>
+                </StackPanel>
+              </Border>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </Grid>
+    </Border>
+
+    <ScrollViewer Grid.Column="1">
+      <StackPanel Spacing="16">
+        <Border Classes="card">
+          <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="14">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+              <StackPanel Spacing="3">
+                <TextBlock Classes="eyebrow" Text="VERSION NODE" />
+                <TextBlock Text="{Binding SelectedVersionStateSummary}" Classes="muted" TextWrapping="Wrap" />
+              </StackPanel>
+              <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                <Button Classes="danger" Content="Mark released" Command="{Binding ReleaseSelectedVersionCommand}" IsEnabled="{Binding CanReleaseSelectedVersion}" />
+                <Button Classes="primary" Content="Export notes" Command="{Binding ExportSelectedVersionChangelogCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" />
+              </StackPanel>
+            </Grid>
+
+            <Grid Grid.Row="1" ColumnDefinitions="1.2*,0.8*" ColumnSpacing="14">
+              <StackPanel Spacing="10">
+                <Grid ColumnDefinitions="*,170" ColumnSpacing="10">
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Version" FontWeight="SemiBold" />
+                    <TextBox PlaceholderText="Select a version" Text="{Binding VersionEditorName}" IsEnabled="{Binding CanEditSelectedVersion}" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1" Spacing="5">
+                    <TextBlock Text="State" FontWeight="SemiBold" />
+                    <ComboBox ItemsSource="{Binding AvailableStatuses}" SelectedItem="{Binding VersionEditorStatus}" IsEnabled="{Binding CanEditSelectedVersion}" />
+                  </StackPanel>
+                </Grid>
+                <StackPanel Spacing="5">
+                  <TextBlock Text="Accomplishment notes" FontWeight="SemiBold" />
+                  <TextBox PlaceholderText="What does this milestone accomplish?"
+                           Text="{Binding VersionEditorNotes}"
+                           AcceptsReturn="True"
+                           Height="88"
+                           IsEnabled="{Binding CanEditSelectedVersion}" />
+                </StackPanel>
+                <Button Classes="secondary"
+                        Content="Save version details"
+                        Command="{Binding SaveVersionDetailsCommand}"
+                        IsEnabled="{Binding CanEditSelectedVersion}"
+                        HorizontalAlignment="Left" />
+              </StackPanel>
+
+              <Border Grid.Column="1" Classes="blueprint-card">
+                <StackPanel Spacing="7">
+                  <TextBlock Classes="eyebrow" Text="CHANGELOG PREVIEW" />
+                  <TextBlock Text="{Binding LastChangelogExportPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+                  <TextBlock Text="{Binding GitChangelogSummary}" Classes="muted" FontSize="12" TextWrapping="Wrap" />
+                  <TextBox Text="{Binding ChangelogPreview}"
+                           AcceptsReturn="True"
+                           IsReadOnly="True"
+                           MinHeight="150"
+                           TextWrapping="Wrap"
+                           FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
+                           FontSize="12" />
+                </StackPanel>
+              </Border>
+            </Grid>
+
+            <Border Grid.Row="2" Background="#F3F9FC" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="12">
+              <StackPanel Spacing="6">
+                <TextBlock Classes="eyebrow" Text="SOURCE TRACE" />
+                <TextBlock Text="{Binding VersionSourceChangeSummary}" Classes="muted" TextWrapping="Wrap" />
+                <ItemsControl ItemsSource="{Binding VersionSourceChangeDiagnostics}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="models:VersionSourceChangeDiagnostic">
+                      <Grid ColumnDefinitions="72,*,140" ColumnSpacing="8" Margin="0,3,0,0">
+                        <TextBlock Classes="mono muted" Text="{Binding Change.ShortHash}" />
+                        <TextBlock Grid.Column="1" Text="{Binding Change.Subject}" TextWrapping="Wrap" />
+                        <TextBlock Grid.Column="2" Text="{Binding MatchSummary}" Classes="muted" TextWrapping="Wrap" />
+                      </Grid>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+            </Border>
+          </Grid>
+        </Border>
+
+        <Grid ColumnDefinitions="340,*" ColumnSpacing="16">
+          <Border Classes="card">
+            <StackPanel Spacing="10">
+              <StackPanel Spacing="3">
+                <TextBlock Classes="eyebrow" Text="WORK ITEM" />
+                <TextBlock Text="Add or edit an accomplishment" FontSize="19" FontWeight="Bold" />
+              </StackPanel>
+              <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                <StackPanel Spacing="5">
+                  <TextBlock Text="Type" FontWeight="SemiBold" />
+                  <ComboBox ItemsSource="{Binding AvailableItemTypes}" SelectedItem="{Binding SelectedItemTypeId}" IsEnabled="{Binding CanEditItems}" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="5">
+                  <TextBlock Text="Changelog group" FontWeight="SemiBold" />
+                  <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding SelectedCategoryId}" IsEnabled="{Binding CanEditItems}" />
+                </StackPanel>
+              </Grid>
+              <TextBox PlaceholderText="Concise outcome" Text="{Binding ItemEditorTitle}" IsEnabled="{Binding CanEditItems}" />
+              <TextBox PlaceholderText="Useful context for people reading the release"
+                       Text="{Binding ItemEditorDescription}"
+                       AcceptsReturn="True"
+                       Height="90"
+                       IsEnabled="{Binding CanEditItems}" />
+              <CheckBox Content="Completed and ready for release notes" IsChecked="{Binding ItemEditorIsDone}" IsEnabled="{Binding CanEditItems}" />
+              <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Classes="primary" Content="Add item" Command="{Binding AddItemCommand}" IsEnabled="{Binding CanEditItems}" />
+                <Button Classes="secondary" Content="Save selected" Command="{Binding SaveItemDetailsCommand}" IsEnabled="{Binding CanEditItems}" />
+              </StackPanel>
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Column="1" Classes="card">
+            <Grid RowDefinitions="Auto,*" RowSpacing="10">
+              <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Spacing="3">
+                  <TextBlock Classes="eyebrow" Text="CONNECTED ITEMS" />
+                  <TextBlock Text="Selected version scope" FontSize="19" FontWeight="Bold" />
+                </StackPanel>
+                <TextBlock Grid.Column="1" Text="{Binding SelectedVersion.ItemCount, StringFormat='Mapped: {0}'}" Classes="mono muted" VerticalAlignment="Center" />
+              </Grid>
+              <ListBox Grid.Row="1" ItemsSource="{Binding SelectedVersion.Items}" SelectedItem="{Binding SelectedItem}" MinHeight="260">
+                <ListBox.ItemTemplate>
+                  <DataTemplate x:DataType="models:WorkspaceItemCard">
+                    <Border Classes="blueprint-card" Margin="0,0,0,8">
+                      <Grid ColumnDefinitions="92,*,Auto,Auto" ColumnSpacing="10">
+                        <TextBlock Classes="mono" Text="{Binding ItemKey}" FontWeight="Bold" Foreground="#0B4F8A" />
+                        <StackPanel Grid.Column="1" Spacing="2">
+                          <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                          <TextBlock Text="{Binding Description}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+                        <Border Grid.Column="2" Background="#E7F3F9" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
+                          <TextBlock Text="{Binding CategoryId}" Foreground="#0B4F8A" FontSize="11" />
+                        </Border>
+                        <Border Grid.Column="3" Background="#EEF4F7" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
+                          <TextBlock Text="{Binding ItemTypeId}" Classes="muted" FontSize="11" />
+                        </Border>
+                      </Grid>
+                    </Border>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+            </Grid>
+          </Border>
+        </Grid>
+      </StackPanel>
+    </ScrollViewer>
+  </Grid>
+</UserControl>

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml.cs
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class ReleasePlannerView : UserControl
+{
+    public ReleasePlannerView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/Components/SetupView.axaml
+++ b/Blueprints.App/Views/Components/SetupView.axaml
@@ -1,0 +1,194 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.SetupView"
+             x:DataType="vm:MainWindowViewModel">
+  <ScrollViewer>
+    <Grid Margin="32" RowDefinitions="Auto,Auto,*" RowSpacing="24">
+      <Grid ColumnDefinitions="1.15*,0.85*" ColumnSpacing="28">
+        <StackPanel Spacing="10" VerticalAlignment="Center">
+          <TextBlock Classes="eyebrow" Text="BLUEPRINT  /  PROJECT ORIGIN" />
+          <TextBlock Text="Turn release intent into a trusted plan."
+                     FontSize="38"
+                     FontWeight="Black"
+                     MaxWidth="720"
+                     TextWrapping="Wrap" />
+          <TextBlock Text="Start with a local source of truth, connect a separate exchange location, then move through the project map one explicit step at a time."
+                     Classes="muted"
+                     FontSize="16"
+                     MaxWidth="720"
+                     TextWrapping="Wrap" />
+          <Border Background="#E2F2FA" BorderBrush="#8BC4DF" BorderThickness="1,0,0,0" Padding="14,10" Margin="0,8,0,0">
+            <TextBlock Text="{Binding SetupMessage}" TextWrapping="Wrap" Foreground="#214A64" />
+          </Border>
+        </StackPanel>
+
+        <Border Grid.Column="1" Classes="dark-card">
+          <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="16">
+            <TextBlock Classes="eyebrow" Text="HOW THE MAP WORKS" Foreground="#62D3F0" />
+            <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto,*,Auto" VerticalAlignment="Center">
+              <Border Width="40" Height="40" CornerRadius="20" Background="#168AD0">
+                <TextBlock Text="01" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
+              </Border>
+              <Border Grid.Column="1" Height="1" Background="#39779D" Margin="8,0" />
+              <Border Grid.Column="2" Width="40" Height="40" CornerRadius="20" Background="#168AD0">
+                <TextBlock Text="02" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
+              </Border>
+              <Border Grid.Column="3" Height="1" Background="#39779D" Margin="8,0" />
+              <Border Grid.Column="4" Width="40" Height="40" CornerRadius="20" Background="#168AD0">
+                <TextBlock Text="03" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
+              </Border>
+            </Grid>
+            <Grid Grid.Row="2" ColumnDefinitions="*,*,*" ColumnSpacing="12">
+              <StackPanel Spacing="3">
+                <TextBlock Text="Draft" Foreground="White" FontWeight="Bold" />
+                <TextBlock Text="Plan versions and work." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
+              </StackPanel>
+              <StackPanel Grid.Column="1" Spacing="3">
+                <TextBlock Text="Verify" Foreground="White" FontWeight="Bold" />
+                <TextBlock Text="Review trust and source." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
+              </StackPanel>
+              <StackPanel Grid.Column="2" Spacing="3">
+                <TextBlock Text="Record" Foreground="White" FontWeight="Bold" />
+                <TextBlock Text="Freeze accomplishments." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
+              </StackPanel>
+            </Grid>
+          </Grid>
+        </Border>
+      </Grid>
+
+      <Grid Grid.Row="1" ColumnDefinitions="1.1*,0.9*" ColumnSpacing="20">
+        <Border Classes="card">
+          <StackPanel Spacing="14">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="NEW PROJECT" />
+              <TextBlock Text="Draw a fresh blueprint" FontSize="22" FontWeight="Bold" />
+              <TextBlock Text="The local workspace is editable. The exchange folder is treated as untrusted input until validation succeeds."
+                         Classes="muted"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+              <StackPanel Spacing="5">
+                <TextBlock Text="Project name" FontWeight="SemiBold" />
+                <TextBox Text="{Binding CreateProjectName}" />
+              </StackPanel>
+              <StackPanel Grid.Column="1" Spacing="5">
+                <TextBlock Text="Project code" FontWeight="SemiBold" />
+                <TextBox Text="{Binding CreateProjectCode}" />
+              </StackPanel>
+            </Grid>
+
+            <StackPanel Spacing="5">
+              <TextBlock Text="Versioning scheme" FontWeight="SemiBold" />
+              <TextBox Text="{Binding CreateVersioningScheme}" />
+            </StackPanel>
+
+            <StackPanel Spacing="5">
+              <TextBlock Text="Local workspace · editable source" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding CreateLocalWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateLocal_Click" />
+              </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="5">
+              <TextBlock Text="Shared exchange · team handoff" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding CreateSharedWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateShared_Click" />
+              </Grid>
+            </StackPanel>
+
+            <Button Classes="primary"
+                    Content="Create signed project  →"
+                    Command="{Binding CreateProjectCommand}"
+                    HorizontalAlignment="Left" />
+          </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1" Classes="card">
+          <StackPanel Spacing="14">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="EXISTING PROJECT" />
+              <TextBlock Text="Continue from a known workspace" FontSize="22" FontWeight="Bold" />
+              <TextBlock Text="Both locations are shown before opening so the trust boundary stays visible."
+                         Classes="muted"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="5">
+              <TextBlock Text="Local workspace" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding OpenLocalWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenLocal_Click" />
+              </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="5">
+              <TextBlock Text="Shared exchange" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding OpenSharedWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenShared_Click" />
+              </Grid>
+            </StackPanel>
+
+            <Button Classes="primary"
+                    Content="Open and validate  →"
+                    Command="{Binding OpenProjectCommand}"
+                    HorizontalAlignment="Left" />
+
+            <Border Background="#F5FAFD" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="12">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Validation gate" FontWeight="Bold" />
+                <TextBlock Text="Signed content is checked before editing is enabled. Invalid or incomplete state opens read-only."
+                           Classes="muted"
+                           TextWrapping="Wrap" />
+              </StackPanel>
+            </Border>
+          </StackPanel>
+        </Border>
+      </Grid>
+
+      <Border Grid.Row="2" Classes="card">
+        <Grid RowDefinitions="Auto,*" RowSpacing="12">
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Spacing="2">
+              <TextBlock Classes="eyebrow" Text="RECENT WORKSPACES" />
+              <TextBlock Text="Resume a saved project map" FontSize="20" FontWeight="Bold" />
+            </StackPanel>
+            <Button Grid.Column="1"
+                    Classes="primary"
+                    Content="Open selected"
+                    Command="{Binding OpenSelectedRecentProjectCommand}" />
+          </Grid>
+          <ListBox Grid.Row="1"
+                   ItemsSource="{Binding RecentProjects}"
+                   SelectedItem="{Binding SelectedRecentProject}"
+                   MaxHeight="220">
+            <ListBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <WrapPanel />
+              </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+              <DataTemplate x:DataType="models:RecentProjectReference">
+                <Border Classes="blueprint-card" Width="300" Margin="0,0,10,10">
+                  <StackPanel Spacing="5">
+                    <Grid ColumnDefinitions="*,Auto">
+                      <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="16" />
+                      <TextBlock Grid.Column="1" Classes="mono" Text="{Binding ProjectCode}" Foreground="#168AD0" />
+                    </Grid>
+                    <TextBlock Text="{Binding LocalWorkspaceRoot}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+                    <TextBlock Text="{Binding LastOpenedUtc, StringFormat='Last opened {0:g}'}" Classes="muted" FontSize="11" />
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </Grid>
+      </Border>
+    </Grid>
+  </ScrollViewer>
+</UserControl>

--- a/Blueprints.App/Views/Components/SetupView.axaml.cs
+++ b/Blueprints.App/Views/Components/SetupView.axaml.cs
@@ -1,0 +1,67 @@
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Blueprints.App.ViewModels;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class SetupView : UserControl
+{
+    public SetupView()
+    {
+        InitializeComponent();
+    }
+
+    private async void BrowseCreateLocal_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Choose the editable local workspace") is { } path)
+        {
+            viewModel.CreateLocalWorkspaceRoot = path;
+        }
+    }
+
+    private async void BrowseCreateShared_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Choose the shared exchange folder") is { } path)
+        {
+            viewModel.CreateSharedWorkspaceRoot = path;
+        }
+    }
+
+    private async void BrowseOpenLocal_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Choose the existing local workspace") is { } path)
+        {
+            viewModel.OpenLocalWorkspaceRoot = path;
+        }
+    }
+
+    private async void BrowseOpenShared_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Choose its shared exchange folder") is { } path)
+        {
+            viewModel.OpenSharedWorkspaceRoot = path;
+        }
+    }
+
+    private async Task<string?> PickFolderAsync(string title)
+    {
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return null;
+        }
+
+        var folders = await storageProvider.OpenFolderPickerAsync(
+            new FolderPickerOpenOptions
+            {
+                Title = title,
+                AllowMultiple = false,
+            });
+
+        return folders.FirstOrDefault()?.TryGetLocalPath();
+    }
+}

--- a/Blueprints.App/Views/Components/SyncView.axaml
+++ b/Blueprints.App/Views/Components/SyncView.axaml
@@ -1,0 +1,123 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.SyncView"
+             x:DataType="vm:MainWindowViewModel">
+  <Grid ColumnDefinitions="330,*" ColumnSpacing="16">
+    <StackPanel Spacing="16">
+      <Border Classes="dark-card">
+        <StackPanel Spacing="12">
+          <TextBlock Classes="eyebrow" Text="EXCHANGE CIRCUIT" Foreground="#62D3F0" />
+          <TextBlock Text="{Binding SyncStatus}" FontSize="21" FontWeight="Bold" Foreground="White" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
+
+          <Grid ColumnDefinitions="*,48,*" VerticalAlignment="Center" Margin="0,8">
+            <Border Background="#0F4F7A" BorderBrush="#3C88B5" BorderThickness="1" CornerRadius="4" Padding="10">
+              <StackPanel Spacing="3">
+                <TextBlock Text="LOCAL" Classes="eyebrow" Foreground="#62D3F0" />
+                <TextBlock Text="{Binding Sync.PendingOutgoingChanges}" FontSize="28" FontWeight="Black" Foreground="White" />
+                <TextBlock Text="outgoing" Foreground="#A9C8DC" FontSize="11" />
+              </StackPanel>
+            </Border>
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+              <TextBlock Text="⇄" Foreground="#62D3F0" FontSize="26" HorizontalAlignment="Center" />
+            </StackPanel>
+            <Border Grid.Column="2" Background="#0F4F7A" BorderBrush="#3C88B5" BorderThickness="1" CornerRadius="4" Padding="10">
+              <StackPanel Spacing="3">
+                <TextBlock Text="SHARED" Classes="eyebrow" Foreground="#62D3F0" />
+                <TextBlock Text="{Binding Sync.PendingIncomingChanges}" FontSize="28" FontWeight="Black" Foreground="White" />
+                <TextBlock Text="incoming" Foreground="#A9C8DC" FontSize="11" />
+              </StackPanel>
+            </Border>
+          </Grid>
+
+          <Button Classes="primary" Content="Refresh comparison" Command="{Binding RefreshWorkspaceCommand}" />
+          <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+            <Button Classes="primary" Content="Push →" Command="{Binding PushWorkspaceCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+            <Button Grid.Column="1" Classes="secondary" Content="← Pull" Command="{Binding PullWorkspaceCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" />
+          </Grid>
+        </StackPanel>
+      </Border>
+
+      <Border Classes="card">
+        <StackPanel Spacing="6">
+          <TextBlock Classes="eyebrow" Text="SHARED ROUTE" />
+          <TextBlock Text="{Binding SharedSyncPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+          <TextBlock Text="The shared location is never trusted merely because it is reachable."
+                     Classes="muted"
+                     FontSize="12"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+
+    <Border Grid.Column="1" Classes="card">
+      <Grid RowDefinitions="Auto,160,Auto,*" RowSpacing="12">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+          <StackPanel Spacing="3">
+            <TextBlock Classes="eyebrow" Text="DIAGNOSTIC LAYER" />
+            <TextBlock Text="Conflicts and exchange findings" FontSize="21" FontWeight="Bold" />
+            <TextBlock Text="{Binding WorkspaceMessage}" Classes="muted" TextWrapping="Wrap" />
+          </StackPanel>
+          <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <Button Classes="secondary" Content="Keep local" Command="{Binding ResolveConflictKeepLocalCommand}" IsEnabled="{Binding CanResolveSelectedConflict}" />
+            <Button Classes="primary" Content="Accept shared" Command="{Binding ResolveConflictAcceptSharedCommand}" IsEnabled="{Binding CanResolveSelectedConflict}" />
+          </StackPanel>
+        </Grid>
+
+        <ListBox Grid.Row="1" ItemsSource="{Binding SyncDiagnostics}" SelectedItem="{Binding SelectedSyncDiagnostic}">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="models:SyncDiagnosticCard">
+              <Border Classes="blueprint-card" Margin="0,0,0,8">
+                <Grid ColumnDefinitions="105,*" ColumnSpacing="10">
+                  <StackPanel Spacing="2">
+                    <TextBlock Text="{Binding Severity}" FontWeight="Bold" Foreground="#A63D40" />
+                    <TextBlock Text="{Binding Source}" Classes="muted" FontSize="11" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1" Spacing="2">
+                    <TextBlock Text="{Binding Path}" Classes="mono" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Message}" Classes="muted" TextWrapping="Wrap" />
+                  </StackPanel>
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+
+        <Border Grid.Row="2" Background="#E7F3F9" BorderBrush="#9AC7DE" BorderThickness="1" CornerRadius="4" Padding="12">
+          <ScrollViewer MaxHeight="110">
+            <TextBlock Text="{Binding SelectedConflictSemanticSummary}" TextWrapping="Wrap" Classes="mono" FontSize="11" Foreground="#214A64" />
+          </ScrollViewer>
+        </Border>
+
+        <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="12" MinHeight="240">
+          <StackPanel Spacing="6">
+            <Grid ColumnDefinitions="Auto,*">
+              <TextBlock Classes="eyebrow" Text="LOCAL COPY" />
+              <Border Grid.Column="1" Height="1" Background="#BED8E8" Margin="10,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+            <TextBox Text="{Binding SelectedConflictLocalPreview}"
+                     AcceptsReturn="True"
+                     TextWrapping="NoWrap"
+                     IsReadOnly="True"
+                     FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
+                     FontSize="11" />
+          </StackPanel>
+          <StackPanel Grid.Column="1" Spacing="6">
+            <Grid ColumnDefinitions="Auto,*">
+              <TextBlock Classes="eyebrow" Text="SHARED COPY" />
+              <Border Grid.Column="1" Height="1" Background="#BED8E8" Margin="10,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+            <TextBox Text="{Binding SelectedConflictSharedPreview}"
+                     AcceptsReturn="True"
+                     TextWrapping="NoWrap"
+                     IsReadOnly="True"
+                     FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
+                     FontSize="11" />
+          </StackPanel>
+        </Grid>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/Blueprints.App/Views/Components/SyncView.axaml.cs
+++ b/Blueprints.App/Views/Components/SyncView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class SyncView : UserControl
+{
+    public SyncView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/Components/TeamView.axaml
+++ b/Blueprints.App/Views/Components/TeamView.axaml
@@ -1,0 +1,114 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.TeamView"
+             x:DataType="vm:MainWindowViewModel">
+  <Grid ColumnDefinitions="0.72*,1.28*" ColumnSpacing="16">
+    <ScrollViewer>
+      <StackPanel Spacing="16">
+        <Border Classes="dark-card">
+          <StackPanel Spacing="10">
+            <TextBlock Classes="eyebrow" Text="LOCAL SIGNING IDENTITY" Foreground="#62D3F0" />
+            <TextBlock Text="{Binding Identity.DisplayName}" FontSize="22" FontWeight="Bold" Foreground="White" />
+            <TextBlock Text="{Binding Identity.UserId}" Classes="mono" FontSize="11" Foreground="#A9C8DC" TextWrapping="Wrap" />
+            <Border Height="1" Background="#245A7D" />
+            <TextBlock Text="{Binding Identity.KeyStorageProvider, StringFormat='Protected by {0}'}" Foreground="#A9C8DC" />
+            <TextBlock Text="Share the bundle only with an administrator who is intentionally inviting this identity."
+                       Foreground="#A9C8DC"
+                       TextWrapping="Wrap"
+                       FontSize="12" />
+            <TextBox Text="{Binding IdentityBundle}"
+                     AcceptsReturn="True"
+                     IsReadOnly="True"
+                     Height="90"
+                     TextWrapping="Wrap"
+                     FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
+                     FontSize="11" />
+          </StackPanel>
+        </Border>
+
+        <Border Classes="card">
+          <StackPanel Spacing="10">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="INVITATION NODE" />
+              <TextBlock Text="Add a signed member" FontSize="19" FontWeight="Bold" />
+            </StackPanel>
+            <TextBox PlaceholderText="User ID" Text="{Binding InviteUserId}" IsEnabled="{Binding CanManageMembers}" />
+            <TextBox PlaceholderText="Display name" Text="{Binding InviteDisplayName}" IsEnabled="{Binding CanManageMembers}" />
+            <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding InviteRole}" IsEnabled="{Binding CanManageMembers}" />
+            <TextBox PlaceholderText="Public key (Base64)"
+                     Text="{Binding InvitePublicKey}"
+                     AcceptsReturn="True"
+                     Height="88"
+                     TextWrapping="Wrap"
+                     IsEnabled="{Binding CanManageMembers}"
+                     FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
+                     FontSize="11" />
+            <Button Classes="primary"
+                    Content="Invite member"
+                    Command="{Binding InviteMemberCommand}"
+                    IsEnabled="{Binding CanManageMembers}"
+                    HorizontalAlignment="Left" />
+          </StackPanel>
+        </Border>
+      </StackPanel>
+    </ScrollViewer>
+
+    <Grid Grid.Column="1" RowDefinitions="*,Auto" RowSpacing="16">
+      <Border Classes="card">
+        <Grid RowDefinitions="Auto,*" RowSpacing="12">
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="MEMBERSHIP MAP" />
+              <TextBlock Text="Signed project participants" FontSize="21" FontWeight="Bold" />
+            </StackPanel>
+            <TextBlock Grid.Column="1"
+                       Text="{Binding MembershipRevision, StringFormat='REV {0:000}'}"
+                       Classes="mono"
+                       Foreground="#168AD0"
+                       VerticalAlignment="Center" />
+          </Grid>
+          <ListBox Grid.Row="1" ItemsSource="{Binding Members}" SelectedItem="{Binding SelectedMember}">
+            <ListBox.ItemTemplate>
+              <DataTemplate x:DataType="models:WorkspaceMemberCard">
+                <Border Classes="blueprint-card" Margin="0,0,0,9">
+                  <Grid ColumnDefinitions="42,*,120,92" ColumnSpacing="12">
+                    <Border Width="34" Height="34" CornerRadius="17" Background="#168AD0" VerticalAlignment="Center">
+                      <TextBlock Text="ID" Foreground="White" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <StackPanel Grid.Column="1" Spacing="2">
+                      <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
+                      <TextBlock Text="{Binding UserId}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+                    </StackPanel>
+                    <TextBlock Grid.Column="2" Text="{Binding Role}" Foreground="#0B4F8A" VerticalAlignment="Center" FontWeight="SemiBold" />
+                    <TextBlock Grid.Column="3" Text="{Binding IsActive, StringFormat='Active: {0}'}" Classes="muted" VerticalAlignment="Center" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </Grid>
+      </Border>
+
+      <Border Grid.Row="1" Classes="card">
+        <Grid ColumnDefinitions="1.2*,1*,1*,Auto" ColumnSpacing="10">
+          <StackPanel Spacing="3">
+            <TextBlock Classes="eyebrow" Text="SELECTED MEMBER" />
+            <TextBlock Text="{Binding SelectedMemberStateSummary}" Classes="muted" TextWrapping="Wrap" />
+          </StackPanel>
+          <TextBox Grid.Column="1" PlaceholderText="Display name" Text="{Binding MemberEditorDisplayName}" IsEnabled="{Binding CanEditSelectedMember}" />
+          <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+            <ComboBox Width="130" ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding MemberEditorRole}" IsEnabled="{Binding CanEditSelectedMember}" />
+            <CheckBox Content="Active" IsChecked="{Binding MemberEditorIsActive}" IsEnabled="{Binding CanEditSelectedMember}" />
+          </StackPanel>
+          <Button Grid.Column="3"
+                  Classes="primary"
+                  Content="Save member"
+                  Command="{Binding SaveMemberDetailsCommand}"
+                  IsEnabled="{Binding CanEditSelectedMember}" />
+        </Grid>
+      </Border>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/Blueprints.App/Views/Components/TeamView.axaml.cs
+++ b/Blueprints.App/Views/Components/TeamView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class TeamView : UserControl
+{
+    public TeamView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/Components/TrustView.axaml
+++ b/Blueprints.App/Views/Components/TrustView.axaml
@@ -1,0 +1,71 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             x:Class="Blueprints.App.Views.Components.TrustView"
+             x:DataType="vm:MainWindowViewModel">
+  <Grid ColumnDefinitions="360,*" ColumnSpacing="16">
+    <StackPanel Spacing="16">
+      <Border Classes="dark-card">
+        <StackPanel Spacing="10">
+          <TextBlock Classes="eyebrow" Text="TRUST GATE" Foreground="#62D3F0" />
+          <Border Width="72" Height="72" CornerRadius="36" Background="#0F5E76" BorderBrush="#62D3F0" BorderThickness="2" HorizontalAlignment="Left">
+            <TextBlock Text="✓" FontSize="32" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" />
+          </Border>
+          <TextBlock Text="{Binding TrustBadge}" FontSize="25" FontWeight="Black" Foreground="White" />
+          <TextBlock Text="{Binding TrustSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
+          <Button Classes="primary" Content="Run validation again" Command="{Binding RefreshWorkspaceCommand}" HorizontalAlignment="Left" />
+        </StackPanel>
+      </Border>
+
+      <Border Classes="card">
+        <StackPanel Spacing="10">
+          <TextBlock Classes="eyebrow" Text="TRUST BOUNDARIES" />
+          <StackPanel Spacing="3">
+            <TextBlock Text="Editable local workspace" FontWeight="Bold" />
+            <TextBlock Text="{Binding WorkspacePath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+          </StackPanel>
+          <Border Height="1" Background="#D5E6F0" />
+          <StackPanel Spacing="3">
+            <TextBlock Text="Untrusted shared exchange" FontWeight="Bold" />
+            <TextBlock Text="{Binding SharedSyncPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+    </StackPanel>
+
+    <Border Grid.Column="1" Classes="card">
+      <Grid RowDefinitions="Auto,*" RowSpacing="12">
+        <StackPanel Spacing="3">
+          <TextBlock Classes="eyebrow" Text="VALIDATION SCHEMATIC" />
+          <TextBlock Text="Audit, signatures, storage, and safety findings" FontSize="21" FontWeight="Bold" />
+          <TextBlock Text="Every finding describes the affected boundary and the safest next action."
+                     Classes="muted"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+        <ListBox Grid.Row="1" ItemsSource="{Binding TrustDiagnostics}">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="models:TrustDiagnosticCard">
+              <Border Classes="blueprint-card" Margin="0,0,0,9">
+                <Grid ColumnDefinitions="48,130,*" ColumnSpacing="12">
+                  <Border Width="34" Height="34" CornerRadius="17" Background="#DDEFF8" VerticalAlignment="Top">
+                    <TextBlock Text="◆" Foreground="#168AD0" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                  </Border>
+                  <StackPanel Grid.Column="1" Spacing="3">
+                    <TextBlock Text="{Binding Severity}" FontWeight="Bold" Foreground="#0B4F8A" />
+                    <TextBlock Text="{Binding Area}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="2" Spacing="5">
+                    <TextBlock Text="{Binding Summary}" FontWeight="Bold" TextWrapping="Wrap" />
+                    <TextBlock Text="{Binding Guidance}" Classes="muted" TextWrapping="Wrap" />
+                  </StackPanel>
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/Blueprints.App/Views/Components/TrustView.axaml.cs
+++ b/Blueprints.App/Views/Components/TrustView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class TrustView : UserControl
+{
+    public TrustView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -1,7 +1,8 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Blueprints.App.ViewModels"
-        xmlns:appModels="using:Blueprints.App.Models"
+        xmlns:views="using:Blueprints.App.Views.Components"
+        xmlns:shapes="using:Avalonia.Controls.Shapes"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
@@ -11,611 +12,179 @@
         x:DataType="vm:MainWindowViewModel"
         Title="Blueprints"
         Icon="/Assets/blueprints.ico"
-        MinWidth="1180"
-        MinHeight="760"
-        Background="#F6F4EF">
+        Width="1440"
+        Height="920"
+        MinWidth="1040"
+        MinHeight="700"
+        Background="#F2F8FC">
   <Design.DataContext>
     <vm:MainWindowViewModel />
   </Design.DataContext>
 
-  <Window.Styles>
-    <Style Selector="TextBlock">
-      <Setter Property="FontFamily" Value="avares://Avalonia.Fonts.Inter#Inter" />
-      <Setter Property="Foreground" Value="#191D1B" />
-    </Style>
-    <Style Selector="TextBox">
-      <Setter Property="CornerRadius" Value="6" />
-      <Setter Property="Padding" Value="10,8" />
-      <Setter Property="MinHeight" Value="36" />
-    </Style>
-    <Style Selector="ComboBox">
-      <Setter Property="CornerRadius" Value="6" />
-      <Setter Property="MinHeight" Value="36" />
-    </Style>
-    <Style Selector="Button">
-      <Setter Property="CornerRadius" Value="6" />
-      <Setter Property="Padding" Value="12,8" />
-      <Setter Property="MinHeight" Value="36" />
-    </Style>
-    <Style Selector="ListBox">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="0" />
-    </Style>
-    <Style Selector="TabControl">
-      <Setter Property="Background" Value="Transparent" />
-    </Style>
-  </Window.Styles>
+  <Grid RowDefinitions="72,*">
+    <Border Grid.Row="0" Background="#06192B" BorderBrush="#1C4A6A" BorderThickness="0,0,0,1" Padding="22,0">
+      <Grid ColumnDefinitions="Auto,20,*,Auto,Auto" VerticalAlignment="Center">
+        <Grid Width="42" Height="42">
+          <Border Background="#0F4F7A" BorderBrush="#62D3F0" BorderThickness="1" CornerRadius="4" />
+          <Canvas IsHitTestVisible="False">
+            <shapes:Line StartPoint="7,12" EndPoint="35,12" Stroke="#62D3F0" StrokeThickness="1" />
+            <shapes:Line StartPoint="7,21" EndPoint="35,21" Stroke="#62D3F0" StrokeThickness="1" />
+            <shapes:Line StartPoint="7,30" EndPoint="27,30" Stroke="#62D3F0" StrokeThickness="1" />
+            <shapes:Line StartPoint="12,7" EndPoint="12,35" Stroke="#62D3F0" StrokeThickness="1" />
+          </Canvas>
+        </Grid>
 
-  <Grid RowDefinitions="64,*">
-    <Border Grid.Row="0" Background="#17211D" Padding="20,0">
-      <Grid ColumnDefinitions="*,Auto,Auto,Auto" VerticalAlignment="Center">
-        <StackPanel Spacing="2">
-          <TextBlock Text="Blueprints" FontSize="24" FontWeight="Black" Foreground="#F8F2E8" />
-          <TextBlock Text="{Binding Title}" Foreground="#B9C7C0" />
+        <StackPanel Grid.Column="2" Spacing="1" VerticalAlignment="Center">
+          <TextBlock Text="BLUEPRINTS" FontSize="19" FontWeight="Black" Foreground="White" LetterSpacing="1.5" />
+          <TextBlock Text="{Binding Title}" FontSize="12" Foreground="#8FB5CC" />
         </StackPanel>
 
-        <StackPanel Grid.Column="1"
+        <StackPanel Grid.Column="3"
                     Orientation="Horizontal"
                     Spacing="8"
-                    VerticalAlignment="Center"
+                    Margin="0,0,18,0"
                     IsVisible="{Binding HasActiveSession}">
-          <Border Background="#244C42" CornerRadius="6" Padding="10,6">
-            <TextBlock Text="{Binding TrustBadge}" FontWeight="Bold" Foreground="#F8F2E8" />
+          <Border Background="#0F4F7A" BorderBrush="#2F799F" BorderThickness="1" CornerRadius="12" Padding="10,5">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock Text="◆" Foreground="#62D3F0" FontSize="10" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding TrustBadge}" Foreground="White" FontWeight="Bold" FontSize="12" />
+            </StackPanel>
           </Border>
-          <Border Background="#C98539" CornerRadius="6" Padding="10,6">
-            <TextBlock Text="{Binding SyncStatus}" FontWeight="Bold" Foreground="#21160E" />
+          <Border Background="#133C58" BorderBrush="#2F6888" BorderThickness="1" CornerRadius="12" Padding="10,5">
+            <TextBlock Text="{Binding SyncStatus}" Foreground="#C5DCE9" FontWeight="SemiBold" FontSize="12" />
           </Border>
         </StackPanel>
 
-        <StackPanel Grid.Column="2"
-                    Orientation="Horizontal"
-                    Spacing="8"
-                    Margin="18,0,0,0"
-                    VerticalAlignment="Center"
-                    IsVisible="{Binding HasActiveSession}">
-          <Button Content="Switch Project"
-                  Command="{Binding ReturnToProjectSetupCommand}"
-                  Background="#F8F2E8"
-                  Foreground="#17211D" />
-          <Button Content="Refresh"
-                  Command="{Binding RefreshWorkspaceCommand}"
-                  Background="#2D4B72"
-                  Foreground="#F8F2E8" />
-        </StackPanel>
-
-        <Border Grid.Column="3"
-                Margin="18,0,0,0"
-                Padding="12,8"
-                CornerRadius="6"
-                Background="#26302B"
-                MinWidth="220">
-          <StackPanel Spacing="1" HorizontalAlignment="Right">
-            <TextBlock Text="{Binding Identity.DisplayName}" FontWeight="Bold" Foreground="#F8F2E8" HorizontalAlignment="Right" />
-            <TextBlock Text="{Binding Identity.KeyStorageProvider}" FontSize="12" Foreground="#B9C7C0" HorizontalAlignment="Right" />
-          </StackPanel>
+        <Border Grid.Column="4"
+                Background="#0B2D49"
+                BorderBrush="#245A7D"
+                BorderThickness="1"
+                CornerRadius="4"
+                Padding="12,7"
+                MinWidth="190"
+                IsVisible="{Binding HasActiveSession}">
+          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+            <StackPanel Spacing="1">
+              <TextBlock Text="{Binding Identity.DisplayName}" Foreground="White" FontWeight="Bold" FontSize="12" />
+              <TextBlock Text="{Binding Identity.KeyStorageProvider}" Foreground="#8FB5CC" FontSize="10" />
+            </StackPanel>
+            <Border Grid.Column="1" Width="28" Height="28" CornerRadius="14" Background="#168AD0">
+              <TextBlock Text="ID" Foreground="White" FontSize="9" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+          </Grid>
         </Border>
       </Grid>
     </Border>
 
-    <Grid Grid.Row="1" Margin="20">
-      <Grid IsVisible="{Binding IsSetupMode}" ColumnDefinitions="1.15*,0.85*" ColumnSpacing="18">
-        <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="22">
-          <Grid RowDefinitions="Auto,*" RowSpacing="18">
-            <StackPanel Spacing="6">
-              <TextBlock Text="Plan the release. Trust the files." FontSize="30" FontWeight="Black" />
-              <TextBlock Text="{Binding SetupMessage}" FontSize="15" TextWrapping="Wrap" Foreground="#5B625D" />
-              <TextBlock Text="Technical preview · Choose an editable local workspace and a separate shared exchange folder." FontSize="13" TextWrapping="Wrap" Foreground="#8A5A25" />
+    <views:SetupView Grid.Row="1" IsVisible="{Binding IsSetupMode}" />
+
+    <Grid Grid.Row="1" ColumnDefinitions="252,*" IsVisible="{Binding HasActiveSession}">
+      <Border Background="#08233A" BorderBrush="#1C4A6A" BorderThickness="0,0,1,0" Padding="16,18">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16">
+          <Border Classes="dark-card" Padding="13">
+            <StackPanel Spacing="5">
+              <TextBlock Classes="eyebrow" Text="ACTIVE BLUEPRINT" Foreground="#62D3F0" />
+              <TextBlock Text="{Binding CurrentProject.Name}" Foreground="White" FontSize="18" FontWeight="Bold" TextWrapping="Wrap" />
+              <TextBlock Text="{Binding CurrentProject.Code, StringFormat='PROJECT / {0}'}" Classes="mono" Foreground="#8FB5CC" FontSize="11" />
+              <TextBlock Text="{Binding VersioningScheme, StringFormat='SCHEME / {0}'}" Classes="mono" Foreground="#8FB5CC" FontSize="11" />
             </StackPanel>
+          </Border>
 
-            <Grid Grid.Row="1" ColumnDefinitions="*,*" ColumnSpacing="18">
-              <Border Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="18">
-                <StackPanel Spacing="12">
-                  <TextBlock Text="Create Project" FontSize="20" FontWeight="Bold" />
-                  <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
-                    <StackPanel Spacing="5">
-                      <TextBlock Text="Project Name" FontWeight="SemiBold" Foreground="#5B625D" />
-                      <TextBox Text="{Binding CreateProjectName}" />
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Spacing="5">
-                      <TextBlock Text="Project Code" FontWeight="SemiBold" Foreground="#5B625D" />
-                      <TextBox Text="{Binding CreateProjectCode}" />
-                    </StackPanel>
-                  </Grid>
-                  <StackPanel Spacing="5">
-                    <TextBlock Text="Versioning Scheme" FontWeight="SemiBold" Foreground="#5B625D" />
-                    <TextBox Text="{Binding CreateVersioningScheme}" />
-                  </StackPanel>
-                  <StackPanel Spacing="5">
-                    <TextBlock Text="Local Workspace · your editable copy" FontWeight="SemiBold" Foreground="#5B625D" />
-                    <TextBox Text="{Binding CreateLocalWorkspaceRoot}" />
-                  </StackPanel>
-                  <StackPanel Spacing="5">
-                    <TextBlock Text="Shared Exchange · the team handoff copy" FontWeight="SemiBold" Foreground="#5B625D" />
-                    <TextBox Text="{Binding CreateSharedWorkspaceRoot}" />
-                  </StackPanel>
-                  <Button Content="Create Signed Project"
-                          Command="{Binding CreateProjectCommand}"
-                          HorizontalAlignment="Left"
-                          Background="#17211D"
-                          Foreground="#F8F2E8" />
-                </StackPanel>
-              </Border>
+          <StackPanel Grid.Row="1" Spacing="4">
+            <TextBlock Classes="eyebrow" Text="PROJECT MAP" Foreground="#62D3F0" Margin="10,0,0,5" />
 
-              <Border Grid.Column="1" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="18">
-                <StackPanel Spacing="12">
-                  <TextBlock Text="Open Project" FontSize="20" FontWeight="Bold" />
-                  <StackPanel Spacing="5">
-                    <TextBlock Text="Local Workspace · your editable copy" FontWeight="SemiBold" Foreground="#5B625D" />
-                    <TextBox Text="{Binding OpenLocalWorkspaceRoot}" />
-                  </StackPanel>
-                  <StackPanel Spacing="5">
-                    <TextBlock Text="Shared Exchange · the team handoff copy" FontWeight="SemiBold" Foreground="#5B625D" />
-                    <TextBox Text="{Binding OpenSharedWorkspaceRoot}" />
-                  </StackPanel>
-                  <Button Content="Open Existing Workspace"
-                          Command="{Binding OpenProjectCommand}"
-                          HorizontalAlignment="Left"
-                          Background="#17211D"
-                          Foreground="#F8F2E8" />
-                  <Border Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="14" Margin="0,8,0,0">
-                    <TextBlock Text="Blueprints keeps release data signed, validates trust on load, and treats shared folders as an explicit exchange layer." TextWrapping="Wrap" Foreground="#4F5B55" />
-                  </Border>
-                </StackPanel>
-              </Border>
-            </Grid>
-          </Grid>
-        </Border>
+            <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Command="{Binding NavigateToOverviewCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="01" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Overview" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+            <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Command="{Binding NavigateToReleasesCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="02" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Releases" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+            <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Command="{Binding NavigateToTeamCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="03" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Team" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+            <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Command="{Binding NavigateToSyncCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="04" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Sync" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+            <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Command="{Binding NavigateToTrustCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="05" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Trust" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+            <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Command="{Binding NavigateToIntegrationsCommand}">
+              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
+                <TextBlock Text="06" Classes="mono" Foreground="#62D3F0" />
+                <TextBlock Grid.Column="1" Text="Integrations" Foreground="{Binding $parent[Button].Foreground}" />
+              </Grid>
+            </Button>
+          </StackPanel>
 
-        <Border Grid.Column="1" Background="#17211D" CornerRadius="8" Padding="18">
-          <Grid RowDefinitions="Auto,*,Auto" RowSpacing="12">
+          <Border Grid.Row="2" BorderBrush="#194765" BorderThickness="1,0,0,0" Margin="20,0,0,0" IsHitTestVisible="False" />
+
+          <StackPanel Grid.Row="3" Spacing="8">
+            <Button Classes="secondary compact" Content="↻ Refresh workspace" Command="{Binding RefreshWorkspaceCommand}" HorizontalContentAlignment="Left" />
+            <Button Classes="nav compact" Content="← Switch project" Command="{Binding ReturnToProjectSetupCommand}" HorizontalContentAlignment="Left" />
+            <TextBlock Text="LOCAL-FIRST  /  SIGNED  /  EXPLICIT"
+                       Classes="mono"
+                       Foreground="#527B94"
+                       FontSize="9"
+                       HorizontalAlignment="Center"
+                       Margin="0,8,0,0" />
+          </StackPanel>
+        </Grid>
+      </Border>
+
+      <Grid Grid.Column="1" Background="#F2F8FC">
+        <Canvas IsHitTestVisible="False" Opacity="0.45">
+          <shapes:Line StartPoint="0,140" EndPoint="1600,140" Stroke="#D7E8F1" StrokeThickness="1" />
+          <shapes:Line StartPoint="0,420" EndPoint="1600,420" Stroke="#D7E8F1" StrokeThickness="1" />
+          <shapes:Line StartPoint="320,0" EndPoint="320,1000" Stroke="#E0EDF4" StrokeThickness="1" />
+          <shapes:Line StartPoint="860,0" EndPoint="860,1000" Stroke="#E0EDF4" StrokeThickness="1" />
+        </Canvas>
+
+        <Grid Margin="24" RowDefinitions="Auto,*" RowSpacing="16">
+          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="18">
             <StackPanel Spacing="4">
-              <TextBlock Text="Recent Workspaces" FontSize="20" FontWeight="Bold" Foreground="#F8F2E8" />
-              <TextBlock Text="Open a known local workspace and its shared sync root." TextWrapping="Wrap" Foreground="#B9C7C0" />
+              <TextBlock Classes="eyebrow" Text="{Binding SelectedWorkspaceSection, StringFormat='BLUEPRINT / {0}'}" />
+              <TextBlock Text="{Binding SelectedWorkspaceSectionTitle}" FontSize="28" FontWeight="Black" />
+              <TextBlock Text="{Binding SelectedWorkspaceSectionDescription}" Classes="muted" TextWrapping="Wrap" />
             </StackPanel>
-
-            <ListBox Grid.Row="1" ItemsSource="{Binding RecentProjects}" SelectedItem="{Binding SelectedRecentProject}">
-              <ListBox.ItemTemplate>
-                <DataTemplate x:DataType="appModels:RecentProjectReference">
-                  <Border Margin="0,0,0,8" Padding="12" CornerRadius="8" Background="#24342E">
-                    <StackPanel Spacing="3">
-                      <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="#F8F2E8" />
-                      <TextBlock Text="{Binding ProjectCode, StringFormat='Code: {0}'}" Foreground="#B9C7C0" />
-                      <TextBlock Text="{Binding LocalWorkspaceRoot}" FontSize="12" TextWrapping="Wrap" Foreground="#93A49C" />
-                    </StackPanel>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-
-            <Button Grid.Row="2"
-                    Content="Open Selected Recent"
-                    Command="{Binding OpenSelectedRecentProjectCommand}"
-                    HorizontalAlignment="Left"
-                    Background="#F8F2E8"
-                    Foreground="#17211D" />
-          </Grid>
-        </Border>
-      </Grid>
-
-      <Grid IsVisible="{Binding HasActiveSession}" RowDefinitions="Auto,Auto,*" RowSpacing="12">
-        <UniformGrid Columns="4">
-          <Border Margin="0,0,10,0" Padding="14" CornerRadius="8" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1">
-            <StackPanel Spacing="3">
-              <TextBlock Text="Workspace" FontWeight="SemiBold" Foreground="#5B625D" />
-              <TextBlock Text="{Binding VersioningScheme, StringFormat='Scheme: {0}'}" FontSize="18" FontWeight="Bold" />
-              <TextBlock Text="{Binding WorkspacePath}" FontSize="12" TextWrapping="Wrap" Foreground="#5B625D" />
-            </StackPanel>
-          </Border>
-          <Border Margin="0,0,10,0" Padding="14" CornerRadius="8" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1">
-            <StackPanel Spacing="3">
-              <TextBlock Text="Project State" FontWeight="SemiBold" Foreground="#5B625D" />
-              <TextBlock Text="{Binding VersionCount, StringFormat='Versions: {0}'}" FontSize="18" FontWeight="Bold" />
-              <TextBlock Text="{Binding ItemCount, StringFormat='Items: {0}'}" Foreground="#5B625D" />
-            </StackPanel>
-          </Border>
-          <Border Margin="0,0,10,0" Padding="14" CornerRadius="8" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1">
-            <StackPanel Spacing="3">
-              <TextBlock Text="Membership" FontWeight="SemiBold" Foreground="#5B625D" />
-              <TextBlock Text="{Binding ActiveMemberCount, StringFormat='Active: {0}'}" FontSize="18" FontWeight="Bold" />
-              <TextBlock Text="{Binding MembershipRevision, StringFormat='Revision: {0}'}" Foreground="#5B625D" />
-            </StackPanel>
-          </Border>
-          <Border Padding="14" CornerRadius="8" Background="#FFF7EA" BorderBrush="#D8D5CB" BorderThickness="1">
-            <StackPanel Spacing="3">
-              <TextBlock Text="Trust + Sync" FontWeight="SemiBold" Foreground="#5B625D" />
-              <TextBlock Text="{Binding SyncStatus}" FontSize="18" FontWeight="Bold" />
-              <TextBlock Text="{Binding WorkspaceModeSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-            </StackPanel>
-          </Border>
-        </UniformGrid>
-
-        <Border Grid.Row="1"
-                Background="#EEF3F0"
-                BorderBrush="#CDD8D1"
-                BorderThickness="1"
-                CornerRadius="8"
-                Padding="12,9">
-          <TextBlock Text="{Binding WorkspaceMessage}"
-                     TextWrapping="Wrap"
-                     Foreground="#33423B" />
-        </Border>
-
-        <TabControl Grid.Row="2">
-          <TabItem Header="Releases">
-            <Grid ColumnDefinitions="320,*" ColumnSpacing="14" Margin="0,12,0,0">
-              <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                <Grid RowDefinitions="Auto,*" RowSpacing="12">
-                  <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                    <TextBlock Text="Versions" FontSize="20" FontWeight="Bold" VerticalAlignment="Center" />
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-                      <TextBox Width="120" PlaceholderText="1.0.0" Text="{Binding NewVersionName}" IsEnabled="{Binding CanMutateWorkspace}" />
-                      <Button Content="New"
-                              Command="{Binding CreateVersionCommand}"
-                              IsEnabled="{Binding CanMutateWorkspace}"
-                              Background="#17211D"
-                              Foreground="#F8F2E8" />
-                    </StackPanel>
-                  </Grid>
-
-                  <ListBox Grid.Row="1" ItemsSource="{Binding Versions}" SelectedItem="{Binding SelectedVersion}">
-                    <ListBox.ItemTemplate>
-                      <DataTemplate x:DataType="appModels:WorkspaceVersionCard">
-                        <Border Margin="0,0,0,8" Padding="12" CornerRadius="8" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1">
-                          <StackPanel Spacing="5">
-                            <Grid ColumnDefinitions="*,Auto">
-                              <TextBlock Text="{Binding Name}" FontFamily="Cascadia Mono, Consolas, monospace" FontSize="17" FontWeight="Bold" />
-                              <Border Grid.Column="1" Background="#E6EBF2" CornerRadius="6" Padding="8,3">
-                                <TextBlock Text="{Binding Status}" FontSize="12" Foreground="#2E486C" />
-                              </Border>
-                            </Grid>
-                            <TextBlock Text="{Binding Notes}" TextWrapping="Wrap" Foreground="#5B625D" />
-                            <TextBlock Text="{Binding CompletedItemCount, StringFormat='Completed: {0}'}" Foreground="#5B625D" />
-                            <TextBlock Text="{Binding ItemCount, StringFormat='Total items: {0}'}" Foreground="#5B625D" />
-                          </StackPanel>
-                        </Border>
-                      </DataTemplate>
-                    </ListBox.ItemTemplate>
-                  </ListBox>
-                </Grid>
-              </Border>
-
-              <Grid Grid.Column="1" RowDefinitions="Auto,*" RowSpacing="14">
-                <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <Grid ColumnDefinitions="1.2*,0.8*" ColumnSpacing="14">
-                    <StackPanel Spacing="10">
-                      <TextBlock Text="Version Editor" FontSize="20" FontWeight="Bold" />
-                      <TextBlock Text="{Binding SelectedVersionStateSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                      <Grid ColumnDefinitions="*,160" ColumnSpacing="10">
-                        <TextBox PlaceholderText="Select a version" Text="{Binding VersionEditorName}" IsEnabled="{Binding CanEditSelectedVersion}" />
-                        <ComboBox Grid.Column="1" ItemsSource="{Binding AvailableStatuses}" SelectedItem="{Binding VersionEditorStatus}" IsEnabled="{Binding CanEditSelectedVersion}" />
-                      </Grid>
-                      <TextBox PlaceholderText="Version notes" Text="{Binding VersionEditorNotes}" AcceptsReturn="True" Height="76" IsEnabled="{Binding CanEditSelectedVersion}" />
-                      <StackPanel Orientation="Horizontal" Spacing="8">
-                        <Button Content="Save Version" Command="{Binding SaveVersionDetailsCommand}" IsEnabled="{Binding CanEditSelectedVersion}" Background="#17211D" Foreground="#F8F2E8" />
-                        <Button Content="Release" Command="{Binding ReleaseSelectedVersionCommand}" IsEnabled="{Binding CanReleaseSelectedVersion}" Background="#A85332" Foreground="#FFFFFF" />
-                        <Button Content="Export Changelog" Command="{Binding ExportSelectedVersionChangelogCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" Background="#2D4B72" Foreground="#FFFFFF" />
-                      </StackPanel>
-                      <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="6">
-                        <TextBlock Text="Source Changes" FontWeight="Bold" />
-                        <TextBlock Grid.Row="1" Text="{Binding VersionSourceChangeSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                        <ItemsControl Grid.Row="2" ItemsSource="{Binding VersionSourceChangeDiagnostics}">
-                          <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="appModels:VersionSourceChangeDiagnostic">
-                              <Grid ColumnDefinitions="72,*,140" ColumnSpacing="8" Margin="0,3,0,0">
-                                <TextBlock Text="{Binding Change.ShortHash}" FontFamily="Cascadia Mono, Consolas, monospace" Foreground="#5B625D" />
-                                <TextBlock Grid.Column="1" Text="{Binding Change.Subject}" TextWrapping="Wrap" />
-                                <TextBlock Grid.Column="2" Text="{Binding MatchSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                              </Grid>
-                            </DataTemplate>
-                          </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                      </Grid>
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="1" Spacing="8">
-                      <TextBlock Text="Changelog Preview" FontWeight="Bold" />
-                      <TextBlock Text="{Binding LastChangelogExportPath}" FontSize="12" TextWrapping="Wrap" Foreground="#5B625D" />
-                      <TextBlock Text="{Binding GitChangelogSummary}" FontSize="12" TextWrapping="Wrap" Foreground="#5B625D" />
-                      <TextBox Text="{Binding ChangelogPreview}" AcceptsReturn="True" IsReadOnly="True" Height="180" TextWrapping="Wrap" />
-                    </StackPanel>
-                  </Grid>
-                </Border>
-
-                <Border Grid.Row="1" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <Grid ColumnDefinitions="360,*" ColumnSpacing="14">
-                    <StackPanel Spacing="10">
-                      <TextBlock Text="Item Editor" FontSize="20" FontWeight="Bold" />
-                      <ComboBox ItemsSource="{Binding AvailableItemTypes}" SelectedItem="{Binding SelectedItemTypeId}" IsEnabled="{Binding CanEditItems}" />
-                      <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding SelectedCategoryId}" IsEnabled="{Binding CanEditItems}" />
-                      <TextBox PlaceholderText="Item title" Text="{Binding ItemEditorTitle}" IsEnabled="{Binding CanEditItems}" />
-                      <TextBox PlaceholderText="Description" Text="{Binding ItemEditorDescription}" AcceptsReturn="True" Height="86" IsEnabled="{Binding CanEditItems}" />
-                      <CheckBox Content="Done" IsChecked="{Binding ItemEditorIsDone}" IsEnabled="{Binding CanEditItems}" />
-                      <StackPanel Orientation="Horizontal" Spacing="8">
-                        <Button Content="Add Item" Command="{Binding AddItemCommand}" IsEnabled="{Binding CanEditItems}" Background="#17211D" Foreground="#F8F2E8" />
-                        <Button Content="Save Item" Command="{Binding SaveItemDetailsCommand}" IsEnabled="{Binding CanEditItems}" Background="#F8F2E8" Foreground="#17211D" />
-                      </StackPanel>
-                    </StackPanel>
-
-                    <Grid Grid.Column="1" RowDefinitions="Auto,*" RowSpacing="8">
-                      <TextBlock Text="Selected Version Items" FontSize="18" FontWeight="Bold" />
-                      <ListBox Grid.Row="1" ItemsSource="{Binding SelectedVersion.Items}" SelectedItem="{Binding SelectedItem}">
-                        <ListBox.ItemTemplate>
-                          <DataTemplate x:DataType="appModels:WorkspaceItemCard">
-                            <Border Margin="0,0,0,8" Padding="12" CornerRadius="8" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1">
-                              <Grid ColumnDefinitions="120,*,90,90" ColumnSpacing="10">
-                                <TextBlock Text="{Binding ItemKey}" FontFamily="Cascadia Mono, Consolas, monospace" FontWeight="Bold" />
-                                <TextBlock Grid.Column="1" Text="{Binding Title}" FontWeight="SemiBold" TextWrapping="Wrap" />
-                                <TextBlock Grid.Column="2" Text="{Binding CategoryId}" Foreground="#5B625D" />
-                                <TextBlock Grid.Column="3" Text="{Binding ItemTypeId}" Foreground="#5B625D" />
-                              </Grid>
-                            </Border>
-                          </DataTemplate>
-                        </ListBox.ItemTemplate>
-                      </ListBox>
-                    </Grid>
-                  </Grid>
-                </Border>
-              </Grid>
-            </Grid>
-          </TabItem>
-
-          <TabItem Header="Team">
-            <Grid ColumnDefinitions="360,*" ColumnSpacing="14" Margin="0,12,0,0">
-              <StackPanel Spacing="14">
-                <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <StackPanel Spacing="8">
-                    <TextBlock Text="Identity Bundle" FontSize="18" FontWeight="Bold" />
-                    <TextBox Text="{Binding IdentityBundle}" AcceptsReturn="True" IsReadOnly="True" Height="86" TextWrapping="Wrap" />
-                  </StackPanel>
-                </Border>
-
-                <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <StackPanel Spacing="10">
-                    <TextBlock Text="Invite Member" FontSize="18" FontWeight="Bold" />
-                    <TextBox PlaceholderText="Invitee user ID" Text="{Binding InviteUserId}" IsEnabled="{Binding CanManageMembers}" />
-                    <TextBox PlaceholderText="Invitee display name" Text="{Binding InviteDisplayName}" IsEnabled="{Binding CanManageMembers}" />
-                    <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding InviteRole}" IsEnabled="{Binding CanManageMembers}" />
-                    <TextBox PlaceholderText="Invitee public key (Base64)" Text="{Binding InvitePublicKey}" AcceptsReturn="True" Height="86" TextWrapping="Wrap" IsEnabled="{Binding CanManageMembers}" />
-                    <Button Content="Invite Member" Command="{Binding InviteMemberCommand}" HorizontalAlignment="Left" IsEnabled="{Binding CanManageMembers}" Background="#17211D" Foreground="#F8F2E8" />
-                  </StackPanel>
-                </Border>
+            <Border Grid.Column="1" Classes="blueprint-card" Padding="12,8" VerticalAlignment="Center">
+              <StackPanel Orientation="Horizontal" Spacing="12">
+                <StackPanel Spacing="1">
+                  <TextBlock Classes="eyebrow" Text="MODE" />
+                  <TextBlock Text="{Binding TrustBadge}" FontWeight="Bold" />
+                </StackPanel>
+                <Border Width="1" Background="#BED8E8" />
+                <StackPanel Spacing="1">
+                  <TextBlock Classes="eyebrow" Text="SYNC" />
+                  <TextBlock Text="{Binding Sync.Health}" FontWeight="Bold" />
+                </StackPanel>
               </StackPanel>
-
-              <Grid Grid.Column="1" ColumnDefinitions="*,340" ColumnSpacing="14">
-                <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <Grid RowDefinitions="Auto,*" RowSpacing="10">
-                    <TextBlock Text="Members" FontSize="20" FontWeight="Bold" />
-                    <ListBox Grid.Row="1" ItemsSource="{Binding Members}" SelectedItem="{Binding SelectedMember}">
-                      <ListBox.ItemTemplate>
-                        <DataTemplate x:DataType="appModels:WorkspaceMemberCard">
-                          <Border Margin="0,0,0,8" Padding="12" CornerRadius="8" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1">
-                            <Grid ColumnDefinitions="*,120,80" ColumnSpacing="10">
-                              <StackPanel Spacing="2">
-                                <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
-                                <TextBlock Text="{Binding UserId}" FontFamily="Cascadia Mono, Consolas, monospace" FontSize="12" Foreground="#5B625D" />
-                              </StackPanel>
-                              <TextBlock Grid.Column="1" Text="{Binding Role}" Foreground="#5B625D" VerticalAlignment="Center" />
-                              <TextBlock Grid.Column="2" Text="{Binding IsActive, StringFormat='Active: {0}'}" Foreground="#5B625D" VerticalAlignment="Center" />
-                            </Grid>
-                          </Border>
-                        </DataTemplate>
-                      </ListBox.ItemTemplate>
-                    </ListBox>
-                  </Grid>
-                </Border>
-
-                <Border Grid.Column="1" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                  <StackPanel Spacing="10">
-                    <TextBlock Text="Member Editor" FontSize="18" FontWeight="Bold" />
-                    <TextBlock Text="{Binding SelectedMemberStateSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    <TextBox PlaceholderText="Display name" Text="{Binding MemberEditorDisplayName}" IsEnabled="{Binding CanEditSelectedMember}" />
-                    <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding MemberEditorRole}" IsEnabled="{Binding CanEditSelectedMember}" />
-                    <CheckBox Content="Active member" IsChecked="{Binding MemberEditorIsActive}" IsEnabled="{Binding CanEditSelectedMember}" />
-                    <Button Content="Save Member" Command="{Binding SaveMemberDetailsCommand}" HorizontalAlignment="Left" IsEnabled="{Binding CanEditSelectedMember}" Background="#17211D" Foreground="#F8F2E8" />
-                  </StackPanel>
-                </Border>
-              </Grid>
-            </Grid>
-          </TabItem>
-
-          <TabItem Header="Sync">
-            <Grid ColumnDefinitions="360,*" ColumnSpacing="14" Margin="0,12,0,0">
-              <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                <StackPanel Spacing="12">
-                  <TextBlock Text="Sync Summary" FontSize="20" FontWeight="Bold" />
-                  <TextBlock Text="{Binding SyncStatus}" FontSize="18" FontWeight="Bold" />
-                  <TextBlock Text="{Binding WorkspaceModeSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                  <Border Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <StackPanel Spacing="5">
-                      <TextBlock Text="Shared Sync Root" FontWeight="Bold" />
-                      <TextBlock Text="{Binding SharedSyncPath}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    </StackPanel>
-                  </Border>
-                  <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button Content="Refresh Analysis" Command="{Binding RefreshWorkspaceCommand}" Background="#2D4B72" Foreground="#FFFFFF" />
-                    <Button Content="Push" Command="{Binding PushWorkspaceCommand}" IsEnabled="{Binding CanMutateWorkspace}" Background="#17211D" Foreground="#F8F2E8" />
-                    <Button Content="Pull" Command="{Binding PullWorkspaceCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" Background="#F8F2E8" Foreground="#17211D" />
-                  </StackPanel>
-                  <Border Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <StackPanel Spacing="4">
-                      <TextBlock Text="Pending Outgoing" FontWeight="Bold" />
-                      <TextBlock Text="{Binding Sync.PendingOutgoingChanges}" FontSize="24" FontWeight="Bold" />
-                      <TextBlock Text="Pending Incoming" FontWeight="Bold" />
-                      <TextBlock Text="{Binding Sync.PendingIncomingChanges}" FontSize="24" FontWeight="Bold" />
-                    </StackPanel>
-                  </Border>
-                </StackPanel>
-              </Border>
-
-              <Border Grid.Column="1" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                <Grid RowDefinitions="Auto,150,150,*" RowSpacing="10">
-                  <Grid ColumnDefinitions="*,220" ColumnSpacing="14">
-                    <StackPanel Spacing="2">
-                      <TextBlock Text="Sync Diagnostics" FontSize="20" FontWeight="Bold" />
-                      <TextBlock Text="{Binding WorkspaceMessage}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Spacing="8">
-                      <Button Content="Keep Local" Command="{Binding ResolveConflictKeepLocalCommand}" IsEnabled="{Binding CanResolveSelectedConflict}" Background="#17211D" Foreground="#F8F2E8" />
-                      <Button Content="Accept Shared" Command="{Binding ResolveConflictAcceptSharedCommand}" IsEnabled="{Binding CanResolveSelectedConflict}" Background="#F8F2E8" Foreground="#17211D" />
-                    </StackPanel>
-                  </Grid>
-
-                  <ListBox Grid.Row="1" ItemsSource="{Binding SyncDiagnostics}" SelectedItem="{Binding SelectedSyncDiagnostic}">
-                    <ListBox.ItemTemplate>
-                      <DataTemplate x:DataType="appModels:SyncDiagnosticCard">
-                        <Border Margin="0,0,0,8" Padding="10" CornerRadius="8" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1">
-                          <Grid ColumnDefinitions="96,*" ColumnSpacing="10">
-                            <StackPanel Spacing="2">
-                              <TextBlock Text="{Binding Severity}" FontWeight="Bold" />
-                              <TextBlock Text="{Binding Source}" FontSize="12" Foreground="#5B625D" />
-                            </StackPanel>
-                            <StackPanel Grid.Column="1" Spacing="2">
-                              <TextBlock Text="{Binding Path}" FontFamily="Cascadia Mono, Consolas, monospace" FontWeight="Bold" />
-                              <TextBlock Text="{Binding Message}" TextWrapping="Wrap" Foreground="#5B625D" />
-                            </StackPanel>
-                          </Grid>
-                        </Border>
-                      </DataTemplate>
-                    </ListBox.ItemTemplate>
-                  </ListBox>
-
-                  <Border Grid.Row="2" Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                      <TextBlock Text="{Binding SelectedConflictSemanticSummary}" TextWrapping="Wrap" FontFamily="Cascadia Mono, Consolas, monospace" FontSize="12" Foreground="#33423B" />
-                    </ScrollViewer>
-                  </Border>
-
-                  <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="12">
-                    <StackPanel Spacing="6">
-                      <TextBlock Text="Local Copy" FontWeight="Bold" />
-                      <TextBox Text="{Binding SelectedConflictLocalPreview}" AcceptsReturn="True" TextWrapping="NoWrap" IsReadOnly="True" FontFamily="Cascadia Mono, Consolas, monospace" FontSize="12" />
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Spacing="6">
-                      <TextBlock Text="Shared Copy" FontWeight="Bold" />
-                      <TextBox Text="{Binding SelectedConflictSharedPreview}" AcceptsReturn="True" TextWrapping="NoWrap" IsReadOnly="True" FontFamily="Cascadia Mono, Consolas, monospace" FontSize="12" />
-                    </StackPanel>
-                  </Grid>
-                </Grid>
-              </Border>
-            </Grid>
-          </TabItem>
-
-          <TabItem Header="Trust">
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="14" Margin="0,12,0,0">
-              <Border Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                <StackPanel Spacing="12">
-                  <TextBlock Text="Trust Report" FontSize="20" FontWeight="Bold" />
-                  <Border Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <TextBlock Text="{Binding TrustSummary}" TextWrapping="Wrap" Foreground="#33423B" />
-                  </Border>
-                  <TextBlock Text="{Binding WorkspaceModeSummary}" TextWrapping="Wrap" Foreground="#5B625D" />
-                  <Button Content="Recheck Trust" Command="{Binding RefreshWorkspaceCommand}" HorizontalAlignment="Left" Background="#17211D" Foreground="#F8F2E8" />
-                </StackPanel>
-              </Border>
-
-              <Border Grid.Column="1" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="16">
-                <Grid RowDefinitions="Auto,*" RowSpacing="10">
-                  <StackPanel Spacing="2">
-                    <TextBlock Text="Audit + Safety" FontSize="20" FontWeight="Bold" />
-                    <TextBlock Text="Signed history, workspace trust, shared-folder safety, and conflict gates." TextWrapping="Wrap" Foreground="#5B625D" />
-                  </StackPanel>
-                  <Grid Grid.Row="1" ColumnDefinitions="*,260" ColumnSpacing="12">
-                    <ListBox ItemsSource="{Binding TrustDiagnostics}">
-                      <ListBox.ItemTemplate>
-                        <DataTemplate x:DataType="appModels:TrustDiagnosticCard">
-                          <Border Margin="0,0,0,8" Padding="12" CornerRadius="8" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1">
-                            <Grid ColumnDefinitions="100,*" ColumnSpacing="10">
-                              <StackPanel Spacing="2">
-                                <TextBlock Text="{Binding Severity}" FontWeight="Bold" />
-                                <TextBlock Text="{Binding Area}" FontSize="12" TextWrapping="Wrap" Foreground="#5B625D" />
-                              </StackPanel>
-                              <StackPanel Grid.Column="1" Spacing="4">
-                                <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" FontWeight="Bold" />
-                                <TextBlock Text="{Binding Guidance}" TextWrapping="Wrap" Foreground="#5B625D" />
-                              </StackPanel>
-                            </Grid>
-                          </Border>
-                        </DataTemplate>
-                      </ListBox.ItemTemplate>
-                    </ListBox>
-                    <StackPanel Grid.Column="1" Spacing="12">
-                  <Border Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <StackPanel Spacing="5">
-                      <TextBlock Text="Local Workspace Root" FontWeight="Bold" />
-                      <TextBlock Text="{Binding WorkspacePath}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    </StackPanel>
-                  </Border>
-                  <Border Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="12">
-                    <StackPanel Spacing="5">
-                      <TextBlock Text="Shared Sync Root" FontWeight="Bold" />
-                      <TextBlock Text="{Binding SharedSyncPath}" TextWrapping="Wrap" Foreground="#5B625D" />
-                    </StackPanel>
-                  </Border>
-                    </StackPanel>
-                  </Grid>
-                </Grid>
-              </Border>
-            </Grid>
-          </TabItem>
-
-          <TabItem Header="Integrations">
-            <Border Margin="0,12,0,0" Background="#FFFFFF" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="18">
-              <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12">
-                <StackPanel Spacing="4">
-                  <TextBlock Text="Integrations" FontSize="22" FontWeight="Bold" />
-                  <TextBlock Text="Provider status is modeled here before provider APIs are wired. Blueprints signed state remains authoritative." TextWrapping="Wrap" Foreground="#5B625D" />
-                </StackPanel>
-                <Border Grid.Row="1" Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="12">
-                  <Grid ColumnDefinitions="160,*,Auto,Auto" ColumnSpacing="10">
-                    <TextBlock Text="Local Git Repository" FontWeight="Bold" VerticalAlignment="Center" />
-                    <TextBox Grid.Column="1" Text="{Binding LocalGitRepositoryPath}" PlaceholderText="/path/to/repository" />
-                    <Button Grid.Column="2" Content="Save" Command="{Binding SaveLocalGitRepositoryPathCommand}" Background="#17211D" Foreground="#F8F2E8" />
-                    <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshIntegrationStatusesCommand}" Background="#F8F2E8" Foreground="#17211D" />
-                  </Grid>
-                </Border>
-                <TextBlock Grid.Row="2" Text="{Binding IntegrationMessage}" TextWrapping="Wrap" Foreground="#5B625D" />
-                <ListBox Grid.Row="3" ItemsSource="{Binding Integrations}">
-                  <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="appModels:IntegrationStatusCard">
-                      <Border Margin="0,0,0,10" Background="#F8F7F2" BorderBrush="#D8D5CB" BorderThickness="1" CornerRadius="8" Padding="14">
-                        <Grid ColumnDefinitions="180,*,260" ColumnSpacing="14">
-                          <StackPanel Spacing="4">
-                            <TextBlock Text="{Binding DisplayName}" FontSize="18" FontWeight="Bold" />
-                            <TextBlock Text="{Binding State}" Foreground="#5B625D" />
-                            <TextBlock Text="{Binding CheckedAtSummary}" FontSize="12" Foreground="#5B625D" />
-                          </StackPanel>
-                          <StackPanel Grid.Column="1" Spacing="5">
-                            <TextBlock Text="{Binding Target}" FontFamily="Cascadia Mono, Consolas, monospace" FontWeight="Bold" />
-                            <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" Foreground="#33423B" />
-                            <TextBlock Text="{Binding Guidance}" TextWrapping="Wrap" Foreground="#5B625D" />
-                            <TextBlock Text="{Binding RecentChangeSummary}" FontWeight="Bold" Foreground="#33423B" />
-                            <ItemsControl ItemsSource="{Binding RecentChanges}">
-                              <ItemsControl.ItemTemplate>
-                                <DataTemplate x:DataType="appModels:SourceChangeSummary">
-                                  <Grid ColumnDefinitions="72,*,120" ColumnSpacing="8" Margin="0,3,0,0">
-                                    <TextBlock Text="{Binding ShortHash}" FontFamily="Cascadia Mono, Consolas, monospace" Foreground="#5B625D" />
-                                    <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
-                                    <TextBlock Grid.Column="2" Text="{Binding ItemKeySummary}" Foreground="#5B625D" />
-                                  </Grid>
-                                </DataTemplate>
-                              </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                          </StackPanel>
-                          <Border Grid.Column="2" Background="#EEF3F0" BorderBrush="#CDD8D1" BorderThickness="1" CornerRadius="8" Padding="10">
-                            <StackPanel Spacing="5">
-                              <TextBlock Text="Trust Boundary" FontWeight="Bold" />
-                              <TextBlock Text="{Binding TrustBoundary}" TextWrapping="Wrap" Foreground="#33423B" />
-                            </StackPanel>
-                          </Border>
-                        </Grid>
-                      </Border>
-                    </DataTemplate>
-                  </ListBox.ItemTemplate>
-                </ListBox>
-              </Grid>
             </Border>
-          </TabItem>
-        </TabControl>
+          </Grid>
+
+          <Grid Grid.Row="1">
+            <views:OverviewView IsVisible="{Binding IsOverviewSelected}" />
+            <views:ReleasePlannerView IsVisible="{Binding IsReleasesSelected}" />
+            <views:TeamView IsVisible="{Binding IsTeamSelected}" />
+            <views:SyncView IsVisible="{Binding IsSyncSelected}" />
+            <views:TrustView IsVisible="{Binding IsTrustSelected}" />
+            <views:IntegrationsView IsVisible="{Binding IsIntegrationsSelected}" />
+          </Grid>
+        </Grid>
       </Grid>
     </Grid>
   </Grid>

--- a/Blueprints.Tests/MainWindowNavigationTests.cs
+++ b/Blueprints.Tests/MainWindowNavigationTests.cs
@@ -1,0 +1,45 @@
+using Blueprints.App.Models;
+using Blueprints.App.ViewModels;
+
+namespace Blueprints.Tests;
+
+public sealed class MainWindowNavigationTests
+{
+    [Fact]
+    public void NavigationCommands_SelectExactlyOneWorkspaceSection()
+    {
+        var viewModel = new MainWindowViewModel();
+
+        viewModel.NavigateToReleasesCommand.Execute(null);
+
+        Assert.Equal(WorkspaceSection.Releases, viewModel.SelectedWorkspaceSection);
+        Assert.True(viewModel.IsReleasesSelected);
+        Assert.False(viewModel.IsOverviewSelected);
+        Assert.False(viewModel.IsTeamSelected);
+        Assert.False(viewModel.IsSyncSelected);
+        Assert.False(viewModel.IsTrustSelected);
+        Assert.False(viewModel.IsIntegrationsSelected);
+        Assert.Equal("Release drafting board", viewModel.SelectedWorkspaceSectionTitle);
+    }
+
+    [Fact]
+    public void NavigationCommands_CanTraverseTheProjectMap()
+    {
+        var viewModel = new MainWindowViewModel();
+
+        viewModel.NavigateToTeamCommand.Execute(null);
+        Assert.True(viewModel.IsTeamSelected);
+
+        viewModel.NavigateToSyncCommand.Execute(null);
+        Assert.True(viewModel.IsSyncSelected);
+
+        viewModel.NavigateToTrustCommand.Execute(null);
+        Assert.True(viewModel.IsTrustSelected);
+
+        viewModel.NavigateToIntegrationsCommand.Execute(null);
+        Assert.True(viewModel.IsIntegrationsSelected);
+
+        viewModel.NavigateToOverviewCommand.Execute(null);
+        Assert.True(viewModel.IsOverviewSelected);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Canonical public documentation for users, contributors, architecture, workspace format, security, and releases.
 - A milestone-based product roadmap.
 - Blueprints visual identity and application icon.
-- Cross-platform CI, CodeQL, dependency review, release packaging, PR labels, and community templates.
-- Build-provenance attestations for tagged release packages.
+- Cross-platform CI, CodeQL, dependency review, milestone automation, PR labels, and community templates.
+- Lightweight milestone-release records generated from the changelog without binary builds.
+- An interactive blueprint-map application shell with focused release, team, sync, trust, and integration workspaces.
+- Native folder pickers for project creation and opening.
 
 ### Changed
 
 - Upgraded the application to .NET 10 LTS, Avalonia 12.1.1, and the latest stable direct dependencies.
+- Reworked the desktop interface into reusable feature views with explicit navigation and clearer action hierarchy.
 - Made command feedback visible across the active workspace.
 - Clarified local-workspace and shared-exchange terminology.
 - Moved superseded planning and handoff documents into `docs/archive`.
@@ -24,6 +27,12 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Repository-local SDK selection now works when only a newer compatible SDK is installed.
 - Shell helpers are executable.
 
-## 0.1.0-alpha.1
+## 0.1.0-alpha.1 — 2026-02-28
 
-Initial application scaffold and early domain contracts.
+Foundation milestone:
+
+- established project, version, item, member, and changelog domain contracts;
+- added canonical JSON persistence and detached Ed25519 signatures;
+- protected local signing keys and validated signed workspaces on load;
+- created the initial shared-folder sync, conflict, and audit-chain foundation;
+- added repository automation and the first executable Avalonia application scaffold.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 - [Security model](docs/security-model.md)
 - [Development guide](docs/development.md)
 - [Release process](docs/releasing.md)
+- [Release history](docs/releases.md)
 - [Roadmap](Roadmap.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -20,21 +20,21 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Restore a reproducible local build and executable helper scripts.
 - [x] Establish public-project documentation, templates, automation, and visual identity.
 - [x] Move the supported runtime to .NET 10 LTS and Avalonia 12.
-- [ ] Split the main window and view model into feature-sized components.
-- [ ] Add folder pickers and validation instead of requiring raw paths.
+- [x] Split the main window into feature-sized views with project-map navigation.
+- [x] Add native folder pickers instead of requiring raw paths.
 - [ ] Add first-run identity setup instead of silently creating a default identity.
 - [ ] Add delete/archive flows for draft versions and items.
 - [ ] Group items by changelog category and improve empty states.
 - [ ] Preview changelogs before writing a file; expose current changelog options.
 - [ ] Add view-model workflow tests for create, edit, freeze, release, and export.
-- [ ] Publish signed preview packages for Windows, macOS, and Linux.
+- [x] Establish lightweight milestone tags and accomplishment records without binary packaging.
 
 Exit criteria:
 
 - clean clone builds with one documented command;
 - create, close, reopen, plan, release, and export work end to end;
 - all destructive or immutable actions explain their consequences;
-- a preview release is downloadable from GitHub.
+- the v0.2 milestone is recorded by a tag, changelog section, release-history entry, and lightweight GitHub prerelease.
 
 ## Next — v0.3: understandable collaboration
 
@@ -119,7 +119,7 @@ Security work is a release requirement across every milestone, not a one-time fe
 - [ ] define key rotation, revocation, recovery, and platform keystore integration;
 - [ ] make workspace updates atomic and recoverable;
 - [ ] generate an SBOM for every published package;
-- [x] generate a provenance attestation for every tagged release package;
+- [ ] generate provenance attestations when downloadable packages are introduced;
 - [ ] commission an independent security review before a stable release;
 - [ ] publish supported-version and vulnerability-response targets;
 - [ ] never describe a release as audited unless its exact source and artifacts were reviewed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this directory as the canonical technical and user documentation.
 | Understanding the code | [Architecture](architecture.md) |
 | Inspecting project files | [Workspace format](workspace-format.md) |
 | Reviewing trust boundaries | [Security model](security-model.md) |
+| Reviewing milestone accomplishments | [Release history](releases.md) |
 | Publishing a build | [Release process](releasing.md) |
 | Choosing the next work | [Roadmap](../Roadmap.md) |
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,32 @@
+# Release history
+
+Blueprints uses versions as durable milestone checkpoints. Each entry links a Git tag to a completed product outcome and summarizes what became true at that point. Pre-v1.0 GitHub releases contain notes only—no application binaries.
+
+## Published milestones
+
+| Version | Date | Milestone | Accomplishments |
+| --- | --- | --- | --- |
+| [`v0.1.0-alpha.1`](https://github.com/ATAC-Helicopter/Blueprints/releases/tag/v0.1.0-alpha.1) | 2026-02-28 | Foundation | Domain contracts, canonical signed persistence, protected identities, shared-folder sync foundation, audit chaining, and the initial Avalonia application scaffold |
+
+## Planned checkpoints
+
+| Version | Milestone outcome |
+| --- | --- |
+| `v0.2.0` | A coherent and usable solo release-planning workflow |
+| `v0.3.0` | Collaboration that two users can understand and recover |
+| `v0.4.0` | Provider-neutral source-control awareness |
+| `v0.5.0` | Explicit VaultSync transport and backup-health integration |
+| `v1.0.0` | A dependable, supported small-team release planner |
+
+## Release record requirements
+
+Every new milestone entry must include:
+
+- the exact version tag and completion date;
+- the roadmap milestone it closes;
+- user-visible capabilities delivered;
+- security or workspace-format changes;
+- important limitations and deferred work;
+- a matching dated section in [`CHANGELOG.md`](../CHANGELOG.md).
+
+See the [release process](releasing.md) for tagging and automation details.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release process
 
-Blueprints is pre-release. Releases should remain marked as prereleases until the v1.0 exit criteria are met.
+Blueprints uses releases as lightweight milestone records while the product is pre-release. A milestone release records what was accomplished; it does not publish installers or application archives.
 
 ## Before promotion
 
@@ -8,33 +8,39 @@ Blueprints is pre-release. Releases should remain marked as prereleases until th
 2. Update `Roadmap.md`, user-facing docs, and dependency notices.
 3. Run `./scripts/verify.sh` on a clean worktree.
 4. Review security-sensitive changes and workspace compatibility.
-5. Merge a promotion pull request from `develop` into `main`.
+5. Create a promotion branch from `main`, apply the verified `develop` diff, and merge that protected pull request into `main`.
 6. Confirm CI and CodeQL succeed on `main`.
 
-## Version and tag
+## Milestone versions
 
-Use semantic versions. Until stable:
+Each roadmap milestone maps to one semantic version:
 
 ```text
-v0.y.z-alpha.n
-v0.y.z-beta.n
-v0.y.z-rc.n
+v0.1 milestone -> v0.1.0
+v0.2 milestone -> v0.2.0
+v0.3 milestone -> v0.3.0
 ```
 
-Create an annotated, signed tag when possible:
+The historical foundation checkpoint used `v0.1.0-alpha.1`. Starting with the v0.2 milestone, use the clean `v0.x.0` form. GitHub records remain marked as prereleases until v1.0.
+
+Before tagging:
+
+1. close or explicitly defer every milestone issue;
+2. move the relevant `Unreleased` changelog entries into `## 0.x.0 — YYYY-MM-DD`;
+3. add the version and its major accomplishments to [release history](releases.md);
+4. promote the exact milestone tree to `main`;
+5. confirm CI and CodeQL are green on `main`.
+
+Create an annotated, signed tag from `main` when possible:
 
 ```sh
-git tag -s v0.2.0-alpha.1 -m "Blueprints v0.2.0-alpha.1"
-git push origin v0.2.0-alpha.1
+git switch main
+git pull --ff-only
+git tag -s v0.2.0 -m "Blueprints v0.2.0 — coherent solo workflow"
+git push origin v0.2.0
 ```
 
-The release workflow publishes platform archives, generates SHA-256 checksums, and records signed build-provenance attestations for `v*` tags. It can also be started manually for packaging verification without creating a public release.
-
-Verify a downloaded archive against the repository’s GitHub attestation:
-
-```sh
-gh attestation verify Blueprints-<runtime>.zip --repo ATAC-Helicopter/Blueprints
-```
+The milestone workflow verifies that the tag belongs to `main`, requires a matching changelog heading, extracts that section, and creates a GitHub prerelease with no attached binaries.
 
 ## Release notes
 
@@ -45,11 +51,11 @@ Include:
 - workspace-format compatibility;
 - known limitations;
 - upgrade and recovery steps;
-- artifact checksums.
+- deferred work that moved to the next milestone.
 
 ## Post-release
 
-- smoke-test each published archive;
 - mark prerelease status correctly;
+- verify the GitHub release has no accidental binary assets;
 - move unfinished issues to the next milestone;
 - open a roadmap issue for any release-specific regression.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # User guide
 
-Blueprints is a desktop application for planning releases in signed local files. It currently targets technical preview users who are comfortable choosing local directories.
+Blueprints is a desktop application for planning releases in signed local files. Its interface is organized as an interactive project blueprint: the left project map moves between the workspaces responsible for planning, evidence, trust, and exchange.
 
 ## Concepts
 
@@ -16,26 +16,26 @@ Blueprints is a desktop application for planning releases in signed local files.
 1. Start Blueprints.
 2. Enter a project name and short code.
 3. Keep `SemVer` or enter the versioning scheme your project uses.
-4. Choose different local and shared roots. Neither may contain the other.
-5. Select **Create Signed Project**.
+4. Use **Browse** to choose different local and shared roots. Neither may contain the other.
+5. Select **Create signed project**.
 
 Blueprints creates the first local identity automatically in the current preview. Identity onboarding is planned.
 
 ## Plan a release
 
-1. Open the **Releases** tab.
-2. Enter a version name and select **New**.
+1. Select **Releases** on the project map.
+2. Enter a version name in the version index and select **Add**.
 3. Select the version and edit its name, status, and notes.
-4. Select an item type and changelog category, enter a title, then select **Add Item**.
-5. Mark completed items as **Done**.
+4. Select an item type and changelog group, enter a title, then select **Add item**.
+5. Mark completed items as ready for release notes.
 
 Item keys are generated from project rules. Released versions are immutable.
 
 ## Export a changelog
 
 1. Select a version.
-2. Select **Export Changelog**.
-3. Review the preview and saved path shown in the version editor.
+2. Select **Export notes**.
+3. Review the changelog preview and saved path in the version node.
 
 Incomplete items are excluded by the current default rules. When a local Git repository is linked, recent commit subjects and matching item keys are added as source context.
 
@@ -43,7 +43,7 @@ Incomplete items are excluded by the current default rules. When a local Git rep
 
 1. Open **Integrations**.
 2. Enter the path to a Git worktree.
-3. Select **Save**, then **Refresh**.
+3. Select **Save connection**, then **Refresh all**.
 
 This integration is read-only. It reads repository status and recent commit metadata; it does not commit, push, or modify the repository.
 
@@ -51,7 +51,7 @@ This integration is read-only. It reads repository status and recent commit meta
 
 The shared root is an exchange layer, not the editable workspace.
 
-- **Refresh Analysis** compares local, shared, and last-synced baselines.
+- **Refresh comparison** compares local, shared, and last-synced baselines.
 - **Push** copies valid outgoing signed documents and updates the signed manifest.
 - **Pull** validates incoming signatures and manifest continuity before applying changes.
 - If both copies changed, Blueprints blocks mutation until you choose **Keep Local** or **Accept Shared**.


### PR DESCRIPTION
## Summary

- rework the desktop shell into a usable, blueprint-themed interactive project map
- add focused Overview, Releases, Team, Sync, Trust, and Integrations workspaces
- add native folder pickers to onboarding
- add navigation coverage and update user/repository documentation
- replace binary-producing release automation with milestone-only tags, changelog notes, and GitHub release records
- publish the historical `v0.1.0-alpha.1` record without build artifacts

## Security scope

This change does not alter domain validation, persistence canonicalization, signatures, key protection, trust policy, or synchronization protocols. It reorganizes their presentation and documents a conservative public-release process.

## Validation

- `dotnet build Blueprints.sln --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet test Blueprints.sln --configuration Release --no-build --no-restore` — 49 passed
- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- `dotnet package list Blueprints.sln --vulnerable --include-transitive` — no known vulnerabilities
- workflow YAML parsed successfully
- production startup smoke test passed
- visual QA completed at 1440×920