### PR TITLE
Promote the diagram-first Blueprints workspace

### DIFF
--- a/Blueprints.App/App.axaml
+++ b/Blueprints.App/App.axaml
@@ -105,6 +105,51 @@
       <Setter Property="Background" Value="#0F4F7A" />
       <Setter Property="Foreground" Value="White" />
     </Style>
+    <Style Selector="Button.tool">
+      <Setter Property="Background" Value="#0B304D" />
+      <Setter Property="Foreground" Value="#C7E2EF" />
+      <Setter Property="BorderBrush" Value="#2A6485" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="Padding" Value="10,5" />
+      <Setter Property="FontSize" Value="12" />
+    </Style>
+    <Style Selector="Button.tool:pointerover">
+      <Setter Property="Background" Value="#11496D" />
+      <Setter Property="BorderBrush" Value="#59BFDE" />
+    </Style>
+    <Style Selector="Button.tool.active">
+      <Setter Property="Background" Value="#146B9F" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="BorderBrush" Value="#6BD8F2" />
+    </Style>
+    <Style Selector="Button.tool.square">
+      <Setter Property="Width" Value="32" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="Button.rail">
+      <Setter Property="Width" Value="56" />
+      <Setter Property="Height" Value="48" />
+      <Setter Property="MinHeight" Value="48" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="#8CB6CC" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
+      <Setter Property="FontSize" Value="17" />
+      <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+    <Style Selector="Button.rail:pointerover">
+      <Setter Property="Background" Value="#0C3858" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="BorderBrush" Value="#2C6D91" />
+    </Style>
+    <Style Selector="Button.rail.active">
+      <Setter Property="Background" Value="#12679A" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="BorderBrush" Value="#65D2EF" />
+    </Style>
 
     <Style Selector="Border.card">
       <Setter Property="Background" Value="#FFFFFF" />

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -276,6 +276,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsSyncSelected));
                 OnPropertyChanged(nameof(IsTrustSelected));
                 OnPropertyChanged(nameof(IsIntegrationsSelected));
+                OnPropertyChanged(nameof(IsDetailsWorkspaceSelected));
                 OnPropertyChanged(nameof(SelectedWorkspaceSectionTitle));
                 OnPropertyChanged(nameof(SelectedWorkspaceSectionDescription));
             }
@@ -293,6 +294,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public bool IsTrustSelected => SelectedWorkspaceSection == WorkspaceSection.Trust;
 
     public bool IsIntegrationsSelected => SelectedWorkspaceSection == WorkspaceSection.Integrations;
+
+    public bool IsDetailsWorkspaceSelected => !IsOverviewSelected;
 
     public string SelectedWorkspaceSectionTitle =>
         SelectedWorkspaceSection switch
@@ -394,6 +397,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(CanEditItems));
                 OnPropertyChanged(nameof(CanReleaseSelectedVersion));
                 OnPropertyChanged(nameof(SelectedVersionStateSummary));
+                OnPropertyChanged(nameof(InspectorSelectionSummary));
                 RefreshVersionSourceChangeDiagnostics();
             }
         }
@@ -407,9 +411,20 @@ public partial class MainWindowViewModel : ViewModelBase
             if (SetProperty(ref _selectedItem, value))
             {
                 PopulateItemEditor();
+                OnPropertyChanged(nameof(HasSelectedItem));
+                OnPropertyChanged(nameof(InspectorSelectionSummary));
             }
         }
     }
+
+    public bool HasSelectedItem => SelectedItem is not null;
+
+    public string InspectorSelectionSummary =>
+        SelectedItem is not null
+            ? $"{SelectedItem.ItemKey} / {SelectedItem.ItemTypeId}"
+            : SelectedVersion is not null
+                ? $"VERSION / {SelectedVersion.Name}"
+                : "SELECT A NODE";
 
     public string NewVersionName
     {
@@ -714,6 +729,50 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void NavigateToIntegrations() =>
         SelectedWorkspaceSection = WorkspaceSection.Integrations;
+
+    [RelayCommand]
+    private void SelectVersionNode(WorkspaceVersionCard? version)
+    {
+        if (version is null)
+        {
+            return;
+        }
+
+        SelectedVersion = version;
+        SelectedItem = null;
+        OnPropertyChanged(nameof(InspectorSelectionSummary));
+    }
+
+    [RelayCommand]
+    private void SelectItemNode(WorkspaceItemCard? item)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        var owningVersion = Versions.FirstOrDefault(version => version.Items.Any(candidate => candidate.ItemId == item.ItemId));
+        if (owningVersion is not null && SelectedVersion?.VersionId != owningVersion.VersionId)
+        {
+            SelectedVersion = owningVersion;
+        }
+
+        SelectedItem = item;
+        OnPropertyChanged(nameof(InspectorSelectionSummary));
+    }
+
+    [RelayCommand]
+    private void BeginNewItem()
+    {
+        if (SelectedVersion is null)
+        {
+            WorkspaceMessage = "Select a version node before connecting a work item.";
+            return;
+        }
+
+        ClearItemEditorForNewItem();
+        WorkspaceMessage = $"Ready to connect a new item to {SelectedVersion.Name}.";
+    }
 
     [RelayCommand]
     private void CreateProject()

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Blueprints.App.Views.Components.BlueprintCanvasSurface">
+  <Border Background="#072A46"
+          BorderBrush="#2C6E96"
+          BorderThickness="1"
+          CornerRadius="4"
+          ClipToBounds="True">
+    <ScrollViewer x:Name="Viewport"
+                  HorizontalScrollBarVisibility="Auto"
+                  VerticalScrollBarVisibility="Auto">
+      <Viewbox x:Name="ZoomHost"
+               Stretch="None"
+               StretchDirection="Both"
+               HorizontalAlignment="Left"
+               VerticalAlignment="Top">
+        <Canvas x:Name="Surface"
+                Width="1500"
+                Height="960"
+                Background="#082F50" />
+      </Viewbox>
+    </ScrollViewer>
+  </Border>
+</UserControl>

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -1,0 +1,450 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Blueprints.App.Models;
+using Blueprints.App.ViewModels;
+
+namespace Blueprints.App.Views.Components;
+
+public partial class BlueprintCanvasSurface : UserControl
+{
+    private const double NodeWidth = 220;
+    private const double VersionNodeHeight = 104;
+    private const double ItemNodeHeight = 82;
+    private readonly Dictionary<Guid, Point> _positions = [];
+    private readonly List<ConnectionVisual> _connections = [];
+    private MainWindowViewModel? _viewModel;
+    private Control? _draggedNode;
+    private Point _dragOffset;
+    private double _zoom = 1;
+
+    public BlueprintCanvasSurface()
+    {
+        InitializeComponent();
+        DataContextChanged += HandleDataContextChanged;
+        DetachedFromVisualTree += (_, _) => DetachViewModel();
+    }
+
+    public void ZoomIn() => SetZoom(_zoom + 0.1);
+
+    public void ZoomOut() => SetZoom(_zoom - 0.1);
+
+    public void ResetView()
+    {
+        _positions.Clear();
+        SetZoom(1);
+        RenderGraph();
+        Viewport.Offset = Vector.Zero;
+    }
+
+    private void SetZoom(double value)
+    {
+        _zoom = Math.Clamp(value, 0.6, 1.5);
+        ZoomHost.Width = Surface.Width * _zoom;
+        ZoomHost.Height = Surface.Height * _zoom;
+        Surface.RenderTransform = new ScaleTransform(_zoom, _zoom);
+        Surface.RenderTransformOrigin = RelativePoint.TopLeft;
+    }
+
+    private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
+    {
+        DetachViewModel();
+        _viewModel = DataContext as MainWindowViewModel;
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged += HandleViewModelPropertyChanged;
+            _viewModel.Versions.CollectionChanged += HandleVersionsChanged;
+        }
+
+        RenderGraph();
+    }
+
+    private void DetachViewModel()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _viewModel.PropertyChanged -= HandleViewModelPropertyChanged;
+        _viewModel.Versions.CollectionChanged -= HandleVersionsChanged;
+        _viewModel = null;
+    }
+
+    private void HandleVersionsChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs) =>
+        RenderGraph();
+
+    private void HandleViewModelPropertyChanged(object? sender, PropertyChangedEventArgs eventArgs)
+    {
+        if (eventArgs.PropertyName is nameof(MainWindowViewModel.SelectedVersion)
+            or nameof(MainWindowViewModel.SelectedItem))
+        {
+            UpdateSelectionVisuals();
+        }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.VersionCount)
+            or nameof(MainWindowViewModel.ItemCount))
+        {
+            RenderGraph();
+        }
+    }
+
+    private void UpdateSelectionVisuals()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        foreach (var border in Surface.Children.OfType<Border>())
+        {
+            if (border.Tag is not NodeTag tag || tag.Id is not Guid id)
+            {
+                continue;
+            }
+
+            var selected = tag.Type switch
+            {
+                "version" => _viewModel.SelectedVersion?.VersionId == id,
+                "item" => _viewModel.SelectedItem?.ItemId == id,
+                _ => false,
+            };
+            border.Background = Brush.Parse(
+                selected
+                    ? "#12669A"
+                    : tag.Type == "version"
+                        ? "#0B3D62"
+                        : "#0A3656");
+            border.BorderBrush = Brush.Parse(
+                selected
+                    ? "#FFFFFF"
+                    : tag.Type == "version"
+                        ? "#4EA9CC"
+                        : "#397F9F");
+        }
+    }
+
+    private void RenderGraph()
+    {
+        Surface.Children.Clear();
+        _connections.Clear();
+        DrawGrid();
+
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        var totalItems = _viewModel.Versions.Sum(static version => version.Items.Count);
+        Surface.Height = Math.Max(900, 180 + Math.Max(_viewModel.Versions.Count * 220, totalItems * 108));
+        Surface.Width = 1260;
+        SetZoom(_zoom);
+
+        var projectNode = CreateProjectNode();
+        var projectPoint = new Point(48, Math.Max(310, Surface.Height / 2 - 70));
+        Place(projectNode, projectPoint);
+        Surface.Children.Add(projectNode);
+
+        var globalItemIndex = 0;
+        for (var versionIndex = 0; versionIndex < _viewModel.Versions.Count; versionIndex++)
+        {
+            var version = _viewModel.Versions[versionIndex];
+            var versionPoint = GetPosition(
+                version.VersionId,
+                new Point(360, 90 + versionIndex * 220));
+            var versionNode = CreateVersionNode(version);
+            Place(versionNode, versionPoint);
+            Surface.Children.Add(versionNode);
+            AddConnection(projectNode, versionNode, "#52C7E8", 2);
+
+            foreach (var item in version.Items)
+            {
+                var itemPoint = GetPosition(
+                    item.ItemId,
+                    new Point(700, 70 + globalItemIndex * 108));
+                var itemNode = CreateItemNode(version, item);
+                Place(itemNode, itemPoint);
+                Surface.Children.Add(itemNode);
+                AddConnection(versionNode, itemNode, item.IsDone ? "#5DD6B2" : "#73AFCF", item.IsDone ? 2 : 1.25);
+                globalItemIndex++;
+            }
+        }
+
+        foreach (var connection in _connections)
+        {
+            Surface.Children.Insert(FindGridVisualCount(), connection.Line);
+            UpdateConnection(connection);
+        }
+
+        if (_viewModel.Versions.Count == 0)
+        {
+            var empty = new TextBlock
+            {
+                Text = "CREATE THE FIRST VERSION TO START DRAWING",
+                FontFamily = FontFamily.Parse("Cascadia Mono, SFMono-Regular, Consolas, monospace"),
+                FontSize = 16,
+                FontWeight = FontWeight.Bold,
+                Foreground = Brush.Parse("#76CDE8"),
+            };
+            Place(empty, new Point(360, 330));
+            Surface.Children.Add(empty);
+        }
+    }
+
+    private int FindGridVisualCount()
+    {
+        var count = 0;
+        foreach (var child in Surface.Children)
+        {
+            if (child is not Line line || line.Tag as string != "grid")
+            {
+                break;
+            }
+
+            count++;
+        }
+
+        return count;
+    }
+
+    private void DrawGrid()
+    {
+        for (var x = 0; x <= Surface.Width; x += 40)
+        {
+            Surface.Children.Add(CreateGridLine(new Point(x, 0), new Point(x, Surface.Height), x % 200 == 0));
+        }
+
+        for (var y = 0; y <= Surface.Height; y += 40)
+        {
+            Surface.Children.Add(CreateGridLine(new Point(0, y), new Point(Surface.Width, y), y % 200 == 0));
+        }
+    }
+
+    private static Line CreateGridLine(Point start, Point end, bool major) =>
+        new()
+        {
+            StartPoint = start,
+            EndPoint = end,
+            Stroke = Brush.Parse(major ? "#1A587A" : "#10415F"),
+            StrokeThickness = major ? 1 : 0.5,
+            IsHitTestVisible = false,
+            Tag = "grid",
+        };
+
+    private Control CreateProjectNode()
+    {
+        var content = new StackPanel { Spacing = 7 };
+        content.Children.Add(CreateLabel("PROJECT ORIGIN", "#65D2EF"));
+        content.Children.Add(CreateTitle(_viewModel?.CurrentProject.Name ?? "Project", 22));
+        content.Children.Add(CreateLabel(
+            $"{_viewModel?.CurrentProject.Code}  /  {_viewModel?.VersioningScheme}",
+            "#A7CEE0"));
+        content.Children.Add(CreateLabel(
+            $"{_viewModel?.VersionCount ?? 0} versions  ·  {_viewModel?.ItemCount ?? 0} items",
+            "#A7CEE0"));
+
+        return CreateNodeShell(content, 250, 140, "#0A2035", "#65D2EF", "project", null);
+    }
+
+    private Control CreateVersionNode(WorkspaceVersionCard version)
+    {
+        var selected = _viewModel?.SelectedVersion?.VersionId == version.VersionId;
+        var content = new StackPanel { Spacing = 6 };
+        content.Children.Add(CreateLabel($"VERSION  /  {version.Status}", selected ? "#FFFFFF" : "#65D2EF"));
+        content.Children.Add(CreateTitle(version.Name, 20));
+        content.Children.Add(CreateLabel(
+            $"{version.CompletedItemCount}/{version.ItemCount} complete",
+            version.CompletedItemCount == version.ItemCount && version.ItemCount > 0 ? "#64DBB6" : "#A7CEE0"));
+
+        var node = CreateNodeShell(
+            content,
+            NodeWidth,
+            VersionNodeHeight,
+            selected ? "#12669A" : "#0B3D62",
+            selected ? "#FFFFFF" : "#4EA9CC",
+            "version",
+            version.VersionId);
+        node.AddHandler(
+            PointerPressedEvent,
+            (_, _) => _viewModel?.SelectVersionNodeCommand.Execute(version),
+            RoutingStrategies.Tunnel);
+        AddDragHandlers(node, version.VersionId);
+        return node;
+    }
+
+    private Control CreateItemNode(WorkspaceVersionCard version, WorkspaceItemCard item)
+    {
+        var selected = _viewModel?.SelectedItem?.ItemId == item.ItemId;
+        var content = new StackPanel { Spacing = 4 };
+        var heading = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
+        heading.Children.Add(CreateLabel(item.ItemKey, selected ? "#FFFFFF" : "#6ED1ED"));
+        var state = CreateLabel(item.IsDone ? "DONE" : "OPEN", item.IsDone ? "#64DBB6" : "#F2C66D");
+        Grid.SetColumn(state, 1);
+        heading.Children.Add(state);
+        content.Children.Add(heading);
+        content.Children.Add(CreateTitle(item.Title, 15));
+        content.Children.Add(CreateLabel($"{item.ItemTypeId}  /  {item.CategoryId}", "#9FC5D8"));
+
+        var node = CreateNodeShell(
+            content,
+            NodeWidth,
+            ItemNodeHeight,
+            selected ? "#12669A" : "#0A3656",
+            selected ? "#FFFFFF" : item.IsDone ? "#4BB99B" : "#397F9F",
+            "item",
+            item.ItemId);
+        node.AddHandler(
+            PointerPressedEvent,
+            (_, _) => _viewModel?.SelectItemNodeCommand.Execute(item),
+            RoutingStrategies.Tunnel);
+        AddDragHandlers(node, item.ItemId);
+        return node;
+    }
+
+    private static Border CreateNodeShell(
+        Control content,
+        double width,
+        double height,
+        string background,
+        string border,
+        string nodeType,
+        Guid? nodeId) =>
+        new()
+        {
+            Width = width,
+            Height = height,
+            Padding = new Thickness(15, 12),
+            Background = Brush.Parse(background),
+            BorderBrush = Brush.Parse(border),
+            BorderThickness = new Thickness(1.5),
+            CornerRadius = new CornerRadius(3),
+            Child = content,
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Tag = new NodeTag(nodeType, nodeId),
+            BoxShadow = new BoxShadows(new BoxShadow
+            {
+                Blur = 12,
+                OffsetX = 0,
+                OffsetY = 4,
+                Color = Color.Parse("#55000000"),
+            }),
+        };
+
+    private static TextBlock CreateLabel(string text, string foreground) =>
+        new()
+        {
+            Text = text,
+            FontFamily = FontFamily.Parse("Cascadia Mono, SFMono-Regular, Consolas, monospace"),
+            FontSize = 10,
+            FontWeight = FontWeight.SemiBold,
+            LetterSpacing = 0.8,
+            Foreground = Brush.Parse(foreground),
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+
+    private static TextBlock CreateTitle(string text, double size) =>
+        new()
+        {
+            Text = text,
+            FontSize = size,
+            FontWeight = FontWeight.Bold,
+            Foreground = Brushes.White,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+
+    private void AddDragHandlers(Control node, Guid nodeId)
+    {
+        node.AddHandler(
+            PointerPressedEvent,
+            (_, eventArgs) =>
+            {
+                _draggedNode = node;
+                var pointer = eventArgs.GetPosition(Surface);
+                _dragOffset = new Point(pointer.X - Canvas.GetLeft(node), pointer.Y - Canvas.GetTop(node));
+                eventArgs.Pointer.Capture(node);
+            },
+            RoutingStrategies.Tunnel);
+        node.PointerMoved += (_, eventArgs) =>
+        {
+            if (_draggedNode != node || !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
+            var pointer = eventArgs.GetPosition(Surface);
+            var point = new Point(
+                Math.Clamp(pointer.X - _dragOffset.X, 0, Surface.Width - node.Bounds.Width),
+                Math.Clamp(pointer.Y - _dragOffset.Y, 0, Surface.Height - node.Bounds.Height));
+            Place(node, point);
+            _positions[nodeId] = point;
+            UpdateConnections(node);
+        };
+        node.PointerReleased += (_, eventArgs) =>
+        {
+            if (_draggedNode == node)
+            {
+                _draggedNode = null;
+                eventArgs.Pointer.Capture(null);
+            }
+        };
+    }
+
+    private void AddConnection(Control source, Control target, string color, double thickness)
+    {
+        _connections.Add(
+            new ConnectionVisual(
+                source,
+                target,
+                new Line
+                {
+                    Stroke = Brush.Parse(color),
+                    StrokeThickness = thickness,
+                    Opacity = 0.85,
+                    IsHitTestVisible = false,
+                }));
+    }
+
+    private void UpdateConnections(Control node)
+    {
+        foreach (var connection in _connections.Where(connection => connection.Source == node || connection.Target == node))
+        {
+            UpdateConnection(connection);
+        }
+    }
+
+    private static void UpdateConnection(ConnectionVisual connection)
+    {
+        connection.Line.StartPoint = new Point(
+            Canvas.GetLeft(connection.Source) + connection.Source.Bounds.Width,
+            Canvas.GetTop(connection.Source) + connection.Source.Bounds.Height / 2);
+        connection.Line.EndPoint = new Point(
+            Canvas.GetLeft(connection.Target),
+            Canvas.GetTop(connection.Target) + connection.Target.Bounds.Height / 2);
+    }
+
+    private Point GetPosition(Guid id, Point fallback)
+    {
+        if (_positions.TryGetValue(id, out var position))
+        {
+            return position;
+        }
+
+        _positions[id] = fallback;
+        return fallback;
+    }
+
+    private static void Place(Control control, Point point)
+    {
+        Canvas.SetLeft(control, point.X);
+        Canvas.SetTop(control, point.Y);
+    }
+
+    private sealed record ConnectionVisual(Control Source, Control Target, Line Line);
+
+    private sealed record NodeTag(string Type, Guid? Id);
+}

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -1,133 +1,146 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:views="using:Blueprints.App.Views.Components"
              x:Class="Blueprints.App.Views.Components.OverviewView"
              x:DataType="vm:MainWindowViewModel">
-  <ScrollViewer>
-    <StackPanel Spacing="18">
-      <UniformGrid Columns="4">
-        <Border Classes="blueprint-card" Margin="0,0,12,0">
-          <StackPanel Spacing="5">
-            <TextBlock Classes="eyebrow" Text="VERSIONS" />
-            <TextBlock Text="{Binding VersionCount}" FontSize="30" FontWeight="Black" />
-            <TextBlock Text="Release plans on the map" Classes="muted" />
-          </StackPanel>
-        </Border>
-        <Border Classes="blueprint-card" Margin="0,0,12,0">
-          <StackPanel Spacing="5">
-            <TextBlock Classes="eyebrow" Text="WORK ITEMS" />
-            <TextBlock Text="{Binding ItemCount}" FontSize="30" FontWeight="Black" />
-            <TextBlock Text="Tracked accomplishments" Classes="muted" />
-          </StackPanel>
-        </Border>
-        <Border Classes="blueprint-card" Margin="0,0,12,0">
-          <StackPanel Spacing="5">
-            <TextBlock Classes="eyebrow" Text="ACTIVE MEMBERS" />
-            <TextBlock Text="{Binding ActiveMemberCount}" FontSize="30" FontWeight="Black" />
-            <TextBlock Text="{Binding MembershipRevision, StringFormat='Membership revision {0}'}" Classes="muted" />
-          </StackPanel>
-        </Border>
-        <Border Classes="blueprint-card">
-          <StackPanel Spacing="5">
-            <TextBlock Classes="eyebrow" Text="SYNC STATE" />
-            <TextBlock Text="{Binding SyncStatus}" FontSize="17" FontWeight="Bold" TextWrapping="Wrap" />
-            <TextBlock Text="{Binding TrustBadge, StringFormat='Trust: {0}'}" Classes="muted" />
-          </StackPanel>
-        </Border>
-      </UniformGrid>
+  <Grid RowDefinitions="58,*">
+    <Border Background="#071F34" BorderBrush="#285E7D" BorderThickness="0,0,0,1" Padding="14,9">
+      <Grid ColumnDefinitions="Auto,18,Auto,*,Auto" ColumnSpacing="8">
+        <StackPanel Orientation="Horizontal" Spacing="7">
+          <Button Classes="tool active" Content="↖ Select" />
+          <TextBox Text="{Binding NewVersionName}"
+                   PlaceholderText="0.2.0"
+                   Width="86"
+                   MinHeight="32"
+                   Padding="8,4"
+                   VerticalContentAlignment="Center"
+                   IsEnabled="{Binding CanMutateWorkspace}" />
+          <Button Classes="tool" Content="＋ Version" Command="{Binding CreateVersionCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+          <Button Classes="tool" Content="⌁ Work item" Command="{Binding BeginNewItemCommand}" IsEnabled="{Binding CanEditItems}" />
+        </StackPanel>
 
-      <Grid ColumnDefinitions="1.35*,0.65*" ColumnSpacing="18">
-        <Border Classes="card">
-          <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="18">
-            <StackPanel Spacing="4">
-              <TextBlock Classes="eyebrow" Text="INTERACTIVE PROJECT MAP" />
-              <TextBlock Text="From idea to milestone record" FontSize="24" FontWeight="Bold" />
-              <TextBlock Text="Each node opens the workspace responsible for that part of the release."
-                         Classes="muted"
-                         TextWrapping="Wrap" />
-            </StackPanel>
+        <Border Grid.Column="1" Width="1" Background="#285E7D" Margin="8,0" />
 
-            <Grid Grid.Row="1" ColumnDefinitions="*,48,*,48,*,48,*" VerticalAlignment="Center">
-              <Button Classes="secondary" Command="{Binding NavigateToReleasesCommand}" Padding="14">
-                <StackPanel Spacing="6">
-                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
-                    <TextBlock Text="01" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
-                  </Border>
-                  <TextBlock Text="Draft" FontSize="17" FontWeight="Bold" />
-                  <TextBlock Text="Versions and items" Classes="muted" FontSize="12" />
-                </StackPanel>
-              </Button>
-              <Border Grid.Column="1" Height="1" Background="#80B8D8" Margin="8,0" />
-              <Button Grid.Column="2" Classes="secondary" Command="{Binding NavigateToIntegrationsCommand}" Padding="14">
-                <StackPanel Spacing="6">
-                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
-                    <TextBlock Text="02" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
-                  </Border>
-                  <TextBlock Text="Connect" FontSize="17" FontWeight="Bold" />
-                  <TextBlock Text="Source evidence" Classes="muted" FontSize="12" />
-                </StackPanel>
-              </Button>
-              <Border Grid.Column="3" Height="1" Background="#80B8D8" Margin="8,0" />
-              <Button Grid.Column="4" Classes="secondary" Command="{Binding NavigateToTrustCommand}" Padding="14">
-                <StackPanel Spacing="6">
-                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
-                    <TextBlock Text="03" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
-                  </Border>
-                  <TextBlock Text="Verify" FontSize="17" FontWeight="Bold" />
-                  <TextBlock Text="Trust and audit" Classes="muted" FontSize="12" />
-                </StackPanel>
-              </Button>
-              <Border Grid.Column="5" Height="1" Background="#80B8D8" Margin="8,0" />
-              <Button Grid.Column="6" Classes="secondary" Command="{Binding NavigateToSyncCommand}" Padding="14">
-                <StackPanel Spacing="6">
-                  <Border Width="30" Height="30" CornerRadius="15" Background="#168AD0" HorizontalAlignment="Left">
-                    <TextBlock Text="04" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="11" FontWeight="Bold" />
-                  </Border>
-                  <TextBlock Text="Exchange" FontSize="17" FontWeight="Bold" />
-                  <TextBlock Text="Signed handoff" Classes="muted" FontSize="12" />
-                </StackPanel>
-              </Button>
-            </Grid>
+        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
+          <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" />
+          <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" />
+          <Button Classes="tool" Content="Fit map" Click="ResetViewClick" />
+        </StackPanel>
 
-            <Border Grid.Row="2" Background="#E8F4FA" BorderBrush="#9AC7DE" BorderThickness="1,0,0,0" Padding="14,10">
-              <TextBlock Text="{Binding WorkspaceModeSummary}" TextWrapping="Wrap" Foreground="#214A64" />
-            </Border>
-          </Grid>
-        </Border>
-
-        <StackPanel Grid.Column="1" Spacing="18">
-          <Border Classes="dark-card">
-            <StackPanel Spacing="10">
-              <TextBlock Classes="eyebrow" Text="NEXT ACTIONS" Foreground="#62D3F0" />
-              <Button Classes="primary" Content="Open release board" Command="{Binding NavigateToReleasesCommand}" HorizontalContentAlignment="Left" />
-              <Button Classes="secondary" Content="Inspect trust report" Command="{Binding NavigateToTrustCommand}" HorizontalContentAlignment="Left" />
-              <Button Classes="secondary" Content="Review sync state" Command="{Binding NavigateToSyncCommand}" HorizontalContentAlignment="Left" />
-            </StackPanel>
+        <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+          <Border Background="#0C3859" BorderBrush="#2E6A8D" BorderThickness="1" CornerRadius="12" Padding="9,4">
+            <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#B9D7E7" FontSize="11" TextTrimming="CharacterEllipsis" MaxWidth="330" />
           </Border>
-
-          <Border Classes="card">
-            <StackPanel Spacing="7">
-              <TextBlock Classes="eyebrow" Text="WORKSPACE ROUTES" />
-              <TextBlock Text="Local source" FontWeight="Bold" />
-              <TextBlock Text="{Binding WorkspacePath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
-              <Border Height="1" Background="#D5E6F0" Margin="0,4" />
-              <TextBlock Text="Shared exchange" FontWeight="Bold" />
-              <TextBlock Text="{Binding SharedSyncPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
-            </StackPanel>
-          </Border>
+          <Button Classes="tool" Content="↻ Refresh" Command="{Binding RefreshWorkspaceCommand}" />
         </StackPanel>
       </Grid>
+    </Border>
 
-      <Border Classes="card">
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
-          <StackPanel Spacing="4">
-            <TextBlock Classes="eyebrow" Text="CURRENT SIGNAL" />
-            <TextBlock Text="{Binding WorkspaceMessage}" TextWrapping="Wrap" />
-            <TextBlock Text="{Binding TrustSummary}" Classes="muted" TextWrapping="Wrap" />
-          </StackPanel>
-          <Button Grid.Column="1" Classes="secondary" Content="Refresh project map" Command="{Binding RefreshWorkspaceCommand}" VerticalAlignment="Center" />
+    <Grid Grid.Row="1" ColumnDefinitions="*,342">
+      <views:BlueprintCanvasSurface x:Name="BlueprintSurface" />
+
+      <Border Grid.Column="1"
+              Background="#F7FBFD"
+              BorderBrush="#9FC5D8"
+              BorderThickness="1,0,0,0">
+        <Grid RowDefinitions="Auto,*,Auto">
+          <Border Background="#E8F3F8" BorderBrush="#B8D5E3" BorderThickness="0,0,0,1" Padding="16,12">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="NODE INSPECTOR" />
+              <TextBlock Text="{Binding InspectorSelectionSummary}" Classes="mono" FontWeight="Bold" FontSize="12" />
+            </StackPanel>
+          </Border>
+
+          <ScrollViewer Grid.Row="1">
+            <StackPanel Margin="16" Spacing="18">
+              <StackPanel Spacing="10">
+                <Grid ColumnDefinitions="*,Auto">
+                  <StackPanel Spacing="2">
+                    <TextBlock Classes="eyebrow" Text="VERSION NODE" />
+                    <TextBlock Text="{Binding SelectedVersion.Name}" FontSize="21" FontWeight="Bold" />
+                  </StackPanel>
+                  <Border Grid.Column="1" Background="#DCEEF7" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding SelectedVersion.Status}" Foreground="#0B4F8A" FontSize="11" FontWeight="Bold" />
+                  </Border>
+                </Grid>
+
+                <TextBox PlaceholderText="Version label"
+                         Text="{Binding VersionEditorName}"
+                         IsEnabled="{Binding CanEditSelectedVersion}" />
+                <ComboBox ItemsSource="{Binding AvailableStatuses}"
+                          SelectedItem="{Binding VersionEditorStatus}"
+                          IsEnabled="{Binding CanEditSelectedVersion}" />
+                <TextBox PlaceholderText="Milestone accomplishment"
+                         Text="{Binding VersionEditorNotes}"
+                         AcceptsReturn="True"
+                         Height="74"
+                         IsEnabled="{Binding CanEditSelectedVersion}" />
+                <Button Classes="secondary"
+                        Content="Apply version changes"
+                        Command="{Binding SaveVersionDetailsCommand}"
+                        IsEnabled="{Binding CanEditSelectedVersion}" />
+              </StackPanel>
+
+              <Border Height="1" Background="#C7DDE8" />
+
+              <StackPanel Spacing="10">
+                <Grid ColumnDefinitions="*,Auto">
+                  <StackPanel Spacing="2">
+                    <TextBlock Classes="eyebrow" Text="CONNECTED WORK ITEM" />
+                    <TextBlock Text="{Binding ItemEditorTitle}" FontSize="17" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
+                  </StackPanel>
+                  <Border Grid.Column="1" Background="#E6F5EF" CornerRadius="10" Padding="8,3" VerticalAlignment="Center" IsVisible="{Binding HasSelectedItem}">
+                    <TextBlock Text="{Binding SelectedItem.ItemKey}" Classes="mono" Foreground="#277A67" FontSize="10" FontWeight="Bold" />
+                  </Border>
+                </Grid>
+
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                  <ComboBox ItemsSource="{Binding AvailableItemTypes}"
+                            SelectedItem="{Binding SelectedItemTypeId}"
+                            IsEnabled="{Binding CanEditItems}" />
+                  <ComboBox Grid.Column="1"
+                            ItemsSource="{Binding AvailableCategories}"
+                            SelectedItem="{Binding SelectedCategoryId}"
+                            IsEnabled="{Binding CanEditItems}" />
+                </Grid>
+                <TextBox PlaceholderText="What changed?"
+                         Text="{Binding ItemEditorTitle}"
+                         IsEnabled="{Binding CanEditItems}" />
+                <TextBox PlaceholderText="Context visible in release notes"
+                         Text="{Binding ItemEditorDescription}"
+                         AcceptsReturn="True"
+                         Height="84"
+                         IsEnabled="{Binding CanEditItems}" />
+                <CheckBox Content="Completed"
+                          IsChecked="{Binding ItemEditorIsDone}"
+                          IsEnabled="{Binding CanEditItems}" />
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                  <Button Classes="primary"
+                          Content="Connect new"
+                          Command="{Binding AddItemCommand}"
+                          IsEnabled="{Binding CanEditItems}" />
+                  <Button Grid.Column="1"
+                          Classes="secondary"
+                          Content="Apply selected"
+                          Command="{Binding SaveItemDetailsCommand}"
+                          IsEnabled="{Binding HasSelectedItem}" />
+                </Grid>
+              </StackPanel>
+            </StackPanel>
+          </ScrollViewer>
+
+          <Border Grid.Row="2" Background="#0A2C47" Padding="14,11">
+            <StackPanel Spacing="4">
+              <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
+              <TextBlock Text="Drag nodes to arrange · Click a node to inspect · Add work to draw a connection"
+                         Foreground="#8FBAD0"
+                         FontSize="10"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
         </Grid>
       </Border>
-    </StackPanel>
-  </ScrollViewer>
+    </Grid>
+  </Grid>
 </UserControl>

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace Blueprints.App.Views.Components;
 
@@ -8,4 +9,13 @@ public partial class OverviewView : UserControl
     {
         InitializeComponent();
     }
+
+    private void ZoomInClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ZoomIn();
+
+    private void ZoomOutClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ZoomOut();
+
+    private void ResetViewClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ResetView();
 }

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -78,106 +78,48 @@
 
     <views:SetupView Grid.Row="1" IsVisible="{Binding IsSetupMode}" />
 
-    <Grid Grid.Row="1" ColumnDefinitions="252,*" IsVisible="{Binding HasActiveSession}">
-      <Border Background="#08233A" BorderBrush="#1C4A6A" BorderThickness="0,0,1,0" Padding="16,18">
-        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16">
-          <Border Classes="dark-card" Padding="13">
-            <StackPanel Spacing="5">
-              <TextBlock Classes="eyebrow" Text="ACTIVE BLUEPRINT" Foreground="#62D3F0" />
-              <TextBlock Text="{Binding CurrentProject.Name}" Foreground="White" FontSize="18" FontWeight="Bold" TextWrapping="Wrap" />
-              <TextBlock Text="{Binding CurrentProject.Code, StringFormat='PROJECT / {0}'}" Classes="mono" Foreground="#8FB5CC" FontSize="11" />
-              <TextBlock Text="{Binding VersioningScheme, StringFormat='SCHEME / {0}'}" Classes="mono" Foreground="#8FB5CC" FontSize="11" />
+    <Grid Grid.Row="1" ColumnDefinitions="74,*" IsVisible="{Binding HasActiveSession}">
+      <Border Background="#061C30" BorderBrush="#285A78" BorderThickness="0,0,1,0">
+        <Grid RowDefinitions="Auto,*,Auto">
+          <Border Margin="10,12" Height="48" Background="#0D4166" BorderBrush="#5CCBE8" BorderThickness="1" CornerRadius="4">
+            <StackPanel VerticalAlignment="Center">
+              <TextBlock Text="{Binding CurrentProject.Code}" Classes="mono" Foreground="White" FontWeight="Black" HorizontalAlignment="Center" />
+              <TextBlock Text="MAP" Classes="mono" Foreground="#6DD6EF" FontSize="8" HorizontalAlignment="Center" />
             </StackPanel>
           </Border>
 
-          <StackPanel Grid.Row="1" Spacing="4">
-            <TextBlock Classes="eyebrow" Text="PROJECT MAP" Foreground="#62D3F0" Margin="10,0,0,5" />
-
-            <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Command="{Binding NavigateToOverviewCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="01" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Overview" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
-            <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Command="{Binding NavigateToReleasesCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="02" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Releases" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
-            <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Command="{Binding NavigateToTeamCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="03" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Team" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
-            <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Command="{Binding NavigateToSyncCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="04" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Sync" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
-            <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Command="{Binding NavigateToTrustCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="05" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Trust" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
-            <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Command="{Binding NavigateToIntegrationsCommand}">
-              <Grid ColumnDefinitions="24,*" ColumnSpacing="10">
-                <TextBlock Text="06" Classes="mono" Foreground="#62D3F0" />
-                <TextBlock Grid.Column="1" Text="Integrations" Foreground="{Binding $parent[Button].Foreground}" />
-              </Grid>
-            </Button>
+          <StackPanel Grid.Row="1" Spacing="7" Margin="8,8">
+            <Button Classes="rail" Classes.active="{Binding IsOverviewSelected}" Content="⌘" ToolTip.Tip="Canvas" Command="{Binding NavigateToOverviewCommand}" />
+            <Button Classes="rail" Classes.active="{Binding IsReleasesSelected}" Content="V" ToolTip.Tip="Versions and releases" Command="{Binding NavigateToReleasesCommand}" />
+            <Button Classes="rail" Classes.active="{Binding IsTeamSelected}" Content="P" ToolTip.Tip="People and identities" Command="{Binding NavigateToTeamCommand}" />
+            <Button Classes="rail" Classes.active="{Binding IsSyncSelected}" Content="⇄" ToolTip.Tip="Sync exchange" Command="{Binding NavigateToSyncCommand}" />
+            <Button Classes="rail" Classes.active="{Binding IsTrustSelected}" Content="◇" ToolTip.Tip="Trust and audit" Command="{Binding NavigateToTrustCommand}" />
+            <Button Classes="rail" Classes.active="{Binding IsIntegrationsSelected}" Content="⌁" ToolTip.Tip="Integrations" Command="{Binding NavigateToIntegrationsCommand}" />
           </StackPanel>
 
-          <Border Grid.Row="2" BorderBrush="#194765" BorderThickness="1,0,0,0" Margin="20,0,0,0" IsHitTestVisible="False" />
-
-          <StackPanel Grid.Row="3" Spacing="8">
-            <Button Classes="secondary compact" Content="↻ Refresh workspace" Command="{Binding RefreshWorkspaceCommand}" HorizontalContentAlignment="Left" />
-            <Button Classes="nav compact" Content="← Switch project" Command="{Binding ReturnToProjectSetupCommand}" HorizontalContentAlignment="Left" />
-            <TextBlock Text="LOCAL-FIRST  /  SIGNED  /  EXPLICIT"
-                       Classes="mono"
-                       Foreground="#527B94"
-                       FontSize="9"
-                       HorizontalAlignment="Center"
-                       Margin="0,8,0,0" />
-          </StackPanel>
+          <Button Grid.Row="2"
+                  Classes="rail"
+                  Content="←"
+                  ToolTip.Tip="Switch project"
+                  Command="{Binding ReturnToProjectSetupCommand}"
+                  Margin="8,0,8,12" />
         </Grid>
       </Border>
 
       <Grid Grid.Column="1" Background="#F2F8FC">
-        <Canvas IsHitTestVisible="False" Opacity="0.45">
-          <shapes:Line StartPoint="0,140" EndPoint="1600,140" Stroke="#D7E8F1" StrokeThickness="1" />
-          <shapes:Line StartPoint="0,420" EndPoint="1600,420" Stroke="#D7E8F1" StrokeThickness="1" />
-          <shapes:Line StartPoint="320,0" EndPoint="320,1000" Stroke="#E0EDF4" StrokeThickness="1" />
-          <shapes:Line StartPoint="860,0" EndPoint="860,1000" Stroke="#E0EDF4" StrokeThickness="1" />
-        </Canvas>
+        <views:OverviewView IsVisible="{Binding IsOverviewSelected}" />
 
-        <Grid Margin="24" RowDefinitions="Auto,*" RowSpacing="16">
+        <Grid IsVisible="{Binding IsDetailsWorkspaceSelected}" Margin="24" RowDefinitions="Auto,*" RowSpacing="16">
           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="18">
             <StackPanel Spacing="4">
-              <TextBlock Classes="eyebrow" Text="{Binding SelectedWorkspaceSection, StringFormat='BLUEPRINT / {0}'}" />
+              <TextBlock Classes="eyebrow" Text="{Binding SelectedWorkspaceSection, StringFormat='TOOLS / {0}'}" />
               <TextBlock Text="{Binding SelectedWorkspaceSectionTitle}" FontSize="28" FontWeight="Black" />
               <TextBlock Text="{Binding SelectedWorkspaceSectionDescription}" Classes="muted" TextWrapping="Wrap" />
             </StackPanel>
-            <Border Grid.Column="1" Classes="blueprint-card" Padding="12,8" VerticalAlignment="Center">
-              <StackPanel Orientation="Horizontal" Spacing="12">
-                <StackPanel Spacing="1">
-                  <TextBlock Classes="eyebrow" Text="MODE" />
-                  <TextBlock Text="{Binding TrustBadge}" FontWeight="Bold" />
-                </StackPanel>
-                <Border Width="1" Background="#BED8E8" />
-                <StackPanel Spacing="1">
-                  <TextBlock Classes="eyebrow" Text="SYNC" />
-                  <TextBlock Text="{Binding Sync.Health}" FontWeight="Bold" />
-                </StackPanel>
-              </StackPanel>
-            </Border>
+            <Button Grid.Column="1" Classes="secondary" Content="Return to canvas" Command="{Binding NavigateToOverviewCommand}" VerticalAlignment="Center" />
           </Grid>
 
           <Grid Grid.Row="1">
-            <views:OverviewView IsVisible="{Binding IsOverviewSelected}" />
             <views:ReleasePlannerView IsVisible="{Binding IsReleasesSelected}" />
             <views:TeamView IsVisible="{Binding IsTeamSelected}" />
             <views:SyncView IsVisible="{Binding IsSyncSelected}" />

--- a/Blueprints.Tests/MainWindowNavigationTests.cs
+++ b/Blueprints.Tests/MainWindowNavigationTests.cs
@@ -42,4 +42,41 @@ public sealed class MainWindowNavigationTests
         viewModel.NavigateToOverviewCommand.Execute(null);
         Assert.True(viewModel.IsOverviewSelected);
     }
+
+    [Fact]
+    public void CanvasNodeSelection_ConnectsInspectorToTheRealWorkspaceObjects()
+    {
+        var viewModel = new MainWindowViewModel();
+        var version = Assert.Single(viewModel.Versions, candidate => candidate.Items.Count > 0);
+        var item = version.Items[0];
+
+        viewModel.SelectItemNodeCommand.Execute(item);
+
+        Assert.Equal(version.VersionId, viewModel.SelectedVersion?.VersionId);
+        Assert.Equal(item.ItemId, viewModel.SelectedItem?.ItemId);
+        Assert.True(viewModel.HasSelectedItem);
+        Assert.Contains(item.ItemKey, viewModel.InspectorSelectionSummary, StringComparison.Ordinal);
+
+        viewModel.SelectVersionNodeCommand.Execute(version);
+
+        Assert.Equal(version.VersionId, viewModel.SelectedVersion?.VersionId);
+        Assert.Null(viewModel.SelectedItem);
+        Assert.False(viewModel.HasSelectedItem);
+        Assert.Equal($"VERSION / {version.Name}", viewModel.InspectorSelectionSummary);
+    }
+
+    [Fact]
+    public void BeginNewItem_ClearsTheInspectorAndKeepsTheSelectedConnectionTarget()
+    {
+        var viewModel = new MainWindowViewModel();
+        var version = Assert.Single(viewModel.Versions, candidate => candidate.Items.Count > 0);
+        viewModel.SelectItemNodeCommand.Execute(version.Items[0]);
+
+        viewModel.BeginNewItemCommand.Execute(null);
+
+        Assert.Equal(version.VersionId, viewModel.SelectedVersion?.VersionId);
+        Assert.Null(viewModel.SelectedItem);
+        Assert.Empty(viewModel.ItemEditorTitle);
+        Assert.Contains(version.Name, viewModel.WorkspaceMessage, StringComparison.Ordinal);
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Blueprints visual identity and application icon.
 - Cross-platform CI, CodeQL, dependency review, milestone automation, PR labels, and community templates.
 - Lightweight milestone-release records generated from the changelog without binary builds.
-- An interactive blueprint-map application shell with focused release, team, sync, trust, and integration workspaces.
+- A diagram-first blueprint canvas with draggable version and work-item nodes, live relationship connectors, zoom controls, and direct node inspection.
 - Native folder pickers for project creation and opening.
 
 ### Changed
 
 - Upgraded the application to .NET 10 LTS, Avalonia 12.1.1, and the latest stable direct dependencies.
-- Reworked the desktop interface into reusable feature views with explicit navigation and clearer action hierarchy.
+- Replaced the dashboard-style overview and wide navigation sidebar with a hands-on canvas, contextual inspector, compact tool rail, and focused secondary workspaces.
 - Made command feedback visible across the active workspace.
 - Clarified local-workspace and shared-exchange terminology.
 - Moved superseded planning and handoff documents into `docs/archive`.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -20,7 +20,8 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Restore a reproducible local build and executable helper scripts.
 - [x] Establish public-project documentation, templates, automation, and visual identity.
 - [x] Move the supported runtime to .NET 10 LTS and Avalonia 12.
-- [x] Split the main window into feature-sized views with project-map navigation.
+- [x] Make the primary workspace a draggable, diagram-first blueprint canvas backed by real version and item relationships.
+- [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
 - [x] Add native folder pickers instead of requiring raw paths.
 - [ ] Add first-run identity setup instead of silently creating a default identity.
 - [ ] Add delete/archive flows for draft versions and items.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # User guide
 
-Blueprints is a desktop application for planning releases in signed local files. Its interface is organized as an interactive project blueprint: the left project map moves between the workspaces responsible for planning, evidence, trust, and exchange.
+Blueprints is a desktop application for planning releases in signed local files. The main workspace is a hands-on blueprint canvas: versions and work items are visible as connected nodes, while a compact tool rail opens evidence, trust, and exchange tools.
 
 ## Concepts
 
@@ -23,25 +23,27 @@ Blueprints creates the first local identity automatically in the current preview
 
 ## Plan a release
 
-1. Select **Releases** on the project map.
-2. Enter a version name in the version index and select **Add**.
-3. Select the version and edit its name, status, and notes.
-4. Select an item type and changelog group, enter a title, then select **Add item**.
-5. Mark completed items as ready for release notes.
+1. Enter a version name in the canvas toolbar and select **Version**.
+2. Select the version node to edit its name, state, and accomplishment notes in the inspector.
+3. Select **Work item**, enter its type, changelog group, title, and context, then select **Connect new**.
+4. Select any work-item node to edit it directly in the inspector.
+5. Drag nodes to arrange the working view, and use zoom or **Fit map** to navigate larger plans.
+6. Mark completed items as ready for release notes.
 
-Item keys are generated from project rules. Released versions are immutable.
+The lines on the canvas represent real project relationships: a work item is connected to the version that owns it. Item keys are generated from project rules. Released versions are immutable.
 
 ## Export a changelog
 
-1. Select a version.
-2. Select **Export notes**.
-3. Review the changelog preview and saved path in the version node.
+1. Select a version node.
+2. Open the **Versions and releases** tool from the rail.
+3. Select **Export notes**.
+4. Review the changelog preview and saved path.
 
 Incomplete items are excluded by the current default rules. When a local Git repository is linked, recent commit subjects and matching item keys are added as source context.
 
 ## Link local Git
 
-1. Open **Integrations**.
+1. Open **Integrations** from the tool rail.
 2. Enter the path to a Git worktree.
 3. Select **Save connection**, then **Refresh all**.
 
@@ -60,7 +62,7 @@ The current conflict preview is low-level. Make a backup before resolving import
 
 ## Trust and read-only mode
 
-Open **Trust** to see signature, audit, shared-folder, and conflict diagnostics.
+Open **Trust** from the tool rail to see signature, audit, shared-folder, and conflict diagnostics.
 
 - **Trusted:** normal editing is allowed.
 - **Untrusted:** one or more signatures did not validate; mutation is disabled.


### PR DESCRIPTION
Promotes the exact tree reviewed and merged in #54 from `develop` to `main`.

The primary workspace is now a hands-on blueprint canvas with draggable version/work-item nodes, real relationship connectors, direct selection and editing, and a compact rail for secondary release, team, sync, trust, and integration tools.

This promotion branch was created from `main` and the verified `develop` squash commit was applied. Its tree is byte-for-byte identical to `origin/develop`.

Validation inherited from #54:

- 51 tests passed
- formatting passed
- Windows, macOS, and Linux builds passed
- CodeQL passed
- dependency audit found no known vulnerabilities