### PR TITLE
Persist and secure the interactive canvas engine

### DIFF
--- a/Blueprints.App/Models/CanvasLayoutEditRequest.cs
+++ b/Blueprints.App/Models/CanvasLayoutEditRequest.cs
@@ -1,0 +1,4 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasLayoutEditRequest(
+    IReadOnlyList<CanvasNodeLayoutEdit> Nodes);

--- a/Blueprints.App/Models/CanvasNodeLayoutEdit.cs
+++ b/Blueprints.App/Models/CanvasNodeLayoutEdit.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasNodeLayoutEdit(
+    string NodeType,
+    Guid EntityId,
+    double X,
+    double Y);

--- a/Blueprints.App/Models/CanvasViewState.cs
+++ b/Blueprints.App/Models/CanvasViewState.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasViewState(
+    double Zoom,
+    double HorizontalOffset,
+    double VerticalOffset)
+{
+    public static CanvasViewState Default { get; } = new(1, 0, 0);
+}

--- a/Blueprints.App/Services/FileSystemCanvasViewStateStore.cs
+++ b/Blueprints.App/Services/FileSystemCanvasViewStateStore.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class FileSystemCanvasViewStateStore
+{
+    private const double MinimumZoom = 0.6;
+    private const double MaximumZoom = 1.5;
+    private const double MaximumOffset = 100_000;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    public CanvasViewState Load(string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+
+        var path = GetPath(workspaceRoot);
+        if (!File.Exists(path))
+        {
+            return CanvasViewState.Default;
+        }
+
+        try
+        {
+            var state = JsonSerializer.Deserialize<CanvasViewState>(
+                File.ReadAllText(path),
+                SerializerOptions);
+            return state is null ? CanvasViewState.Default : Validate(state);
+        }
+        catch (Exception exception) when (exception is JsonException or IOException or InvalidOperationException)
+        {
+            return CanvasViewState.Default;
+        }
+    }
+
+    public void Save(string workspaceRoot, CanvasViewState state)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(state);
+
+        var validated = Validate(state);
+        var path = GetPath(workspaceRoot);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var temporaryPath = path + ".tmp";
+        File.WriteAllText(temporaryPath, JsonSerializer.Serialize(validated, SerializerOptions));
+        File.Move(temporaryPath, path, overwrite: true);
+    }
+
+    private static CanvasViewState Validate(CanvasViewState state)
+    {
+        ValidateRange(state.Zoom, MinimumZoom, MaximumZoom, "Canvas zoom");
+        ValidateRange(state.HorizontalOffset, 0, MaximumOffset, "Canvas horizontal offset");
+        ValidateRange(state.VerticalOffset, 0, MaximumOffset, "Canvas vertical offset");
+        return state;
+    }
+
+    private static void ValidateRange(double value, double minimum, double maximum, string name)
+    {
+        if (!double.IsFinite(value) || value < minimum || value > maximum)
+        {
+            throw new InvalidOperationException($"{name} must be between {minimum} and {maximum}.");
+        }
+    }
+
+    private static string GetPath(string workspaceRoot) =>
+        Path.Combine(workspaceRoot, ".blueprints", "canvas-view.json");
+}

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -275,6 +275,56 @@ public sealed class ProjectWorkspaceCoordinatorService
         }, "item.save", $"Saved item {normalizedTitle}.");
     }
 
+    public LocalWorkspaceSession SaveCanvasLayout(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        CanvasLayoutEditRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+
+        var layout = new CanvasLayoutDocument(
+            CurrentSchemaVersion,
+            workspace.Project.ProjectId,
+            (workspace.CanvasLayout?.Revision ?? 0) + 1,
+            request.Nodes
+                .Select(static node => new CanvasNodePosition(
+                    node.NodeType,
+                    node.EntityId,
+                    node.X,
+                    node.Y))
+                .OrderBy(static node => node.NodeType, StringComparer.Ordinal)
+                .ThenBy(static node => node.EntityId)
+                .ToArray(),
+            DateTimeOffset.UtcNow,
+            identity.Profile.UserId,
+            identity.Profile.DisplayName);
+        CanvasLayoutValidator.Validate(layout, workspace.Project.ProjectId);
+        CanvasLayoutValidator.ValidateEntityReferences(
+            layout,
+            workspace.Project.ProjectId,
+            workspace.Versions.Select(static version => version.Version.VersionId).ToHashSet(),
+            workspace.Versions
+                .SelectMany(static version => version.Items)
+                .Select(static item => item.ItemId)
+                .ToHashSet());
+
+        _workspaceStore.SaveCanvasLayout(localWorkspaceRoot, layout, identity.SigningKey);
+        AppendAuditEntry(
+            localWorkspaceRoot,
+            identity,
+            workspace,
+            "canvas.layout.save",
+            $"Saved canvas layout revision {layout.Revision} with {layout.Nodes.Count} nodes.");
+        return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+    }
+
     public LocalWorkspaceSession ReleaseVersion(
         string localWorkspaceRoot,
         string sharedWorkspaceRoot,

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,7 @@ public partial class MainWindowViewModel : ViewModelBase
 {
     private readonly ProjectWorkspaceCoordinatorService? _coordinatorService;
     private readonly IntegrationStatusService _integrationStatusService;
+    private readonly FileSystemCanvasViewStateStore _canvasViewStateStore;
     private LocalWorkspaceSession? _currentSession;
     private string _title = "Blueprints Setup";
     private ProjectSummary _currentProject = new(string.Empty, string.Empty, TrustState.Corrupt, string.Empty);
@@ -73,6 +74,8 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _localGitRepositoryPath = string.Empty;
     private string _integrationMessage = string.Empty;
     private WorkspaceSection _selectedWorkspaceSection = WorkspaceSection.Overview;
+    private CanvasLayoutDocument? _canvasLayout;
+    private CanvasViewState _canvasViewState = CanvasViewState.Default;
 
     public MainWindowViewModel()
     {
@@ -87,6 +90,7 @@ public partial class MainWindowViewModel : ViewModelBase
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
         _integrationStatusService = new IntegrationStatusService();
+        _canvasViewStateStore = new FileSystemCanvasViewStateStore();
         ApplyDesignSession(CreateDesignSession());
         RefreshIntegrations();
     }
@@ -97,6 +101,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         _coordinatorService = coordinatorService;
         _integrationStatusService = integrationStatusService;
+        _canvasViewStateStore = new FileSystemCanvasViewStateStore();
         Versions = new ObservableCollection<WorkspaceVersionCard>();
         AvailableItemTypes = new ObservableCollection<string>();
         AvailableCategories = new ObservableCollection<string>();
@@ -144,6 +149,29 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         get => _integrationMessage;
         private set => SetProperty(ref _integrationMessage, value);
+    }
+
+    public CanvasLayoutDocument? CanvasLayout
+    {
+        get => _canvasLayout;
+        private set
+        {
+            if (SetProperty(ref _canvasLayout, value))
+            {
+                OnPropertyChanged(nameof(CanvasLayoutRevisionSummary));
+            }
+        }
+    }
+
+    public string CanvasLayoutRevisionSummary =>
+        CanvasLayout is null
+            ? "Layout has not been saved yet"
+            : $"Shared layout revision {CanvasLayout.Revision}";
+
+    public CanvasViewState CanvasViewState
+    {
+        get => _canvasViewState;
+        private set => SetProperty(ref _canvasViewState, value);
     }
 
     public string Title
@@ -775,6 +803,43 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void SaveCanvasLayout(CanvasLayoutEditRequest? request)
+    {
+        if (_coordinatorService is null || _currentSession is null || request is null)
+        {
+            return;
+        }
+
+        try
+        {
+            ApplySession(
+                _coordinatorService.SaveCanvasLayout(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    request));
+            WorkspaceMessage = CanvasLayout is null
+                ? "Canvas layout saved."
+                : $"Canvas layout revision {CanvasLayout.Revision} saved.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void SaveCanvasViewState(CanvasViewState? state)
+    {
+        if (state is null || string.IsNullOrWhiteSpace(WorkspacePath))
+        {
+            return;
+        }
+
+        _canvasViewStateStore.Save(WorkspacePath, state);
+        CanvasViewState = state;
+    }
+
+    [RelayCommand]
     private void CreateProject()
     {
         if (_coordinatorService is null)
@@ -1230,7 +1295,8 @@ public partial class MainWindowViewModel : ViewModelBase
             project.Name,
             project.ProjectCode,
             session.LoadResult.TrustReport.State,
-            session.Paths.SharedProjectRoot);
+            session.Paths.SharedProjectRoot,
+            project.ProjectId);
 
         Identity = new IdentitySummary(
             session.Identity.Profile.DisplayName,
@@ -1299,12 +1365,14 @@ public partial class MainWindowViewModel : ViewModelBase
         Title = $"{project.Name} ({project.ProjectCode})";
         TrustSummary = session.LoadResult.TrustReport.Summary;
         WorkspacePath = session.Paths.LocalWorkspaceRoot;
+        CanvasViewState = _canvasViewStateStore.Load(session.Paths.LocalWorkspaceRoot);
         SharedSyncPath = session.Paths.SharedProjectRoot;
         VersioningScheme = project.VersioningScheme;
         VersionCount = workspace.Versions.Count;
         ItemCount = workspace.Versions.Sum(static version => version.Items.Count);
         ActiveMemberCount = workspace.Members.Members.Count(static member => member.IsActive);
         MembershipRevision = workspace.Members.MembershipRevision;
+        CanvasLayout = workspace.CanvasLayout;
         Sync = session.Sync;
         HasActiveSession = true;
         WorkspaceMessage = string.Empty;
@@ -1365,12 +1433,14 @@ public partial class MainWindowViewModel : ViewModelBase
         CurrentProject = new ProjectSummary(string.Empty, string.Empty, TrustState.Corrupt, string.Empty);
         TrustSummary = message;
         WorkspacePath = string.Empty;
+        CanvasViewState = Blueprints.App.Models.CanvasViewState.Default;
         SharedSyncPath = string.Empty;
         VersioningScheme = string.Empty;
         VersionCount = 0;
         ItemCount = 0;
         ActiveMemberCount = 0;
         MembershipRevision = 0;
+        CanvasLayout = null;
         Sync = new SyncSummary(SyncHealth.Idle, 0, 0, 0);
         Versions.Clear();
         AvailableItemTypes.Clear();

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="Blueprints.App.Views.Components.BlueprintCanvasSurface">
+             x:Class="Blueprints.App.Views.Components.BlueprintCanvasSurface"
+             Focusable="True">
   <Border Background="#072A46"
           BorderBrush="#2C6E96"
           BorderThickness="1"

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Blueprints.App.Models;
 using Blueprints.App.ViewModels;
 
@@ -23,33 +24,64 @@ public partial class BlueprintCanvasSurface : UserControl
     private Control? _draggedNode;
     private Point _dragOffset;
     private double _zoom = 1;
+    private bool _isRestoringLayout;
+    private readonly DispatcherTimer _viewportSaveTimer;
+    private bool _isPanning;
+    private Point _panStart;
+    private Vector _panOrigin;
 
     public BlueprintCanvasSurface()
     {
         InitializeComponent();
+        _viewportSaveTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(650),
+        };
+        _viewportSaveTimer.Tick += HandleViewportSaveTimerTick;
+        Viewport.ScrollChanged += HandleViewportScrollChanged;
+        Surface.PointerPressed += HandleSurfacePointerPressed;
+        Surface.PointerMoved += HandleSurfacePointerMoved;
+        Surface.PointerReleased += HandleSurfacePointerReleased;
+        Surface.PointerWheelChanged += HandleSurfacePointerWheelChanged;
+        KeyDown += HandleKeyDown;
         DataContextChanged += HandleDataContextChanged;
         DetachedFromVisualTree += (_, _) => DetachViewModel();
     }
 
-    public void ZoomIn() => SetZoom(_zoom + 0.1);
+    public void ZoomIn() => SetZoom(_zoom + 0.1, persist: true);
 
-    public void ZoomOut() => SetZoom(_zoom - 0.1);
+    public void ZoomOut() => SetZoom(_zoom - 0.1, persist: true);
 
-    public void ResetView()
+    public void FitView()
+    {
+        SetZoom(0.8);
+        Viewport.Offset = Vector.Zero;
+        PersistViewState();
+    }
+
+    public void AutoArrange()
     {
         _positions.Clear();
         SetZoom(1);
         RenderGraph();
         Viewport.Offset = Vector.Zero;
+        PersistLayout();
+        PersistViewState();
     }
 
-    private void SetZoom(double value)
+    public void SaveLayout() => PersistLayout();
+
+    private void SetZoom(double value, bool persist = false)
     {
         _zoom = Math.Clamp(value, 0.6, 1.5);
         ZoomHost.Width = Surface.Width * _zoom;
         ZoomHost.Height = Surface.Height * _zoom;
         Surface.RenderTransform = new ScaleTransform(_zoom, _zoom);
         Surface.RenderTransformOrigin = RelativePoint.TopLeft;
+        if (persist)
+        {
+            PersistViewState();
+        }
     }
 
     private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
@@ -62,7 +94,9 @@ public partial class BlueprintCanvasSurface : UserControl
             _viewModel.Versions.CollectionChanged += HandleVersionsChanged;
         }
 
+        RestoreLayout();
         RenderGraph();
+        RestoreViewState();
     }
 
     private void DetachViewModel()
@@ -77,8 +111,15 @@ public partial class BlueprintCanvasSurface : UserControl
         _viewModel = null;
     }
 
-    private void HandleVersionsChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs) =>
+    private void HandleVersionsChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
+    {
+        _viewportSaveTimer.Stop();
+        _isRestoringLayout = true;
         RenderGraph();
+        Dispatcher.UIThread.Post(
+            () => _isRestoringLayout = false,
+            DispatcherPriority.Loaded);
+    }
 
     private void HandleViewModelPropertyChanged(object? sender, PropertyChangedEventArgs eventArgs)
     {
@@ -86,6 +127,15 @@ public partial class BlueprintCanvasSurface : UserControl
             or nameof(MainWindowViewModel.SelectedItem))
         {
             UpdateSelectionVisuals();
+        }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasLayout))
+        {
+            RestoreLayout();
+            RenderGraph();
+        }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasViewState))
+        {
+            RestoreViewState();
         }
         else if (eventArgs.PropertyName is nameof(MainWindowViewModel.VersionCount)
             or nameof(MainWindowViewModel.ItemCount))
@@ -146,7 +196,9 @@ public partial class BlueprintCanvasSurface : UserControl
         SetZoom(_zoom);
 
         var projectNode = CreateProjectNode();
-        var projectPoint = new Point(48, Math.Max(310, Surface.Height / 2 - 70));
+        var projectPoint = GetPosition(
+            _viewModel.CurrentProject.ProjectId,
+            new Point(48, Math.Max(310, Surface.Height / 2 - 70)));
         Place(projectNode, projectPoint);
         Surface.Children.Add(projectNode);
 
@@ -248,7 +300,20 @@ public partial class BlueprintCanvasSurface : UserControl
             $"{_viewModel?.VersionCount ?? 0} versions  ·  {_viewModel?.ItemCount ?? 0} items",
             "#A7CEE0"));
 
-        return CreateNodeShell(content, 250, 140, "#0A2035", "#65D2EF", "project", null);
+        var node = CreateNodeShell(
+            content,
+            250,
+            140,
+            "#0A2035",
+            "#65D2EF",
+            "project",
+            _viewModel?.CurrentProject.ProjectId);
+        if (_viewModel?.CurrentProject.ProjectId is Guid projectId && projectId != Guid.Empty)
+        {
+            AddDragHandlers(node, projectId);
+        }
+
+        return node;
     }
 
     private Control CreateVersionNode(WorkspaceVersionCard version)
@@ -390,8 +455,203 @@ public partial class BlueprintCanvasSurface : UserControl
             {
                 _draggedNode = null;
                 eventArgs.Pointer.Capture(null);
+                PersistLayout();
             }
         };
+    }
+
+    private void RestoreLayout()
+    {
+        _viewportSaveTimer.Stop();
+        _isRestoringLayout = true;
+        if (_viewModel?.CanvasLayout is not { } layout)
+        {
+            _positions.Clear();
+            Dispatcher.UIThread.Post(
+                () => _isRestoringLayout = false,
+                DispatcherPriority.Loaded);
+            return;
+        }
+
+        _positions.Clear();
+        foreach (var node in layout.Nodes)
+        {
+            _positions[node.EntityId] = new Point(node.X, node.Y);
+        }
+
+        Dispatcher.UIThread.Post(
+            () => _isRestoringLayout = false,
+            DispatcherPriority.Loaded);
+    }
+
+    private void RestoreViewState()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _viewportSaveTimer.Stop();
+        _isRestoringLayout = true;
+        SetZoom(_viewModel.CanvasViewState.Zoom);
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                Viewport.Offset = new Vector(
+                    _viewModel.CanvasViewState.HorizontalOffset,
+                    _viewModel.CanvasViewState.VerticalOffset);
+                _isRestoringLayout = false;
+            },
+            DispatcherPriority.Loaded);
+    }
+
+    private void HandleViewportScrollChanged(object? sender, ScrollChangedEventArgs eventArgs)
+    {
+        if (_isRestoringLayout || _viewModel is null)
+        {
+            return;
+        }
+
+        _viewportSaveTimer.Stop();
+        _viewportSaveTimer.Start();
+    }
+
+    private void HandleViewportSaveTimerTick(object? sender, EventArgs eventArgs)
+    {
+        _viewportSaveTimer.Stop();
+        PersistViewState();
+    }
+
+    private void HandleSurfacePointerPressed(object? sender, PointerPressedEventArgs eventArgs)
+    {
+        if (!eventArgs.GetCurrentPoint(Surface).Properties.IsMiddleButtonPressed)
+        {
+            Focus();
+            return;
+        }
+
+        _isPanning = true;
+        _panStart = eventArgs.GetPosition(Viewport);
+        _panOrigin = Viewport.Offset;
+        Surface.Cursor = new Cursor(StandardCursorType.SizeAll);
+        eventArgs.Pointer.Capture(Surface);
+        eventArgs.Handled = true;
+    }
+
+    private void HandleSurfacePointerMoved(object? sender, PointerEventArgs eventArgs)
+    {
+        if (!_isPanning)
+        {
+            return;
+        }
+
+        var current = eventArgs.GetPosition(Viewport);
+        var delta = current - _panStart;
+        Viewport.Offset = new Vector(
+            Math.Max(0, _panOrigin.X - delta.X),
+            Math.Max(0, _panOrigin.Y - delta.Y));
+        eventArgs.Handled = true;
+    }
+
+    private void HandleSurfacePointerReleased(object? sender, PointerReleasedEventArgs eventArgs)
+    {
+        if (!_isPanning)
+        {
+            return;
+        }
+
+        _isPanning = false;
+        Surface.Cursor = Cursor.Default;
+        eventArgs.Pointer.Capture(null);
+        PersistViewState();
+        eventArgs.Handled = true;
+    }
+
+    private void HandleSurfacePointerWheelChanged(object? sender, PointerWheelEventArgs eventArgs)
+    {
+        if (!eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            return;
+        }
+
+        SetZoom(_zoom + Math.Sign(eventArgs.Delta.Y) * 0.1, persist: true);
+        eventArgs.Handled = true;
+    }
+
+    private void HandleKeyDown(object? sender, KeyEventArgs eventArgs)
+    {
+        var control = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control);
+        if (control && eventArgs.Key == Key.S)
+        {
+            SaveLayout();
+        }
+        else if (control && eventArgs.Key == Key.D0)
+        {
+            FitView();
+        }
+        else if (control && eventArgs.Key is Key.Add or Key.OemPlus)
+        {
+            ZoomIn();
+        }
+        else if (control && eventArgs.Key is Key.Subtract or Key.OemMinus)
+        {
+            ZoomOut();
+        }
+        else
+        {
+            return;
+        }
+
+        eventArgs.Handled = true;
+    }
+
+    private void PersistLayout()
+    {
+        if (_isRestoringLayout || _viewModel?.CanMutateWorkspace != true)
+        {
+            return;
+        }
+
+        var nodes = new List<CanvasNodeLayoutEdit>();
+        AddLayoutNode(nodes, "project", _viewModel.CurrentProject.ProjectId);
+        foreach (var version in _viewModel.Versions)
+        {
+            AddLayoutNode(nodes, "version", version.VersionId);
+            foreach (var item in version.Items)
+            {
+                AddLayoutNode(nodes, "item", item.ItemId);
+            }
+        }
+
+        _viewModel.SaveCanvasLayoutCommand.Execute(
+            new CanvasLayoutEditRequest(nodes));
+    }
+
+    private void PersistViewState()
+    {
+        if (_isRestoringLayout || _viewModel is null)
+        {
+            return;
+        }
+
+        _viewModel.SaveCanvasViewStateCommand.Execute(
+            new CanvasViewState(
+                _zoom,
+                Math.Max(0, Viewport.Offset.X),
+                Math.Max(0, Viewport.Offset.Y)));
+    }
+
+    private void AddLayoutNode(
+        ICollection<CanvasNodeLayoutEdit> nodes,
+        string nodeType,
+        Guid entityId)
+    {
+        if (entityId == Guid.Empty || !_positions.TryGetValue(entityId, out var point))
+        {
+            return;
+        }
+
+        nodes.Add(new CanvasNodeLayoutEdit(nodeType, entityId, point.X, point.Y));
     }
 
     private void AddConnection(Control source, Control target, string color, double thickness)

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -25,7 +25,9 @@
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
           <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" />
           <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" />
-          <Button Classes="tool" Content="Fit map" Click="ResetViewClick" />
+          <Button Classes="tool" Content="Fit view" Click="FitViewClick" />
+          <Button Classes="tool" Content="Auto arrange" Click="AutoArrangeClick" IsEnabled="{Binding CanMutateWorkspace}" />
+          <Button Classes="tool" Content="Save layout" Click="SaveLayoutClick" IsEnabled="{Binding CanMutateWorkspace}" />
         </StackPanel>
 
         <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -133,7 +135,8 @@
           <Border Grid.Row="2" Background="#0A2C47" Padding="14,11">
             <StackPanel Spacing="4">
               <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
-              <TextBlock Text="Drag nodes to arrange · Click a node to inspect · Add work to draw a connection"
+              <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#6DD6EF" FontSize="10" />
+              <TextBlock Text="Drag nodes · Middle-drag to pan · Ctrl+wheel to zoom · Ctrl+S to save layout"
                          Foreground="#8FBAD0"
                          FontSize="10"
                          TextWrapping="Wrap" />

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -16,6 +16,12 @@ public partial class OverviewView : UserControl
     private void ZoomOutClick(object? sender, RoutedEventArgs eventArgs) =>
         BlueprintSurface.ZoomOut();
 
-    private void ResetViewClick(object? sender, RoutedEventArgs eventArgs) =>
-        BlueprintSurface.ResetView();
+    private void FitViewClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.FitView();
+
+    private void AutoArrangeClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.AutoArrange();
+
+    private void SaveLayoutClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.SaveLayout();
 }

--- a/Blueprints.Core/Models/CanvasLayoutDocument.cs
+++ b/Blueprints.Core/Models/CanvasLayoutDocument.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.Core.Models;
+
+public sealed record CanvasLayoutDocument(
+    int SchemaVersion,
+    Guid ProjectId,
+    int Revision,
+    IReadOnlyList<CanvasNodePosition> Nodes,
+    DateTimeOffset UpdatedUtc,
+    Guid LastModifiedByUserId,
+    string LastModifiedByName);

--- a/Blueprints.Core/Models/CanvasNodePosition.cs
+++ b/Blueprints.Core/Models/CanvasNodePosition.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.Core.Models;
+
+public sealed record CanvasNodePosition(
+    string NodeType,
+    Guid EntityId,
+    double X,
+    double Y);

--- a/Blueprints.Core/Models/ProjectSummary.cs
+++ b/Blueprints.Core/Models/ProjectSummary.cs
@@ -6,4 +6,5 @@ public sealed record ProjectSummary(
     string Name,
     string Code,
     TrustState TrustState,
-    string SharedFolderPath);
+    string SharedFolderPath,
+    Guid ProjectId = default);

--- a/Blueprints.Core/Services/CanvasLayoutValidator.cs
+++ b/Blueprints.Core/Services/CanvasLayoutValidator.cs
@@ -1,0 +1,99 @@
+using Blueprints.Core.Models;
+
+namespace Blueprints.Core.Services;
+
+public static class CanvasLayoutValidator
+{
+    public const double MaximumCoordinate = 100_000;
+    public const int MaximumNodeCount = 10_000;
+
+    private static readonly HashSet<string> SupportedNodeTypes =
+        new(StringComparer.Ordinal)
+        {
+            "project",
+            "version",
+            "item",
+        };
+
+    public static void Validate(CanvasLayoutDocument layout, Guid expectedProjectId)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+
+        if (layout.SchemaVersion != 1)
+        {
+            throw new InvalidOperationException($"Canvas layout schema {layout.SchemaVersion} is not supported.");
+        }
+
+        if (layout.ProjectId == Guid.Empty || layout.ProjectId != expectedProjectId)
+        {
+            throw new InvalidOperationException("Canvas layout project identity does not match the workspace.");
+        }
+
+        if (layout.Revision < 1)
+        {
+            throw new InvalidOperationException("Canvas layout revision must be at least 1.");
+        }
+
+        if (layout.Nodes.Count > MaximumNodeCount)
+        {
+            throw new InvalidOperationException($"Canvas layout cannot contain more than {MaximumNodeCount} nodes.");
+        }
+
+        var identities = new HashSet<(string NodeType, Guid EntityId)>();
+        foreach (var node in layout.Nodes)
+        {
+            if (!SupportedNodeTypes.Contains(node.NodeType))
+            {
+                throw new InvalidOperationException($"Canvas node type '{node.NodeType}' is not supported.");
+            }
+
+            if (node.EntityId == Guid.Empty)
+            {
+                throw new InvalidOperationException("Canvas nodes require a non-empty entity ID.");
+            }
+
+            if (!identities.Add((node.NodeType, node.EntityId)))
+            {
+                throw new InvalidOperationException($"Canvas node '{node.NodeType}/{node.EntityId}' is duplicated.");
+            }
+
+            ValidateFiniteRange(node.X, 0, MaximumCoordinate, "Canvas node X coordinate");
+            ValidateFiniteRange(node.Y, 0, MaximumCoordinate, "Canvas node Y coordinate");
+        }
+    }
+
+    public static void ValidateEntityReferences(
+        CanvasLayoutDocument layout,
+        Guid projectId,
+        IReadOnlySet<Guid> versionIds,
+        IReadOnlySet<Guid> itemIds)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        ArgumentNullException.ThrowIfNull(versionIds);
+        ArgumentNullException.ThrowIfNull(itemIds);
+
+        foreach (var node in layout.Nodes)
+        {
+            var exists = node.NodeType switch
+            {
+                "project" => node.EntityId == projectId,
+                "version" => versionIds.Contains(node.EntityId),
+                "item" => itemIds.Contains(node.EntityId),
+                _ => false,
+            };
+            if (!exists)
+            {
+                throw new InvalidOperationException(
+                    $"Canvas node '{node.NodeType}/{node.EntityId}' does not reference an entity in this workspace.");
+            }
+        }
+    }
+
+    private static void ValidateFiniteRange(double value, double minimum, double maximum, string name)
+    {
+        if (!double.IsFinite(value) || value < minimum || value > maximum)
+        {
+            throw new InvalidOperationException($"{name} must be between {minimum} and {maximum}.");
+        }
+    }
+}

--- a/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
@@ -1,3 +1,4 @@
+using Blueprints.Core.Models;
 using Blueprints.Security.Models;
 using Blueprints.Storage.Models;
 
@@ -13,4 +14,9 @@ public interface IProjectWorkspaceStore
     ProjectWorkspaceLoadResult Load(
         string workspaceRoot,
         SignaturePublicKey publicKey);
+
+    void SaveCanvasLayout(
+        string workspaceRoot,
+        CanvasLayoutDocument layout,
+        SignatureKeyMaterial signingKey);
 }

--- a/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
+++ b/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
@@ -5,4 +5,5 @@ namespace Blueprints.Storage.Models;
 public sealed record ProjectWorkspaceSnapshot(
     ProjectConfigurationDocument Project,
     MemberDocument Members,
-    IReadOnlyList<VersionWorkspaceSnapshot> Versions);
+    IReadOnlyList<VersionWorkspaceSnapshot> Versions,
+    CanvasLayoutDocument? CanvasLayout = null);

--- a/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
@@ -1,5 +1,6 @@
 using Blueprints.Core.Enums;
 using Blueprints.Core.Models;
+using Blueprints.Core.Services;
 using Blueprints.Security.Models;
 using Blueprints.Storage.Abstractions;
 using Blueprints.Storage.Models;
@@ -34,6 +35,23 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
             var allSignaturesValid = projectResult.IsSignatureValid && membersResult.IsSignatureValid;
             var totalDocuments = 2;
             var invalidSignatures = allSignaturesValid ? 0 : CountInvalid(projectResult.IsSignatureValid, membersResult.IsSignatureValid);
+            CanvasLayoutDocument? canvasLayout = null;
+
+            var canvasLayoutPath = GetCanvasLayoutDocumentPath(workspaceRoot);
+            if (File.Exists(canvasLayoutPath))
+            {
+                var canvasLayoutResult = _signedDocumentStore.Read<CanvasLayoutDocument>(
+                    canvasLayoutPath,
+                    publicKey);
+                CanvasLayoutValidator.Validate(canvasLayoutResult.Document, projectResult.Document.ProjectId);
+                canvasLayout = canvasLayoutResult.Document;
+                totalDocuments++;
+                if (!canvasLayoutResult.IsSignatureValid)
+                {
+                    invalidSignatures++;
+                    allSignaturesValid = false;
+                }
+            }
 
             var versionsRoot = GetVersionsRoot(workspaceRoot);
             if (Directory.Exists(versionsRoot))
@@ -73,13 +91,25 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                 }
             }
 
+            if (canvasLayout is not null)
+            {
+                CanvasLayoutValidator.ValidateEntityReferences(
+                    canvasLayout,
+                    projectResult.Document.ProjectId,
+                    versionSnapshots.Select(static version => version.Version.VersionId).ToHashSet(),
+                    versionSnapshots
+                        .SelectMany(static version => version.Items)
+                        .Select(static item => item.ItemId)
+                        .ToHashSet());
+            }
+
             var trustState = allSignaturesValid ? TrustState.Trusted : TrustState.Untrusted;
             var summary = allSignaturesValid
                 ? $"Validated {totalDocuments} signed documents."
                 : $"Validated {totalDocuments} signed documents with {invalidSignatures} invalid signatures.";
 
             return new ProjectWorkspaceLoadResult(
-                new ProjectWorkspaceSnapshot(projectResult.Document, membersResult.Document, versionSnapshots),
+                new ProjectWorkspaceSnapshot(projectResult.Document, membersResult.Document, versionSnapshots, canvasLayout),
                 new TrustReport(trustState, summary, DateTimeOffset.UtcNow));
         }
         catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException or InvalidOperationException)
@@ -113,6 +143,10 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
             GetMembersDocumentPath(workspaceRoot),
             workspace.Members,
             signingKey);
+        if (workspace.CanvasLayout is not null)
+        {
+            SaveCanvasLayout(workspaceRoot, workspace.CanvasLayout, signingKey);
+        }
 
         foreach (var versionSnapshot in workspace.Versions)
         {
@@ -133,6 +167,21 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                     signingKey);
             }
         }
+    }
+
+    public void SaveCanvasLayout(
+        string workspaceRoot,
+        CanvasLayoutDocument layout,
+        SignatureKeyMaterial signingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(layout);
+
+        CanvasLayoutValidator.Validate(layout, layout.ProjectId);
+        _signedDocumentStore.Write(
+            GetCanvasLayoutDocumentPath(workspaceRoot),
+            layout,
+            signingKey);
     }
 
     private static ProjectWorkspaceSnapshot EmptyWorkspace() =>
@@ -165,6 +214,9 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
 
     private static string GetMembersDocumentPath(string workspaceRoot) =>
         Path.Combine(GetProjectRoot(workspaceRoot), "members.json");
+
+    private static string GetCanvasLayoutDocumentPath(string workspaceRoot) =>
+        Path.Combine(GetProjectRoot(workspaceRoot), "canvas-layout.json");
 
     private static string GetVersionDirectory(string workspaceRoot, Guid versionId) =>
         Path.Combine(GetVersionsRoot(workspaceRoot), versionId.ToString("N"));

--- a/Blueprints.Tests/CanvasLayoutValidatorTests.cs
+++ b/Blueprints.Tests/CanvasLayoutValidatorTests.cs
@@ -1,0 +1,79 @@
+using Blueprints.Core.Models;
+using Blueprints.Core.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class CanvasLayoutValidatorTests
+{
+    [Fact]
+    public void Validate_AcceptsFiniteUniqueWorkspaceNodes()
+    {
+        var projectId = Guid.NewGuid();
+        var layout = CreateLayout(
+            projectId,
+            [
+                new CanvasNodePosition("project", projectId, 20, 30),
+                new CanvasNodePosition("version", Guid.NewGuid(), 400, 120),
+                new CanvasNodePosition("item", Guid.NewGuid(), 760, 180),
+            ]);
+
+        CanvasLayoutValidator.Validate(layout, projectId);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateNodeIdentity()
+    {
+        var projectId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var layout = CreateLayout(
+            projectId,
+            [
+                new CanvasNodePosition("version", versionId, 100, 100),
+                new CanvasNodePosition("version", versionId, 200, 200),
+            ]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => CanvasLayoutValidator.Validate(layout, projectId));
+
+        Assert.Contains("duplicated", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(-1)]
+    [InlineData(100_001)]
+    public void Validate_RejectsUnsafeCoordinates(double coordinate)
+    {
+        var projectId = Guid.NewGuid();
+        var layout = CreateLayout(
+            projectId,
+            [new CanvasNodePosition("project", projectId, coordinate, 100)]);
+
+        Assert.Throws<InvalidOperationException>(
+            () => CanvasLayoutValidator.Validate(layout, projectId));
+    }
+
+    [Fact]
+    public void Validate_RejectsAnotherWorkspaceIdentity()
+    {
+        var layout = CreateLayout(Guid.NewGuid(), []);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => CanvasLayoutValidator.Validate(layout, Guid.NewGuid()));
+
+        Assert.Contains("does not match", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CanvasLayoutDocument CreateLayout(
+        Guid projectId,
+        IReadOnlyList<CanvasNodePosition> nodes) =>
+        new(
+            1,
+            projectId,
+            1,
+            nodes,
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Test User");
+}

--- a/Blueprints.Tests/FileSystemCanvasViewStateStoreTests.cs
+++ b/Blueprints.Tests/FileSystemCanvasViewStateStoreTests.cs
@@ -1,0 +1,65 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemCanvasViewStateStoreTests : IDisposable
+{
+    private readonly string _workspaceRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "CanvasViewState",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Load_ReturnsDefault_WhenLocalStateDoesNotExist()
+    {
+        var store = new FileSystemCanvasViewStateStore();
+
+        var state = store.Load(_workspaceRoot);
+
+        Assert.Equal(CanvasViewState.Default, state);
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTripsMachineLocalViewport()
+    {
+        var store = new FileSystemCanvasViewStateStore();
+        var expected = new CanvasViewState(0.8, 125, 240);
+
+        store.Save(_workspaceRoot, expected);
+        var actual = store.Load(_workspaceRoot);
+
+        Assert.Equal(expected, actual);
+        Assert.True(File.Exists(Path.Combine(_workspaceRoot, ".blueprints", "canvas-view.json")));
+    }
+
+    [Fact]
+    public void Load_FallsBackToDefault_WhenLocalStateIsMalformed()
+    {
+        var path = Path.Combine(_workspaceRoot, ".blueprints", "canvas-view.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, """{"zoom":999,"horizontalOffset":0,"verticalOffset":0}""");
+
+        var state = new FileSystemCanvasViewStateStore().Load(_workspaceRoot);
+
+        Assert.Equal(CanvasViewState.Default, state);
+    }
+
+    [Fact]
+    public void Save_RejectsNonFiniteViewportValues()
+    {
+        var store = new FileSystemCanvasViewStateStore();
+
+        Assert.Throws<InvalidOperationException>(
+            () => store.Save(_workspaceRoot, new CanvasViewState(double.NaN, 0, 0)));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workspaceRoot))
+        {
+            Directory.Delete(_workspaceRoot, recursive: true);
+        }
+    }
+}

--- a/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
+++ b/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
@@ -70,6 +70,121 @@ public sealed class FileSystemProjectWorkspaceStoreTests : IDisposable
         Assert.Equal(TrustState.Untrusted, result.TrustReport.State);
     }
 
+    [Fact]
+    public void SaveAndLoad_RoundTripsOptionalSignedCanvasLayout()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = CreateWorkspaceSnapshot();
+        var projectId = workspace.Project.ProjectId;
+        var layout = new CanvasLayoutDocument(
+            1,
+            projectId,
+            3,
+            [new CanvasNodePosition("project", projectId, 80, 320)],
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Layout Author");
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace with { CanvasLayout = layout },
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Trusted, result.TrustReport.State);
+        var loadedLayout = Assert.IsType<CanvasLayoutDocument>(result.Workspace.CanvasLayout);
+        Assert.Equal(layout.SchemaVersion, loadedLayout.SchemaVersion);
+        Assert.Equal(layout.ProjectId, loadedLayout.ProjectId);
+        Assert.Equal(layout.Revision, loadedLayout.Revision);
+        Assert.Equal(layout.Nodes, loadedLayout.Nodes);
+        Assert.Equal(layout.UpdatedUtc, loadedLayout.UpdatedUtc);
+        Assert.Equal(layout.LastModifiedByUserId, loadedLayout.LastModifiedByUserId);
+        Assert.Equal(layout.LastModifiedByName, loadedLayout.LastModifiedByName);
+        Assert.True(File.Exists(Path.Combine(_workspaceRoot, "project", "canvas-layout.sig")));
+    }
+
+    [Fact]
+    public void Load_ReturnsUntrusted_WhenCanvasLayoutSignatureIsTampered()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = CreateWorkspaceSnapshot();
+        var projectId = workspace.Project.ProjectId;
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace with
+            {
+                CanvasLayout = new CanvasLayoutDocument(
+                    1,
+                    projectId,
+                    1,
+                    [new CanvasNodePosition("project", projectId, 80, 320)],
+                    DateTimeOffset.UtcNow,
+                    Guid.NewGuid(),
+                    "Layout Author"),
+            },
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        File.AppendAllText(Path.Combine(_workspaceRoot, "project", "canvas-layout.json"), " ");
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Untrusted, result.TrustReport.State);
+    }
+
+    [Fact]
+    public void Load_ReturnsCorrupt_WhenValidlySignedCanvasLayoutReferencesUnknownEntity()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = CreateWorkspaceSnapshot();
+        var projectId = workspace.Project.ProjectId;
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace with
+            {
+                CanvasLayout = new CanvasLayoutDocument(
+                    1,
+                    projectId,
+                    1,
+                    [new CanvasNodePosition("item", Guid.NewGuid(), 100, 100)],
+                    DateTimeOffset.UtcNow,
+                    Guid.NewGuid(),
+                    "Layout Author"),
+            },
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Corrupt, result.TrustReport.State);
+        Assert.Contains("does not reference", result.TrustReport.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_workspaceRoot))

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -4,6 +4,7 @@ using Blueprints.App.Models;
 using Blueprints.App.Services;
 using Blueprints.Collaboration.Models;
 using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
 using Blueprints.Security.Abstractions;
 using Blueprints.Security.Services;
 using Blueprints.Storage.Services;
@@ -90,14 +91,14 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         var sharedRoot = Path.Combine(_rootDirectory, "audit-tamper-shared", "BP");
         var service = CreateService();
 
-        service.CreateProject(
+        var created = service.CreateProject(
             new ProjectCreateRequest(
                 "Blueprints",
                 "BP",
                 "SemVer",
                 localRoot,
                 sharedRoot));
-        service.SaveVersion(
+        var versionSession = service.SaveVersion(
             localRoot,
             sharedRoot,
             new VersionEditRequest(
@@ -105,6 +106,22 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
                 "1.0.0",
                 ReleaseStatus.InProgress,
                 "Baseline"));
+        service.SaveCanvasLayout(
+            localRoot,
+            sharedRoot,
+            new CanvasLayoutEditRequest(
+                [
+                    new CanvasNodeLayoutEdit(
+                        "project",
+                        created.LoadResult.Workspace.Project.ProjectId,
+                        50,
+                        300),
+                    new CanvasNodeLayoutEdit(
+                        "version",
+                        versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId,
+                        400,
+                        100),
+                ]));
 
         File.Delete(FindGenesisAuditEntry(Path.Combine(localRoot, "log")));
 
@@ -210,12 +227,49 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
     }
 
     [Fact]
-    public void PushWorkspace_PublishesLocalChangesAndRefreshesSyncState()
+    public void SaveCanvasLayout_PersistsSignedEntityPositionsAndAuditRevision()
     {
-        var localRoot = Path.Combine(_rootDirectory, "push-local", "BP");
-        var sharedRoot = Path.Combine(_rootDirectory, "push-shared", "BP");
+        var localRoot = Path.Combine(_rootDirectory, "canvas-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "canvas-shared", "BP");
         var service = CreateService();
+        var created = service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "1.0.0", ReleaseStatus.InProgress, null));
+        var projectId = created.LoadResult.Workspace.Project.ProjectId;
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
 
+        var updated = service.SaveCanvasLayout(
+            localRoot,
+            sharedRoot,
+            new CanvasLayoutEditRequest(
+                [
+                    new CanvasNodeLayoutEdit("project", projectId, 50, 300),
+                    new CanvasNodeLayoutEdit("version", versionId, 420, 90),
+                ]));
+
+        var layout = Assert.IsType<CanvasLayoutDocument>(updated.LoadResult.Workspace.CanvasLayout);
+        Assert.Equal(1, layout.Revision);
+        Assert.Equal(2, layout.Nodes.Count);
+        Assert.True(File.Exists(Path.Combine(localRoot, "project", "canvas-layout.sig")));
+        Assert.Contains(
+            Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json"),
+            path => File.ReadAllText(path).Contains("canvas.layout.save", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SaveCanvasLayout_RejectsReferencesOutsideTheWorkspace()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "canvas-invalid-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "canvas-invalid-shared", "BP");
+        var service = CreateService();
         service.CreateProject(
             new ProjectCreateRequest(
                 "Blueprints",
@@ -223,7 +277,33 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
                 "SemVer",
                 localRoot,
                 sharedRoot));
-        service.SaveVersion(
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => service.SaveCanvasLayout(
+                localRoot,
+                sharedRoot,
+                new CanvasLayoutEditRequest(
+                    [new CanvasNodeLayoutEdit("version", Guid.NewGuid(), 100, 100)])));
+
+        Assert.Contains("does not reference", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(localRoot, "project", "canvas-layout.json")));
+    }
+
+    [Fact]
+    public void PushWorkspace_PublishesLocalChangesAndRefreshesSyncState()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "push-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "push-shared", "BP");
+        var service = CreateService();
+
+        var created = service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
             localRoot,
             sharedRoot,
             new VersionEditRequest(
@@ -231,6 +311,22 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
                 "1.0.0",
                 ReleaseStatus.InProgress,
                 "Baseline"));
+        service.SaveCanvasLayout(
+            localRoot,
+            sharedRoot,
+            new CanvasLayoutEditRequest(
+                [
+                    new CanvasNodeLayoutEdit(
+                        "project",
+                        created.LoadResult.Workspace.Project.ProjectId,
+                        50,
+                        300),
+                    new CanvasNodeLayoutEdit(
+                        "version",
+                        versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId,
+                        400,
+                        100),
+                ]));
 
         var beforePush = service.OpenProject(localRoot, sharedRoot);
         Assert.True(beforePush.Sync.PendingOutgoingChanges > 0);
@@ -242,6 +338,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.True(result.AppliedDocumentCount > 0);
         Assert.True(File.Exists(Path.Combine(sharedRoot, "manifest", "sync-manifest.json")));
         Assert.True(File.Exists(Path.Combine(sharedRoot, "project", "project.json")));
+        Assert.True(File.Exists(Path.Combine(sharedRoot, "project", "canvas-layout.json")));
+        Assert.True(File.Exists(Path.Combine(sharedRoot, "project", "canvas-layout.sig")));
 
         var refreshed = service.OpenProject(localRoot, sharedRoot);
         Assert.Equal(0, refreshed.Sync.PendingOutgoingChanges);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Cross-platform CI, CodeQL, dependency review, milestone automation, PR labels, and community templates.
 - Lightweight milestone-release records generated from the changelog without binary builds.
 - A diagram-first blueprint canvas with draggable version and work-item nodes, live relationship connectors, zoom controls, and direct node inspection.
+- Signed, revisioned node-position persistence with entity validation, audit entries, sync support, auto arrangement, and explicit save controls.
+- Machine-local canvas zoom and viewport persistence that cannot create audit noise or collaboration conflicts.
+- Canvas-engine and troubleshooting documentation covering behavior, format, security, compatibility, conflicts, and recovery.
 - Native folder pickers for project creation and opening.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 Release notes often live in scattered issues, commit messages, and private documents. Blueprints keeps release intent in a portable workspace that remains readable without a server:
 
 - plan versions and categorized release items;
+- arrange versions and work items on a persistent signed blueprint canvas;
 - generate stable human-readable item keys;
 - freeze and release versions with immutable released content;
 - export Markdown changelogs, optionally enriched by local Git history;
@@ -36,6 +37,7 @@ Release notes often live in scattered issues, commit messages, and private docum
 | Area | Status |
 | --- | --- |
 | Local project, version, and item workflow | Working |
+| Persistent signed canvas layout | Working |
 | Signed persistence and trust validation | Working |
 | Markdown changelog export | Working |
 | Shared-folder push/pull | Working foundation |
@@ -88,6 +90,8 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 
 - [Documentation index](docs/README.md)
 - [User guide](docs/user-guide.md)
+- [Canvas engine](docs/canvas-engine.md)
+- [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](docs/architecture.md)
 - [Workspace format](docs/workspace-format.md)
 - [Security model](docs/security-model.md)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -2,7 +2,7 @@
 
 This is the canonical product roadmap. It is organized by outcomes, not implementation layers, and should be updated when an issue changes scope or a milestone is completed.
 
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-30
 
 ## Product direction
 
@@ -21,6 +21,9 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Establish public-project documentation, templates, automation, and visual identity.
 - [x] Move the supported runtime to .NET 10 LTS and Avalonia 12.
 - [x] Make the primary workspace a draggable, diagram-first blueprint canvas backed by real version and item relationships.
+- [x] Persist, sign, audit, sync, validate, and restore shared node positions while keeping viewport preferences machine-local.
+- [ ] Add undo/redo, box selection, multi-select, keyboard movement, alignment guides, and a minimap.
+- [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
 - [x] Add native folder pickers instead of requiring raw paths.
 - [ ] Add first-run identity setup instead of silently creating a default identity.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Use this directory as the canonical technical and user documentation.
 | Audience | Document |
 | --- | --- |
 | Trying the app | [User guide](user-guide.md) |
+| Understanding the visual workspace | [Canvas engine](canvas-engine.md) |
+| Diagnosing a problem | [Troubleshooting](troubleshooting.md) |
 | Building or contributing | [Development guide](development.md) |
 | Understanding the code | [Architecture](architecture.md) |
 | Inspecting project files | [Workspace format](workspace-format.md) |
@@ -21,5 +23,6 @@ Use this directory as the canonical technical and user documentation.
 - `Roadmap.md` is the only canonical forward plan.
 - `Plan.md`, `ImplementationPlan.md`, `ProductDirection.md`, `IntegrationsStrategy.md`, `VaultSyncContext.md`, `AgentQuickstart.md`, `CodexHandoff.md`, and `TestPlan.md` are retained as historical design and handoff material. They may contain stale status statements.
 - A behavior change is incomplete until its relevant guide and tests are updated.
+- Persisted-format changes must document compatibility, validation, sync behavior, failure handling, and security impact.
 
 If documentation and code disagree, treat code and tests as current behavior, then fix the documentation in the same pull request.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,11 @@ There is no dependency-injection container. Constructor composition keeps the cu
 1. Resolve local and shared paths.
 2. Load the local identity.
 3. Load project, membership, versions, and items.
-4. Verify detached signatures with the project member key selected by the current workflow.
-5. Validate the signed audit chain.
-6. Analyze local/shared changes against local sync state.
-7. return a `LocalWorkspaceSession` containing data, trust, sync, safety, and conflict state.
+4. Load the optional canvas layout and validate schema, project identity, entity references, and rendering bounds.
+5. Verify detached signatures with the project member key selected by the current workflow.
+6. Validate the signed audit chain.
+7. Analyze local/shared changes against local sync state.
+8. Return a `LocalWorkspaceSession` containing data, layout, trust, sync, safety, and conflict state.
 
 ### Mutation
 
@@ -59,6 +60,18 @@ There is no dependency-injection container. Constructor composition keeps the cu
 4. Write canonical JSON and detached signatures.
 5. Append a signed, hash-linked audit entry.
 6. Reload the session so displayed state comes from disk.
+
+### Canvas layout mutation
+
+1. Collect current project/version/item node positions.
+2. Require a trusted workspace with no unresolved conflicts.
+3. Reject unknown entities, duplicate node identities, unsupported types, non-finite values, and out-of-range coordinates.
+4. Increment the layout revision.
+5. Write only `project/canvas-layout.json` and its detached signature.
+6. Append a signed audit entry.
+7. Reload and project the layout onto current signed entities.
+
+Zoom and scroll offsets follow a separate local-preference flow: validate bounded values, atomically replace `.blueprints/canvas-view.json`, and never include it in signatures, audit entries, manifests, or exchange analysis.
 
 ### Push
 
@@ -86,6 +99,7 @@ There is no dependency-injection container. Constructor composition keeps the cu
 - Membership always retains at least one active administrator.
 - Hosted providers cannot become authoritative for signed project truth.
 - Local-only integration credentials and paths stay outside project files.
+- Canvas layout is shared signed presentation state; version and item documents remain authoritative content.
 
 ## Known structural debt
 

--- a/docs/canvas-engine.md
+++ b/docs/canvas-engine.md
@@ -1,0 +1,112 @@
+# Canvas engine
+
+The canvas is the primary Blueprints workspace. It visualizes signed project entities without replacing them with a second source of truth.
+
+## Graph projection
+
+The current graph is derived from existing domain relationships:
+
+```text
+project
+└── version
+    └── work item
+```
+
+- The project node uses `ProjectConfigurationDocument.ProjectId`.
+- A version node uses `VersionDocument.VersionId`.
+- A work-item node uses `ItemDocument.ItemId`.
+- Connector lines are derived from version ownership; they are not persisted separately.
+
+Changing a node title, state, category, or completion value uses the existing version and item workflows. Moving a node changes only the layout document.
+
+## Interaction model
+
+| Action | Result |
+| --- | --- |
+| Click a version | Select it and open version fields in the inspector |
+| Click a work item | Select it, its owning version, and its item fields |
+| Drag a node | Move it and save a new signed layout revision on release |
+| Middle-drag empty canvas | Pan without changing shared node positions |
+| Scroll the canvas | Save machine-local viewport offsets after a short debounce |
+| Ctrl+mouse wheel or zoom buttons | Change and save machine-local zoom |
+| Fit view | Use the standard local overview zoom and return to the origin |
+| Auto arrange | Rebuild deterministic default positions and save them |
+| Save layout | Explicitly write the current shared node positions |
+| Ctrl+S | Save shared node positions |
+| Ctrl+0 | Fit the local view |
+| Ctrl+plus/minus | Zoom the local view |
+
+Editing and layout controls are disabled when the workspace is untrusted or has unresolved sync conflicts.
+
+## Persistence
+
+Shared node positions are stored in:
+
+```text
+project/canvas-layout.json
+project/canvas-layout.sig
+```
+
+The signed layout document contains:
+
+- schema and project identity;
+- monotonically increasing layout revision;
+- node type, entity ID, and coordinates;
+- update time and last-modifier identity.
+
+The document is optional for schema-1 compatibility. An older workspace without it opens normally and receives deterministic default positions. The first layout save creates revision 1.
+
+Each successful save:
+
+1. reopens and validates the workspace;
+2. requires trusted, conflict-free mutable state;
+3. verifies every layout node refers to an existing project entity;
+4. validates coordinate, uniqueness, and size limits;
+5. writes canonical JSON and an Ed25519 detached signature;
+6. appends a signed `canvas.layout.save` audit entry;
+7. reloads displayed state from disk.
+
+Layout writes do not rewrite version or item documents.
+
+Zoom and viewport offsets are machine-local preferences stored in:
+
+```text
+.blueprints/canvas-view.json
+```
+
+This file is not signed, audited, synchronized, or authoritative. Invalid local values fall back to the default view. Keeping viewport preferences local prevents ordinary scrolling from creating audit noise or collaboration conflicts.
+
+## Validation limits
+
+The schema-1 validator enforces:
+
+- supported node types: `project`, `version`, and `item`;
+- non-empty and unique `(nodeType, entityId)` pairs;
+- entity membership in the current workspace;
+- finite coordinates from `0` through `100000`;
+- no more than `10000` nodes;
+- matching non-empty project identity;
+- schema version `1` and revision of at least `1`.
+
+These limits prevent malformed, non-finite, or unbounded layout input from reaching Avalonia rendering.
+
+The local view-state store separately accepts zoom from `0.6` through `1.5` and non-negative offsets through `100000`.
+
+## Sync and conflicts
+
+The layout lives under `project/`, so the exchange snapshot, manifest, signature validator, push, pull, and conflict analyzer include it automatically.
+
+Two collaborators moving the same canvas from a common baseline may produce a conflict in `project/canvas-layout.json`. Blueprints deliberately treats the complete layout as one document in schema 1. Conflict resolution therefore chooses the local or shared arrangement as a whole.
+
+Version and work-item content remain separate documents. A layout conflict does not imply that their content has conflicted.
+
+## Current limits
+
+- There is one shared release-planning canvas per project.
+- Node positions are shared project state, not per-user preferences.
+- Connectors represent ownership and cannot yet be created as arbitrary edge types.
+- There is no undo/redo stack, minimap, box selection, grouping, or keyboard-driven movement yet.
+- Auto arrangement is deterministic but not a graph-optimization engine.
+- Layout conflict resolution is whole-document.
+
+These are product limitations, not hidden behavior. Planned work belongs in the canonical [roadmap](../Roadmap.md).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -10,6 +10,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - sync manifest continuity;
 - audit-history continuity;
 - user control over incoming shared changes.
+- canvas integrity and resistance to malicious rendering input.
 
 ## Trust boundaries
 
@@ -20,6 +21,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 | Local identity directory | Sensitive local state protected by OS permissions and key protection |
 | Git/provider integration | Informational; not authoritative project truth |
 | UI input | Validated by application workflows before persistence |
+| Canvas layout | Signed shared node positions; entity references and coordinate bounds validated before rendering or saving |
+| Canvas viewport | Unsigned machine-local preference; bounded and excluded from sync and trust decisions |
 
 ## Cryptography
 
@@ -39,6 +42,10 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - At least one active Admin must remain.
 - Released versions reject further version and item edits.
 - Local and shared roots may not overlap.
+- A persisted canvas node must reference an existing signed project entity.
+- Canvas coordinates, node count, project identity, schema, and uniqueness are bounded and validated.
+- Local viewport values are bounded but cannot affect signed project truth or workspace trust.
+- Invalid canvas signatures place the workspace in read-only untrusted state.
 
 ## Important limitations
 
@@ -48,6 +55,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - The audit chain detects many edits and deletions, but is not anchored to an external transparency service.
 - Shared-folder availability, confidentiality, and rollback resistance depend on the underlying storage.
 - Current workspace saves are not a single atomic transaction across all changed files.
+- Canvas layout is a whole signed document; concurrent arrangements conflict as a unit and are not field-merged.
 - Conflict resolution currently exposes low-level previews and supports whole-document choices.
 - Blueprints does not encrypt project content.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting
+
+This guide covers supported diagnostic and recovery steps. Do not delete signatures or edit signed JSON to make an error disappear.
+
+## The workspace opens read-only
+
+Check the trust summary and open **Trust**.
+
+Common causes:
+
+- a signed JSON document changed without a matching signature;
+- a required document or signature is missing;
+- the audit chain is incomplete;
+- local and shared roots overlap or fail a safety check;
+- local and shared copies changed from the same baseline.
+
+Preserve both roots before attempting recovery. Restore the affected document and its sibling `.sig` from the same known-good snapshot.
+
+## The canvas arrangement resets
+
+Look for `project/canvas-layout.json` and `project/canvas-layout.sig`.
+
+- If neither exists, the workspace is using the compatible default arrangement. Move a node or select **Save layout**.
+- If both exist, open **Trust**. An invalid layout signature makes the workspace read-only.
+- If another collaborator pushed a layout, pull it through the normal sync workflow.
+- **Auto arrange** intentionally replaces the saved arrangement with deterministic defaults.
+- If only zoom or scroll position resets, inspect `.blueprints/canvas-view.json`; malformed local view state safely falls back to defaults.
+
+Never copy only `canvas-layout.json`; its detached signature must come from the same save.
+
+## A layout conflict blocks editing
+
+Open **Sync** and select `project/canvas-layout.json`.
+
+- **Keep Local** keeps your complete arrangement and publishes it on the next push.
+- **Accept Shared** replaces your complete arrangement with the shared copy.
+
+Schema 1 cannot merge individual node positions. Back up both document/signature pairs if both arrangements matter.
+
+## A node is missing
+
+Select **Refresh**, then **Auto arrange** if necessary.
+
+The canvas is projected from signed project entities. A layout entry alone cannot create a node. If a version or item is absent from the signed workspace, its layout entry is rejected or ignored by the projection.
+
+## The wrong node is selected after refresh
+
+Select the node again. Workspace mutation reloads signed state from disk, and a removed or replaced entity cannot remain selected.
+
+## Build or SDK selection fails
+
+```sh
+dotnet --list-sdks
+dotnet --version
+dotnet restore Blueprints.sln
+```
+
+Install .NET 10 SDK `10.0.300` or a newer compatible patch. The repository-owned `global.json` is authoritative.
+
+## Linux application startup fails
+
+Avalonia currently needs an accessible X11/XWayland display.
+
+```sh
+./scripts/diagnose-linux-display.sh
+```
+
+Review `DISPLAY`, `WAYLAND_DISPLAY`, and `XAUTHORITY`. A successful headless build does not prove that the current shell can open a desktop window.
+
+## Reporting a defect
+
+Include:
+
+- operating system and `dotnet --info`;
+- the exact action and visible message;
+- whether the workspace was Trusted, Untrusted, or Corrupt;
+- whether sync conflicts existed;
+- sanitized relative document paths;
+- the output of `./scripts/verify.sh`.
+
+Do not attach private keys, protection keys, provider tokens, or confidential project content to a public issue. Report suspected vulnerabilities according to [SECURITY.md](../SECURITY.md).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -27,10 +27,25 @@ Blueprints creates the first local identity automatically in the current preview
 2. Select the version node to edit its name, state, and accomplishment notes in the inspector.
 3. Select **Work item**, enter its type, changelog group, title, and context, then select **Connect new**.
 4. Select any work-item node to edit it directly in the inspector.
-5. Drag nodes to arrange the working view, and use zoom or **Fit map** to navigate larger plans.
+5. Drag nodes to arrange the working view, and use zoom or **Fit view** to navigate larger plans.
 6. Mark completed items as ready for release notes.
 
 The lines on the canvas represent real project relationships: a work item is connected to the version that owns it. Item keys are generated from project rules. Released versions are immutable.
+
+## Arrange and share the canvas
+
+- Dragging a node saves the arrangement when the pointer is released.
+- Middle-drag empty canvas space to pan.
+- Scrolling saves the viewport locally after a short pause.
+- Use Ctrl+mouse wheel or Ctrl+plus/minus to zoom; zoom is remembered locally for this workspace.
+- Ctrl+S saves shared node positions and Ctrl+0 fits the local view.
+- **Fit view** returns to the standard overview without rearranging nodes.
+- **Auto arrange** deliberately replaces positions with deterministic defaults.
+- **Save layout** explicitly writes the current arrangement.
+
+The saved revision appears at the bottom of the inspector. Node positions are signed project state and participate in push, pull, trust validation, audit history, and conflicts. Zoom and scroll offsets stay machine-local so navigating does not create team conflicts. Older workspaces without a layout file use default positions until the first save.
+
+See [canvas engine](canvas-engine.md) for the exact model and [troubleshooting](troubleshooting.md) for recovery.
 
 ## Export a changelog
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -10,7 +10,9 @@ This document describes the current schema-1 layout. The format is pre-release a
 │   ├── project.json
 │   ├── project.sig
 │   ├── members.json
-│   └── members.sig
+│   ├── members.sig
+│   ├── canvas-layout.json      # optional until first layout save
+│   └── canvas-layout.sig
 ├── versions/
 │   └── <version-id-without-dashes>/
 │       ├── version.json
@@ -22,10 +24,11 @@ This document describes the current schema-1 layout. The format is pre-release a
 │   ├── <change-id>.json
 │   └── <change-id>.sig
 └── .blueprints/
-    └── sync-state.json
+    ├── sync-state.json
+    └── canvas-view.json
 ```
 
-The collaboration layer also writes a signed manifest in the shared project root. `.blueprints/sync-state.json` is local bookkeeping and is not signed project truth.
+The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` are local bookkeeping and are not signed project truth or exchange input.
 
 ## Serialization
 
@@ -58,6 +61,37 @@ Contains the membership revision and members. A member has a user ID, display na
 
 Roles are Viewer, Editor, and Admin.
 
+### `canvas-layout.json`
+
+Contains the shared visual arrangement without duplicating version or item content:
+
+```json
+{
+  "schemaVersion": 1,
+  "projectId": "00000000-0000-0000-0000-000000000000",
+  "revision": 1,
+  "nodes": [
+    {
+      "nodeType": "project",
+      "entityId": "00000000-0000-0000-0000-000000000000",
+      "x": 48,
+      "y": 310
+    }
+  ],
+  "updatedUtc": "2026-07-30T00:00:00+00:00",
+  "lastModifiedByUserId": "00000000-0000-0000-0000-000000000000",
+  "lastModifiedByName": "Local Admin"
+}
+```
+
+The real project ID replaces the illustrative zero GUIDs. The file is optional for older schema-1 workspaces. Once present, its signature and project identity must validate. Node identities must reference existing signed entities.
+
+See [canvas engine](canvas-engine.md) for validation limits and interaction behavior.
+
+### `.blueprints/canvas-view.json`
+
+Contains machine-local zoom and scroll offsets. It is deliberately unsigned and excluded from exchange snapshots. Invalid or missing view state falls back to zoom `1` and zero offsets without changing workspace trust.
+
 ### `version.json`
 
 Contains a version ID, name, lifecycle status, creation/release times, notes, and manual item ordering.
@@ -74,7 +108,7 @@ Contains a unique change ID, operation, human summary, author, membership revisi
 
 ## Compatibility
 
-There is no migration engine yet. Do not manually change `schemaVersion`. Before adopting a future schema, preserve a complete copy of the workspace and identity data.
+There is no general migration engine yet. Optional schema-1 documents, including the canvas layout, use explicit missing-file compatibility. Do not manually change `schemaVersion`. Before adopting a future schema, preserve a complete copy of the workspace and identity data.
 
 ## Files that must never be shared as project data
 


### PR DESCRIPTION
## Summary

- persist project, version, and work-item node positions as a separately signed canvas layout document
- keep zoom and viewport offsets in bounded machine-local state so navigation does not alter signed project truth
- add draggable project nodes, middle-button panning, Ctrl+wheel zoom, fit view, auto arrange, explicit save, and keyboard shortcuts
- validate layout schema, project identity, entity references, coordinate bounds, and signatures on load and save
- include shared layouts in the existing sync/conflict model while preserving compatibility with older workspaces
- document the canvas engine, workspace format, security boundary, troubleshooting, usage, architecture, roadmap, and changelog

## Security model

Shared node positions live in `project/canvas-layout.json` with its detached signature. Tampering changes workspace trust, and unknown validly signed entity references are treated as corrupt. Machine-local viewport state lives in `.blueprints/canvas-view.json`; it is unsigned, excluded from exchange snapshots, bounded on load, and cannot affect trust decisions.

## Verification

- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- `dotnet build Blueprints.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test Blueprints.sln --configuration Release --no-build --no-restore` (67 passed)
- `dotnet package list --project Blueprints.sln --vulnerable --include-transitive` (no known vulnerable packages)
- production application smoke launch on macOS
- visual QA of the interactive workspace and inspector
