### PR TITLE
Add approval-first Source Lens and adaptive workflow UI

### DIFF
--- a/Blueprints.App/Models/ApprovedSourceImportItem.cs
+++ b/Blueprints.App/Models/ApprovedSourceImportItem.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.App.Models;
+
+public sealed record ApprovedSourceImportItem(
+    Guid VersionId,
+    string ItemTypeId,
+    string CategoryId,
+    string Title,
+    string? Description,
+    bool IsDone,
+    SourceArtifactKind SourceKind,
+    string SourceReference);

--- a/Blueprints.App/Models/ApprovedSourceImportRequest.cs
+++ b/Blueprints.App/Models/ApprovedSourceImportRequest.cs
@@ -1,0 +1,4 @@
+namespace Blueprints.App.Models;
+
+public sealed record ApprovedSourceImportRequest(
+    IReadOnlyList<ApprovedSourceImportItem> Items);

--- a/Blueprints.App/Models/SourceArtifactKind.cs
+++ b/Blueprints.App/Models/SourceArtifactKind.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.App.Models;
+
+public enum SourceArtifactKind
+{
+    Changelog,
+    Roadmap,
+    GitHubIssue,
+    GitHubProject,
+}

--- a/Blueprints.App/Models/SourceDiscoveryCandidate.cs
+++ b/Blueprints.App/Models/SourceDiscoveryCandidate.cs
@@ -1,0 +1,12 @@
+namespace Blueprints.App.Models;
+
+public sealed record SourceDiscoveryCandidate(
+    SourceArtifactKind Kind,
+    string Title,
+    string? Description,
+    string SuggestedItemTypeId,
+    string SuggestedCategoryId,
+    bool IsDone,
+    string SourceReference,
+    string SourceContext,
+    double Confidence);

--- a/Blueprints.App/Models/SourceDiscoveryResult.cs
+++ b/Blueprints.App/Models/SourceDiscoveryResult.cs
@@ -1,0 +1,14 @@
+namespace Blueprints.App.Models;
+
+public sealed record SourceDiscoveryResult(
+    IReadOnlyList<SourceDiscoveryCandidate> Candidates,
+    IReadOnlyList<string> Warnings,
+    int ChangelogCount,
+    int RoadmapCount,
+    int GitHubIssueCount,
+    int GitHubProjectCount)
+{
+    public string Summary =>
+        $"Found {Candidates.Count} proposals · {ChangelogCount} changelog · {RoadmapCount} roadmap · " +
+        $"{GitHubIssueCount} issues · {GitHubProjectCount} project-linked";
+}

--- a/Blueprints.App/Models/SourceImportProposal.cs
+++ b/Blueprints.App/Models/SourceImportProposal.cs
@@ -1,0 +1,86 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Blueprints.App.Models;
+
+public sealed class SourceImportProposal : ObservableObject
+{
+    private bool _isIncluded;
+    private string _title;
+    private string _description;
+    private string _itemTypeId;
+    private string _categoryId;
+    private bool _isDone;
+    private WorkspaceVersionCard? _targetVersion;
+
+    public SourceImportProposal(
+        SourceDiscoveryCandidate candidate,
+        WorkspaceVersionCard? targetVersion,
+        bool isDuplicate)
+    {
+        Candidate = candidate;
+        _isIncluded = !isDuplicate;
+        _title = candidate.Title;
+        _description = candidate.Description ?? string.Empty;
+        _itemTypeId = candidate.SuggestedItemTypeId;
+        _categoryId = candidate.SuggestedCategoryId;
+        _isDone = candidate.IsDone;
+        _targetVersion = targetVersion;
+        IsDuplicate = isDuplicate;
+    }
+
+    public SourceDiscoveryCandidate Candidate { get; }
+
+    public SourceArtifactKind Kind => Candidate.Kind;
+
+    public string SourceReference => Candidate.SourceReference;
+
+    public string SourceContext => Candidate.SourceContext;
+
+    public string ConfidenceSummary => $"{Candidate.Confidence:P0} confidence";
+
+    public bool IsDuplicate { get; }
+
+    public string DuplicateSummary => IsDuplicate ? "Possible duplicate" : "New proposal";
+
+    public bool IsIncluded
+    {
+        get => _isIncluded;
+        set => SetProperty(ref _isIncluded, value);
+    }
+
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    public string Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value);
+    }
+
+    public string ItemTypeId
+    {
+        get => _itemTypeId;
+        set => SetProperty(ref _itemTypeId, value);
+    }
+
+    public string CategoryId
+    {
+        get => _categoryId;
+        set => SetProperty(ref _categoryId, value);
+    }
+
+    public bool IsDone
+    {
+        get => _isDone;
+        set => SetProperty(ref _isDone, value);
+    }
+
+    public WorkspaceVersionCard? TargetVersion
+    {
+        get => _targetVersion;
+        set => SetProperty(ref _targetVersion, value);
+    }
+}

--- a/Blueprints.App/Services/ISourceDiscoveryService.cs
+++ b/Blueprints.App/Services/ISourceDiscoveryService.cs
@@ -1,0 +1,8 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public interface ISourceDiscoveryService
+{
+    SourceDiscoveryResult Discover(string repositoryPath);
+}

--- a/Blueprints.App/Services/MarkdownSourceDiscoveryParser.cs
+++ b/Blueprints.App/Services/MarkdownSourceDiscoveryParser.cs
@@ -1,0 +1,148 @@
+using System.Text.RegularExpressions;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed partial class MarkdownSourceDiscoveryParser
+{
+    private const int MaximumCandidatesPerFile = 100;
+
+    public IReadOnlyList<SourceDiscoveryCandidate> Parse(string filePath, SourceArtifactKind kind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        if (kind is not SourceArtifactKind.Changelog and not SourceArtifactKind.Roadmap)
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), "Only changelog and roadmap Markdown can be parsed.");
+        }
+
+        var candidates = new List<SourceDiscoveryCandidate>();
+        var heading = string.Empty;
+        var lines = File.ReadLines(filePath).Take(5_000);
+        var lineNumber = 0;
+
+        foreach (var rawLine in lines)
+        {
+            lineNumber++;
+            var line = rawLine.Trim();
+            var headingMatch = HeadingPattern().Match(line);
+            if (headingMatch.Success)
+            {
+                heading = headingMatch.Groups["heading"].Value.Trim();
+                continue;
+            }
+
+            var itemMatch = MarkdownItemPattern().Match(line);
+            if (!itemMatch.Success)
+            {
+                continue;
+            }
+
+            var title = NormalizeMarkdown(itemMatch.Groups["title"].Value);
+            if (title.Length < 3 || IsDecorativeItem(title))
+            {
+                continue;
+            }
+
+            var checkbox = itemMatch.Groups["checkbox"].Value;
+            var isDone = checkbox.Equals("x", StringComparison.OrdinalIgnoreCase);
+            var category = SuggestCategory(kind, heading, title);
+            var itemType = SuggestItemType(heading, title);
+            var relativeName = Path.GetFileName(filePath);
+            var context = string.IsNullOrWhiteSpace(heading) ? relativeName : heading;
+
+            candidates.Add(
+                new SourceDiscoveryCandidate(
+                    kind,
+                    title,
+                    string.IsNullOrWhiteSpace(heading) ? null : $"Imported from section “{heading}”.",
+                    itemType,
+                    category,
+                    isDone || kind == SourceArtifactKind.Changelog,
+                    $"{kind.ToString().ToLowerInvariant()}:{relativeName}:{lineNumber}",
+                    context,
+                    kind == SourceArtifactKind.Roadmap && checkbox.Length > 0 ? 0.94 : 0.82));
+
+            if (candidates.Count >= MaximumCandidatesPerFile)
+            {
+                break;
+            }
+        }
+
+        return candidates;
+    }
+
+    private static string SuggestCategory(SourceArtifactKind kind, string heading, string title)
+    {
+        var text = $"{heading} {title}";
+        if (ContainsAny(text, "security", "vulnerability", "cve"))
+        {
+            return "security";
+        }
+
+        if (ContainsAny(text, "fix", "fixed", "bug", "repair"))
+        {
+            return "fixed";
+        }
+
+        if (ContainsAny(text, "remove", "removed", "deprecated"))
+        {
+            return "removed";
+        }
+
+        if (kind == SourceArtifactKind.Changelog &&
+            ContainsAny(text, "add", "added", "new", "feature"))
+        {
+            return "added";
+        }
+
+        return kind == SourceArtifactKind.Roadmap ? "added" : "changed";
+    }
+
+    private static string SuggestItemType(string heading, string title)
+    {
+        var text = $"{heading} {title}";
+        if (ContainsAny(text, "security", "vulnerability", "cve"))
+        {
+            return "security";
+        }
+
+        if (ContainsAny(text, "fix", "bug", "defect", "crash"))
+        {
+            return "bug";
+        }
+
+        if (ContainsAny(text, "issue", "investigate", "research"))
+        {
+            return "issue";
+        }
+
+        return "feature";
+    }
+
+    private static bool ContainsAny(string value, params string[] terms) =>
+        terms.Any(term => value.Contains(term, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsDecorativeItem(string title) =>
+        title.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
+        title.Equals("TBD", StringComparison.OrdinalIgnoreCase) ||
+        title.Equals("None", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeMarkdown(string value)
+    {
+        var withoutLinks = MarkdownLinkPattern().Replace(value, static match => match.Groups["label"].Value);
+        return withoutLinks
+            .Replace("`", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .TrimEnd('.');
+    }
+
+    [GeneratedRegex(@"^#{1,6}\s+(?<heading>.+)$")]
+    private static partial Regex HeadingPattern();
+
+    [GeneratedRegex(@"^[-*+]\s+(?:\[(?<checkbox>[ xX])\]\s+)?(?<title>.+)$")]
+    private static partial Regex MarkdownItemPattern();
+
+    [GeneratedRegex(@"\[(?<label>[^\]]+)\]\([^)]+\)")]
+    private static partial Regex MarkdownLinkPattern();
+}

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -275,6 +275,97 @@ public sealed class ProjectWorkspaceCoordinatorService
         }, "item.save", $"Saved item {normalizedTitle}.");
     }
 
+    public LocalWorkspaceSession ApplyApprovedSourceImport(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        ApprovedSourceImportRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Items.Count is < 1 or > 100)
+        {
+            throw new InvalidOperationException("Approve between 1 and 100 source proposals at a time.");
+        }
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var versions = workspace.Versions.ToList();
+
+        foreach (var import in request.Items)
+        {
+            var versionIndex = versions.FindIndex(snapshot => snapshot.Version.VersionId == import.VersionId);
+            if (versionIndex < 0)
+            {
+                throw new InvalidOperationException($"The target version for “{import.Title}” was not found.");
+            }
+
+            if (!workspace.Project.ItemTypes.ContainsKey(import.ItemTypeId))
+            {
+                throw new InvalidOperationException($"Item type “{import.ItemTypeId}” is not configured for this project.");
+            }
+
+            if (!workspace.Project.DefaultCategories.Any(category =>
+                    string.Equals(category.Id, import.CategoryId, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException($"Category “{import.CategoryId}” is not configured for this project.");
+            }
+
+            var title = import.Title.Trim();
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                throw new InvalidOperationException("Every approved proposal needs a title.");
+            }
+
+            var targetVersion = versions[versionIndex];
+            EnsureItemChangesAllowed(targetVersion.Version.Status);
+            var currentWorkspace = workspace with { Versions = versions.ToArray() };
+            var createdUtc = DateTimeOffset.UtcNow;
+            var items = targetVersion.Items
+                .Append(
+                    new ItemDocument(
+                        CurrentSchemaVersion,
+                        workspace.Project.ProjectId,
+                        import.VersionId,
+                        Guid.NewGuid(),
+                        GenerateItemKey(currentWorkspace, targetVersion, import.ItemTypeId),
+                        import.ItemTypeId,
+                        import.CategoryId,
+                        title,
+                        string.IsNullOrWhiteSpace(import.Description) ? null : import.Description.Trim(),
+                        import.IsDone,
+                        [
+                            "source-import",
+                            $"source:{import.SourceKind.ToString().ToLowerInvariant()}",
+                            import.SourceReference,
+                        ],
+                        createdUtc,
+                        createdUtc,
+                        identity.Profile.UserId,
+                        identity.Profile.DisplayName))
+                .ToArray();
+            versions[versionIndex] = targetVersion with
+            {
+                Items = items,
+                Version = targetVersion.Version with
+                {
+                    ManualOrder = items.Select(static item => item.ItemId).ToArray(),
+                },
+            };
+        }
+
+        return SaveWorkspace(
+            localWorkspaceRoot,
+            sharedWorkspaceRoot,
+            identity,
+            workspace with { Versions = versions.ToArray() },
+            "source.import.apply",
+            $"Approved and imported {request.Items.Count} source proposals.");
+    }
+
     public LocalWorkspaceSession SaveCanvasLayout(
         string localWorkspaceRoot,
         string sharedWorkspaceRoot,

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -1,0 +1,341 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryService
+{
+    private const int MaximumGitHubIssues = 100;
+    private readonly MarkdownSourceDiscoveryParser _markdownParser;
+
+    public RepositorySourceDiscoveryService()
+        : this(new MarkdownSourceDiscoveryParser())
+    {
+    }
+
+    public RepositorySourceDiscoveryService(MarkdownSourceDiscoveryParser markdownParser)
+    {
+        _markdownParser = markdownParser;
+    }
+
+    public SourceDiscoveryResult Discover(string repositoryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryPath);
+
+        var root = Path.GetFullPath(repositoryPath.Trim());
+        if (!Directory.Exists(root))
+        {
+            throw new InvalidOperationException("The linked repository path does not exist.");
+        }
+
+        var candidates = new List<SourceDiscoveryCandidate>();
+        var warnings = new List<string>();
+        var changelogCount = AddMarkdownCandidates(root, SourceArtifactKind.Changelog, candidates);
+        var roadmapCount = AddMarkdownCandidates(root, SourceArtifactKind.Roadmap, candidates);
+
+        var repositoryName = ReadGitHubRepositoryName(root);
+        var githubIssueCount = 0;
+        var githubProjectCount = 0;
+        if (string.IsNullOrWhiteSpace(repositoryName))
+        {
+            warnings.Add("GitHub issues were skipped because the origin remote is not a recognizable GitHub repository.");
+        }
+        else
+        {
+            var github = ReadGitHubIssues(root, repositoryName);
+            candidates.AddRange(github.Candidates);
+            warnings.AddRange(github.Warnings);
+            githubIssueCount = github.Candidates.Count;
+            githubProjectCount = github.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject);
+        }
+
+        var deduplicated = candidates
+            .GroupBy(
+                static candidate => $"{candidate.Kind}:{NormalizeTitle(candidate.Title)}",
+                StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .Take(250)
+            .ToArray();
+
+        return new SourceDiscoveryResult(
+            deduplicated,
+            warnings,
+            changelogCount,
+            roadmapCount,
+            githubIssueCount,
+            githubProjectCount);
+    }
+
+    private int AddMarkdownCandidates(
+        string root,
+        SourceArtifactKind kind,
+        ICollection<SourceDiscoveryCandidate> candidates)
+    {
+        var names = kind == SourceArtifactKind.Changelog
+            ? new[] { "CHANGELOG.md", "Changelog.md", "changelog.md" }
+            : new[] { "Roadmap.md", "ROADMAP.md", "roadmap.md" };
+        var paths = names
+            .Select(name => Path.Combine(root, name))
+            .Concat(names.Select(name => Path.Combine(root, "docs", name)))
+            .Where(File.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToArray();
+
+        var countBefore = candidates.Count;
+        foreach (var path in paths)
+        {
+            foreach (var candidate in _markdownParser.Parse(path, kind))
+            {
+                candidates.Add(candidate);
+            }
+        }
+
+        return candidates.Count - countBefore;
+    }
+
+    private static GitHubDiscovery ReadGitHubIssues(string root, string repositoryName)
+    {
+        var command = RunProcess(
+            root,
+            "gh",
+            [
+                "issue",
+                "list",
+                "--repo",
+                repositoryName,
+                "--state",
+                "all",
+                "--limit",
+                MaximumGitHubIssues.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                "--json",
+                "number,title,body,state,labels,milestone,url,projectItems",
+            ]);
+
+        if (!command.Success)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub issues were skipped: {command.Error}"]);
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(command.Output);
+            var candidates = document.RootElement
+                .EnumerateArray()
+                .Select(ParseGitHubIssue)
+                .ToArray();
+            return new GitHubDiscovery(candidates, []);
+        }
+        catch (JsonException exception)
+        {
+            return new GitHubDiscovery([], [$"GitHub returned unreadable issue data: {exception.Message}"]);
+        }
+    }
+
+    private static SourceDiscoveryCandidate ParseGitHubIssue(JsonElement issue)
+    {
+        var number = issue.GetProperty("number").GetInt32();
+        var title = issue.GetProperty("title").GetString()?.Trim() ?? $"Issue #{number}";
+        var body = issue.TryGetProperty("body", out var bodyElement)
+            ? Truncate(bodyElement.GetString()?.Trim(), 2_000)
+            : null;
+        var state = issue.TryGetProperty("state", out var stateElement)
+            ? stateElement.GetString()
+            : null;
+        var url = issue.TryGetProperty("url", out var urlElement)
+            ? urlElement.GetString()
+            : null;
+        var labels = issue.TryGetProperty("labels", out var labelsElement)
+            ? labelsElement.EnumerateArray()
+                .Select(static label => label.TryGetProperty("name", out var name) ? name.GetString() : null)
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Cast<string>()
+                .ToArray()
+            : [];
+        var milestone = issue.TryGetProperty("milestone", out var milestoneElement) &&
+                        milestoneElement.ValueKind == JsonValueKind.Object &&
+                        milestoneElement.TryGetProperty("title", out var milestoneTitle)
+            ? milestoneTitle.GetString()
+            : null;
+        var projectNames = ReadProjectNames(issue);
+        var isProjectLinked = projectNames.Count > 0;
+        var contextParts = new[]
+            {
+                milestone is null ? null : $"Milestone: {milestone}",
+                projectNames.Count == 0 ? null : $"Projects: {string.Join(", ", projectNames)}",
+                labels.Length == 0 ? null : $"Labels: {string.Join(", ", labels)}",
+            }
+            .Where(static value => value is not null);
+
+        return new SourceDiscoveryCandidate(
+            isProjectLinked ? SourceArtifactKind.GitHubProject : SourceArtifactKind.GitHubIssue,
+            title,
+            body,
+            SuggestGitHubItemType(labels, title),
+            SuggestGitHubCategory(labels, state),
+            string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase),
+            $"github:#{number}",
+            string.Join(" · ", contextParts.DefaultIfEmpty($"GitHub issue #{number}")),
+            isProjectLinked ? 0.97 : 0.93);
+    }
+
+    private static IReadOnlyList<string> ReadProjectNames(JsonElement issue)
+    {
+        if (!issue.TryGetProperty("projectItems", out var projects) ||
+            projects.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return projects
+            .EnumerateArray()
+            .Select(static project =>
+            {
+                if (project.TryGetProperty("title", out var title))
+                {
+                    return title.GetString();
+                }
+
+                return project.TryGetProperty("project", out var nested) &&
+                       nested.TryGetProperty("title", out var nestedTitle)
+                    ? nestedTitle.GetString()
+                    : null;
+            })
+            .Where(static title => !string.IsNullOrWhiteSpace(title))
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string SuggestGitHubItemType(IReadOnlyList<string> labels, string title)
+    {
+        var text = $"{string.Join(' ', labels)} {title}";
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "bug";
+        }
+
+        if (text.Contains("feature", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("enhancement", StringComparison.OrdinalIgnoreCase))
+        {
+            return "feature";
+        }
+
+        return "issue";
+    }
+
+    private static string SuggestGitHubCategory(IReadOnlyList<string> labels, string? state)
+    {
+        var text = string.Join(' ', labels);
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "fixed";
+        }
+
+        return string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase)
+            ? "changed"
+            : "added";
+    }
+
+    private static string ReadGitHubRepositoryName(string root)
+    {
+        var remote = RunProcess(root, "git", ["-C", root, "config", "--get", "remote.origin.url"]);
+        if (!remote.Success)
+        {
+            return string.Empty;
+        }
+
+        var match = GitHubRemotePattern().Match(remote.Output.Trim());
+        if (!match.Success)
+        {
+            return string.Empty;
+        }
+
+        var repository = match.Groups["repo"].Value;
+        if (repository.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            repository = repository[..^4];
+        }
+
+        return $"{match.Groups["owner"].Value}/{repository}";
+    }
+
+    private static ProcessResult RunProcess(
+        string workingDirectory,
+        string fileName,
+        IReadOnlyList<string> arguments)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(fileName)
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(15_000))
+            {
+                process.Kill(entireProcessTree: true);
+                return new ProcessResult(false, string.Empty, $"{fileName} timed out after 15 seconds.");
+            }
+
+            return process.ExitCode == 0
+                ? new ProcessResult(true, output.Trim(), string.Empty)
+                : new ProcessResult(false, string.Empty, string.IsNullOrWhiteSpace(error) ? $"{fileName} exited with code {process.ExitCode}." : error.Trim());
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            return new ProcessResult(false, string.Empty, $"{fileName} is unavailable: {exception.Message}");
+        }
+    }
+
+    private static string NormalizeTitle(string title) =>
+        WhitespacePattern().Replace(title.Trim().ToUpperInvariant(), " ");
+
+    private static string? Truncate(string? value, int maximumLength) =>
+        string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Length <= maximumLength
+                ? value
+                : $"{value[..maximumLength]}…";
+
+    [GeneratedRegex(@"(?:github\.com[:/])(?<owner>[^/\s]+)/(?<repo>[^/\s]+)$")]
+    private static partial Regex GitHubRemotePattern();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespacePattern();
+
+    private sealed record ProcessResult(bool Success, string Output, string Error);
+
+    private sealed record GitHubDiscovery(
+        IReadOnlyList<SourceDiscoveryCandidate> Candidates,
+        IReadOnlyList<string> Warnings);
+}

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,7 @@ public partial class MainWindowViewModel : ViewModelBase
 {
     private readonly ProjectWorkspaceCoordinatorService? _coordinatorService;
     private readonly IntegrationStatusService _integrationStatusService;
+    private readonly ISourceDiscoveryService _sourceDiscoveryService;
     private readonly FileSystemCanvasViewStateStore _canvasViewStateStore;
     private LocalWorkspaceSession? _currentSession;
     private string _title = "Blueprints Setup";
@@ -76,6 +77,10 @@ public partial class MainWindowViewModel : ViewModelBase
     private WorkspaceSection _selectedWorkspaceSection = WorkspaceSection.Overview;
     private CanvasLayoutDocument? _canvasLayout;
     private CanvasViewState _canvasViewState = CanvasViewState.Default;
+    private SourceImportProposal? _selectedSourceProposal;
+    private string _sourceDiscoverySummary = "Connect a repository, then scan its planning sources.";
+    private string _sourceDiscoveryWarnings = string.Empty;
+    private bool _isDiscoveringSources;
 
     public MainWindowViewModel()
     {
@@ -90,17 +95,22 @@ public partial class MainWindowViewModel : ViewModelBase
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
         _integrationStatusService = new IntegrationStatusService();
+        _sourceDiscoveryService = new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
+        SourceImportProposals = new ObservableCollection<SourceImportProposal>();
         ApplyDesignSession(CreateDesignSession());
+        ApplyDesignSourceProposals();
         RefreshIntegrations();
     }
 
     public MainWindowViewModel(
         ProjectWorkspaceCoordinatorService coordinatorService,
-        IntegrationStatusService integrationStatusService)
+        IntegrationStatusService integrationStatusService,
+        ISourceDiscoveryService? sourceDiscoveryService = null)
     {
         _coordinatorService = coordinatorService;
         _integrationStatusService = integrationStatusService;
+        _sourceDiscoveryService = sourceDiscoveryService ?? new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
         Versions = new ObservableCollection<WorkspaceVersionCard>();
         AvailableItemTypes = new ObservableCollection<string>();
@@ -112,6 +122,7 @@ public partial class MainWindowViewModel : ViewModelBase
         TrustDiagnostics = new ObservableCollection<TrustDiagnosticCard>();
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
+        SourceImportProposals = new ObservableCollection<SourceImportProposal>();
 
         RefreshRecentProjects();
         RefreshSuggestedPaths();
@@ -139,10 +150,86 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public ObservableCollection<VersionSourceChangeDiagnostic> VersionSourceChangeDiagnostics { get; }
 
+    public ObservableCollection<SourceImportProposal> SourceImportProposals { get; }
+
+    public SourceImportProposal? SelectedSourceProposal
+    {
+        get => _selectedSourceProposal;
+        set
+        {
+            if (SetProperty(ref _selectedSourceProposal, value))
+            {
+                OnPropertyChanged(nameof(HasSelectedSourceProposal));
+            }
+        }
+    }
+
+    public bool HasSelectedSourceProposal => SelectedSourceProposal is not null;
+
+    public string SourceDiscoverySummary
+    {
+        get => _sourceDiscoverySummary;
+        private set => SetProperty(ref _sourceDiscoverySummary, value);
+    }
+
+    public string SourceDiscoveryWarnings
+    {
+        get => _sourceDiscoveryWarnings;
+        private set
+        {
+            if (SetProperty(ref _sourceDiscoveryWarnings, value))
+            {
+                OnPropertyChanged(nameof(HasSourceDiscoveryWarnings));
+            }
+        }
+    }
+
+    public bool HasSourceDiscoveryWarnings => !string.IsNullOrWhiteSpace(SourceDiscoveryWarnings);
+
+    public bool IsDiscoveringSources
+    {
+        get => _isDiscoveringSources;
+        private set
+        {
+            if (SetProperty(ref _isDiscoveringSources, value))
+            {
+                OnPropertyChanged(nameof(CanDiscoverSources));
+            }
+        }
+    }
+
+    public bool CanDiscoverSources =>
+        !IsDiscoveringSources && !string.IsNullOrWhiteSpace(LocalGitRepositoryPath);
+
+    public bool HasSourceProposals => SourceImportProposals.Count > 0;
+
+    public int ApprovedSourceProposalCount =>
+        SourceImportProposals.Count(static proposal => proposal.IsIncluded);
+
+    public string SourceApprovalSummary =>
+        HasSourceProposals
+            ? $"{ApprovedSourceProposalCount} of {SourceImportProposals.Count} proposals approved"
+            : "Nothing is queued for approval.";
+
+    public bool CanApplyApprovedSourceProposals =>
+        CanMutateWorkspace &&
+        ApprovedSourceProposalCount > 0 &&
+        SourceImportProposals
+            .Where(static proposal => proposal.IsIncluded)
+            .All(static proposal =>
+                proposal.TargetVersion is not null &&
+                !string.IsNullOrWhiteSpace(proposal.Title));
+
     public string LocalGitRepositoryPath
     {
         get => _localGitRepositoryPath;
-        set => SetProperty(ref _localGitRepositoryPath, value);
+        set
+        {
+            if (SetProperty(ref _localGitRepositoryPath, value))
+            {
+                OnPropertyChanged(nameof(CanDiscoverSources));
+            }
+        }
     }
 
     public string IntegrationMessage
@@ -333,7 +420,7 @@ public partial class MainWindowViewModel : ViewModelBase
             WorkspaceSection.Team => "Team and signing identities",
             WorkspaceSection.Sync => "Workspace exchange",
             WorkspaceSection.Trust => "Trust and audit",
-            WorkspaceSection.Integrations => "Connected systems",
+            WorkspaceSection.Integrations => "Source Lens",
             _ => "Project overview",
         };
 
@@ -345,7 +432,7 @@ public partial class MainWindowViewModel : ViewModelBase
             WorkspaceSection.Team => "Review signed membership and manage the people allowed to contribute.",
             WorkspaceSection.Sync => "Compare local and shared state before moving signed changes.",
             WorkspaceSection.Trust => "Inspect validation results, conflicts, and the audit boundary.",
-            WorkspaceSection.Integrations => "Connect source history without making a provider authoritative.",
+            WorkspaceSection.Integrations => "Discover project signals, shape editable proposals, and approve exactly what enters the signed blueprint.",
             _ => string.Empty,
         };
 
@@ -734,6 +821,36 @@ public partial class MainWindowViewModel : ViewModelBase
             _ => "Workspace is trusted and editable.",
         };
 
+    public string AdaptiveGuidanceTitle =>
+        !IsWorkspaceTrusted
+            ? "Review trust before editing"
+            : HasConflicts
+                ? $"Resolve {Conflicts.Count} sync conflict{(Conflicts.Count == 1 ? string.Empty : "s")}"
+                : Versions.Count == 0
+                    ? "Create the first release node"
+                    : HasSourceProposals
+                        ? $"Review {SourceImportProposals.Count} source proposals"
+                        : ItemCount == 0
+                            ? "Connect work to the selected release"
+                            : Sync.PendingOutgoingChanges > 0
+                                ? $"Review {Sync.PendingOutgoingChanges} outgoing changes"
+                                : "Shape the map around your next milestone";
+
+    public string AdaptiveGuidanceDetail =>
+        !IsWorkspaceTrusted
+            ? "Blueprints has disabled mutations to protect signed project truth."
+            : HasConflicts
+                ? "Choose local or shared content for every conflict before continuing."
+                : Versions.Count == 0
+                    ? "A version gives imported and manual work a deliberate destination."
+                    : HasSourceProposals
+                        ? "Edit titles, targets, types, and completion state before approving anything."
+                        : ItemCount == 0
+                            ? "Add work manually or open Source Lens to discover it from project signals."
+                            : Sync.PendingOutgoingChanges > 0
+                                ? "Your local signed workspace has changes that have not been shared."
+                                : "Drag nodes, inspect relationships, and make the release plan reflect reality.";
+
     [RelayCommand]
     private void NavigateToOverview() =>
         SelectedWorkspaceSection = WorkspaceSection.Overview;
@@ -1095,6 +1212,118 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private async Task DiscoverSources()
+    {
+        if (!CanDiscoverSources)
+        {
+            IntegrationMessage = "Link a local Git repository before scanning planning sources.";
+            return;
+        }
+
+        IsDiscoveringSources = true;
+        IntegrationMessage = "Reading changelogs, roadmaps, GitHub issues, and project links…";
+        try
+        {
+            var result = await Task.Run(() => _sourceDiscoveryService.Discover(LocalGitRepositoryPath));
+            PopulateSourceProposals(result);
+            IntegrationMessage = result.Candidates.Count == 0
+                ? "The scan completed, but no importable planning entries were found."
+                : "Discovery is complete. Review, edit, and approve proposals before applying them.";
+        }
+        catch (Exception exception)
+        {
+            SourceDiscoverySummary = "Discovery could not be completed.";
+            SourceDiscoveryWarnings = exception.Message;
+            IntegrationMessage = exception.Message;
+        }
+        finally
+        {
+            IsDiscoveringSources = false;
+        }
+    }
+
+    [RelayCommand]
+    private void ApproveAllSourceProposals()
+    {
+        foreach (var proposal in SourceImportProposals)
+        {
+            proposal.IsIncluded = true;
+        }
+
+        RefreshSourceApprovalState();
+    }
+
+    [RelayCommand]
+    private void ClearSourceProposalApprovals()
+    {
+        foreach (var proposal in SourceImportProposals)
+        {
+            proposal.IsIncluded = false;
+        }
+
+        RefreshSourceApprovalState();
+    }
+
+    [RelayCommand]
+    private void ApplyApprovedSourceProposals()
+    {
+        if (_coordinatorService is null || _currentSession is null)
+        {
+            IntegrationMessage = "Open a project before applying source proposals.";
+            return;
+        }
+
+        var approved = SourceImportProposals
+            .Where(static proposal => proposal.IsIncluded)
+            .ToArray();
+        if (approved.Length == 0)
+        {
+            IntegrationMessage = "Approve at least one proposal before applying.";
+            return;
+        }
+
+        if (approved.Any(static proposal =>
+                proposal.TargetVersion is null ||
+                string.IsNullOrWhiteSpace(proposal.Title)))
+        {
+            IntegrationMessage = "Every approved proposal needs a title and target version.";
+            return;
+        }
+
+        try
+        {
+            var request = new ApprovedSourceImportRequest(
+                approved
+                    .Select(static proposal => new ApprovedSourceImportItem(
+                        proposal.TargetVersion!.VersionId,
+                        proposal.ItemTypeId,
+                        proposal.CategoryId,
+                        proposal.Title,
+                        proposal.Description,
+                        proposal.IsDone,
+                        proposal.Kind,
+                        proposal.SourceReference))
+                    .ToArray());
+            ApplySession(
+                _coordinatorService.ApplyApprovedSourceImport(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    request));
+
+            SourceImportProposals.Clear();
+            SelectedSourceProposal = null;
+            SourceDiscoverySummary = $"{approved.Length} approved proposals were added as signed work items.";
+            SourceDiscoveryWarnings = string.Empty;
+            RefreshSourceApprovalState();
+            IntegrationMessage = $"Applied {approved.Length} approved proposals. No source system was modified.";
+        }
+        catch (Exception exception)
+        {
+            IntegrationMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
     private void PushWorkspace()
     {
         if (_coordinatorService is null || _currentSession is null)
@@ -1423,6 +1652,9 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(CanResolveSelectedConflict));
         OnPropertyChanged(nameof(HasSyncDiagnostics));
         OnPropertyChanged(nameof(HasTrustDiagnostics));
+        OnPropertyChanged(nameof(CanApplyApprovedSourceProposals));
+        OnPropertyChanged(nameof(AdaptiveGuidanceTitle));
+        OnPropertyChanged(nameof(AdaptiveGuidanceDetail));
         RefreshVersionSourceChangeDiagnostics();
     }
 
@@ -1450,6 +1682,10 @@ public partial class MainWindowViewModel : ViewModelBase
         SyncDiagnostics.Clear();
         TrustDiagnostics.Clear();
         VersionSourceChangeDiagnostics.Clear();
+        SourceImportProposals.Clear();
+        SelectedSourceProposal = null;
+        SourceDiscoverySummary = "Connect a repository, then scan its planning sources.";
+        SourceDiscoveryWarnings = string.Empty;
         SelectedVersion = null;
         SelectedItem = null;
         SelectedMember = null;
@@ -1486,6 +1722,7 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(HasSyncDiagnostics));
         OnPropertyChanged(nameof(HasTrustDiagnostics));
         OnPropertyChanged(nameof(VersionSourceChangeSummary));
+        RefreshSourceApprovalState();
     }
 
     private void ApplyDesignSession(LocalWorkspaceSession session)
@@ -1524,6 +1761,108 @@ public partial class MainWindowViewModel : ViewModelBase
         }
 
         RefreshVersionSourceChangeDiagnostics();
+    }
+
+    private void PopulateSourceProposals(SourceDiscoveryResult result)
+    {
+        SourceImportProposals.Clear();
+        var targetVersion = SelectedVersion is { Status: not ReleaseStatus.Frozen and not ReleaseStatus.Released }
+            ? SelectedVersion
+            : Versions.FirstOrDefault(static version =>
+                version.Status is not ReleaseStatus.Frozen and not ReleaseStatus.Released);
+        var existingTitles = Versions
+            .SelectMany(static version => version.Items)
+            .Select(static item => NormalizeComparableTitle(item.Title))
+            .ToHashSet(StringComparer.Ordinal);
+        var defaultItemType = AvailableItemTypes.FirstOrDefault() ?? "feature";
+        var defaultCategory = AvailableCategories.FirstOrDefault() ?? "added";
+
+        foreach (var candidate in result.Candidates)
+        {
+            var compatibleCandidate = candidate with
+            {
+                SuggestedItemTypeId = AvailableItemTypes.Contains(candidate.SuggestedItemTypeId)
+                    ? candidate.SuggestedItemTypeId
+                    : defaultItemType,
+                SuggestedCategoryId = AvailableCategories.Contains(candidate.SuggestedCategoryId)
+                    ? candidate.SuggestedCategoryId
+                    : defaultCategory,
+            };
+            var proposal = new SourceImportProposal(
+                compatibleCandidate,
+                targetVersion,
+                existingTitles.Contains(NormalizeComparableTitle(candidate.Title)));
+            proposal.PropertyChanged += SourceProposalPropertyChanged;
+            SourceImportProposals.Add(proposal);
+        }
+
+        SelectedSourceProposal = SourceImportProposals.FirstOrDefault();
+        SourceDiscoverySummary = result.Summary;
+        SourceDiscoveryWarnings = string.Join(Environment.NewLine, result.Warnings);
+        RefreshSourceApprovalState();
+    }
+
+    private void SourceProposalPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs eventArgs) =>
+        RefreshSourceApprovalState();
+
+    private void RefreshSourceApprovalState()
+    {
+        OnPropertyChanged(nameof(HasSourceProposals));
+        OnPropertyChanged(nameof(ApprovedSourceProposalCount));
+        OnPropertyChanged(nameof(SourceApprovalSummary));
+        OnPropertyChanged(nameof(CanApplyApprovedSourceProposals));
+        OnPropertyChanged(nameof(AdaptiveGuidanceTitle));
+        OnPropertyChanged(nameof(AdaptiveGuidanceDetail));
+    }
+
+    private static string NormalizeComparableTitle(string title) =>
+        string.Join(
+            ' ',
+            title.Trim()
+                .ToUpperInvariant()
+                .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    private void ApplyDesignSourceProposals()
+    {
+        PopulateSourceProposals(
+            new SourceDiscoveryResult(
+                [
+                    new SourceDiscoveryCandidate(
+                        SourceArtifactKind.GitHubProject,
+                        "Interactive dependency map",
+                        "Let users connect work visually and reveal release blockers.",
+                        "feature",
+                        "added",
+                        false,
+                        "github:#42",
+                        "Project: Canvas engine · Milestone: 0.2.0",
+                        0.97),
+                    new SourceDiscoveryCandidate(
+                        SourceArtifactKind.Roadmap,
+                        "Add undo and redo history",
+                        "Imported from section “Canvas interaction”.",
+                        "feature",
+                        "added",
+                        false,
+                        "roadmap:Roadmap.md:88",
+                        "Canvas interaction",
+                        0.94),
+                    new SourceDiscoveryCandidate(
+                        SourceArtifactKind.Changelog,
+                        "Signed shared canvas layouts",
+                        "Imported from section “Unreleased”.",
+                        "feature",
+                        "changed",
+                        true,
+                        "changelog:CHANGELOG.md:12",
+                        "Unreleased",
+                        0.82),
+                ],
+                [],
+                1,
+                1,
+                1,
+                1));
     }
 
     private IReadOnlyList<SourceChangeSummary> GetLocalGitRecentChanges() =>

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -4,75 +4,213 @@
              xmlns:models="using:Blueprints.App.Models"
              x:Class="Blueprints.App.Views.Components.IntegrationsView"
              x:DataType="vm:MainWindowViewModel">
-  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="14">
-    <Border Classes="card">
-      <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="10">
-        <StackPanel Margin="0,0,10,0" VerticalAlignment="Center">
-          <TextBlock Classes="eyebrow" Text="LOCAL SOURCE" />
-          <TextBlock Text="Git repository" FontWeight="Bold" />
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="12">
+    <Border Background="#082941" BorderBrush="#2A698A" BorderThickness="1" CornerRadius="8" Padding="18">
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="20">
+        <StackPanel Spacing="6">
+          <TextBlock Text="SOURCE LENS" Foreground="#68D5EF" FontSize="11" FontWeight="Bold" LetterSpacing="1.6" />
+          <TextBlock Text="Turn project signals into an editable blueprint" Foreground="White" FontSize="22" FontWeight="Black" />
+          <TextBlock Text="Blueprints reads local planning files and GitHub metadata. Every result remains a draft until you edit and approve it."
+                     Foreground="#B5D4E3"
+                     TextWrapping="Wrap"
+                     MaxWidth="760" />
         </StackPanel>
-        <TextBox Grid.Column="1" Text="{Binding LocalGitRepositoryPath}" PlaceholderText="/path/to/repository" />
-        <Button Grid.Column="2" Classes="primary" Content="Save connection" Command="{Binding SaveLocalGitRepositoryPathCommand}" />
-        <Button Grid.Column="3" Classes="secondary" Content="Refresh all" Command="{Binding RefreshIntegrationStatusesCommand}" />
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+          <Button Classes="tool"
+                  Content="Refresh health"
+                  Command="{Binding RefreshIntegrationStatusesCommand}" />
+          <Button Classes="primary"
+                  Content="Scan sources"
+                  Command="{Binding DiscoverSourcesCommand}"
+                  IsEnabled="{Binding CanDiscoverSources}" />
+        </StackPanel>
       </Grid>
     </Border>
 
-    <Border Grid.Row="1" Background="#E8F4FA" BorderBrush="#9AC7DE" BorderThickness="1,0,0,0" Padding="12,9">
-      <TextBlock Text="{Binding IntegrationMessage}" Foreground="#214A64" TextWrapping="Wrap" />
-    </Border>
+    <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+      <Border Classes="card" Padding="12,8">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <TextBlock Text="REPOSITORY" Classes="eyebrow" VerticalAlignment="Center" />
+          <TextBlock Text="read-only" Foreground="#277A67" FontSize="11" FontWeight="Bold" VerticalAlignment="Center" />
+        </StackPanel>
+      </Border>
+      <TextBox Grid.Column="1"
+               Text="{Binding LocalGitRepositoryPath}"
+               PlaceholderText="/path/to/repository" />
+      <Button Grid.Column="2"
+              Classes="secondary"
+              Content="Save link"
+              Command="{Binding SaveLocalGitRepositoryPathCommand}" />
+    </Grid>
 
-    <ListBox Grid.Row="2" ItemsSource="{Binding Integrations}">
-      <ListBox.ItemsPanel>
-        <ItemsPanelTemplate>
-          <WrapPanel />
-        </ItemsPanelTemplate>
-      </ListBox.ItemsPanel>
-      <ListBox.ItemTemplate>
-        <DataTemplate x:DataType="models:IntegrationStatusCard">
-          <Border Classes="card" Width="500" MinHeight="250" Margin="0,0,12,12">
-            <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="10">
+    <Grid Grid.Row="2" ColumnDefinitions="390,*" ColumnSpacing="12">
+      <Border Classes="card" Padding="0">
+        <Grid RowDefinitions="Auto,Auto,*,Auto">
+          <Border Padding="15,13" BorderBrush="#D1E4EE" BorderThickness="0,0,0,1">
+            <StackPanel Spacing="3">
               <Grid ColumnDefinitions="*,Auto">
-                <StackPanel Spacing="3">
-                  <TextBlock Classes="eyebrow" Text="{Binding Provider}" />
-                  <TextBlock Text="{Binding DisplayName}" FontSize="21" FontWeight="Bold" />
-                </StackPanel>
-                <Border Grid.Column="1" Background="#DDEFF8" CornerRadius="12" Padding="10,4" VerticalAlignment="Top">
-                  <TextBlock Text="{Binding State}" Foreground="#0B4F8A" FontSize="12" FontWeight="Bold" />
+                <TextBlock Text="Proposal inbox" FontSize="17" FontWeight="Bold" />
+                <Border Grid.Column="1" Background="#E1F2F8" CornerRadius="10" Padding="8,3">
+                  <TextBlock Text="{Binding SourceImportProposals.Count}" Foreground="#0B5D8B" FontWeight="Bold" FontSize="11" />
                 </Border>
               </Grid>
+              <TextBlock Text="{Binding SourceDiscoverySummary}" Classes="muted" FontSize="11" TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
 
-              <StackPanel Grid.Row="1" Spacing="3">
-                <TextBlock Text="{Binding Target}" Classes="mono" FontWeight="Bold" TextWrapping="Wrap" />
-                <TextBlock Text="{Binding CheckedAtSummary}" Classes="muted" FontSize="11" />
+          <Border Grid.Row="1"
+                  Background="#FFF7E6"
+                  BorderBrush="#E8C97B"
+                  BorderThickness="0,0,0,1"
+                  Padding="12,8"
+                  IsVisible="{Binding HasSourceDiscoveryWarnings}">
+            <TextBlock Text="{Binding SourceDiscoveryWarnings}" Foreground="#725315" FontSize="11" TextWrapping="Wrap" />
+          </Border>
+
+          <ListBox Grid.Row="2"
+                   ItemsSource="{Binding SourceImportProposals}"
+                   SelectedItem="{Binding SelectedSourceProposal}"
+                   Background="#F7FBFD">
+            <ListBox.ItemTemplate>
+              <DataTemplate x:DataType="models:SourceImportProposal">
+                <Border Background="White"
+                        BorderBrush="#D3E5EE"
+                        BorderThickness="0,0,0,1"
+                        Padding="12">
+                  <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                    <CheckBox IsChecked="{Binding IsIncluded}" VerticalAlignment="Top" />
+                    <StackPanel Grid.Column="1" Spacing="4">
+                      <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{Binding Kind}" Classes="eyebrow" FontSize="9" />
+                        <TextBlock Grid.Column="1" Text="{Binding ConfidenceSummary}" Foreground="#277A67" FontSize="10" />
+                      </Grid>
+                      <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextWrapping="Wrap" MaxLines="2" />
+                      <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{Binding SourceContext}" Classes="muted" FontSize="10" TextTrimming="CharacterEllipsis" />
+                        <TextBlock Grid.Column="1" Text="{Binding DuplicateSummary}" Foreground="#A56B00" FontSize="10" />
+                      </Grid>
+                    </StackPanel>
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+
+          <Border Grid.Row="3" Background="#EDF6FA" BorderBrush="#D1E4EE" BorderThickness="0,1,0,0" Padding="12">
+            <StackPanel Spacing="8">
+              <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Text="{Binding SourceApprovalSummary}" FontWeight="Bold" FontSize="11" VerticalAlignment="Center" />
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="5">
+                  <Button Classes="compact secondary" Content="All" Command="{Binding ApproveAllSourceProposalsCommand}" />
+                  <Button Classes="compact secondary" Content="None" Command="{Binding ClearSourceProposalApprovalsCommand}" />
+                </StackPanel>
+              </Grid>
+              <Button Classes="primary"
+                      Content="Apply approved to blueprint"
+                      Command="{Binding ApplyApprovedSourceProposalsCommand}"
+                      IsEnabled="{Binding CanApplyApprovedSourceProposals}" />
+            </StackPanel>
+          </Border>
+        </Grid>
+      </Border>
+
+      <Border Grid.Column="1" Classes="card" Padding="0">
+        <Grid RowDefinitions="Auto,*,Auto">
+          <Border Padding="17,13" Background="#F1F8FB" BorderBrush="#D1E4EE" BorderThickness="0,0,0,1">
+            <Grid ColumnDefinitions="*,Auto">
+              <StackPanel Spacing="2">
+                <TextBlock Text="REVIEW + SHAPE" Classes="eyebrow" />
+                <TextBlock Text="You own the final blueprint" FontSize="17" FontWeight="Bold" />
+              </StackPanel>
+              <Border Grid.Column="1" Background="#DFF4ED" CornerRadius="12" Padding="9,4" VerticalAlignment="Center">
+                <TextBlock Text="No automatic writes" Foreground="#277A67" FontSize="11" FontWeight="Bold" />
+              </Border>
+            </Grid>
+          </Border>
+
+          <ScrollViewer Grid.Row="1">
+            <StackPanel Margin="18" Spacing="14">
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="3">
+                  <TextBlock Text="{Binding SelectedSourceProposal.Kind}" Classes="eyebrow" />
+                  <TextBlock Text="{Binding SelectedSourceProposal.SourceReference}" Classes="mono muted" FontSize="10" />
+                </StackPanel>
+                <CheckBox Grid.Column="1"
+                          Content="Approved"
+                          IsChecked="{Binding SelectedSourceProposal.IsIncluded}"
+                          VerticalAlignment="Center" />
+              </Grid>
+
+              <StackPanel Spacing="5">
+                <TextBlock Text="Title" FontWeight="Bold" FontSize="11" />
+                <TextBox Text="{Binding SelectedSourceProposal.Title}" PlaceholderText="Proposal title" />
               </StackPanel>
 
-              <StackPanel Grid.Row="2" Spacing="7">
-                <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
-                <TextBlock Text="{Binding Guidance}" Classes="muted" TextWrapping="Wrap" />
-                <TextBlock Text="{Binding RecentChangeSummary}" FontWeight="Bold" />
-                <ItemsControl ItemsSource="{Binding RecentChanges}">
+              <StackPanel Spacing="5">
+                <TextBlock Text="Context and release-note detail" FontWeight="Bold" FontSize="11" />
+                <TextBox Text="{Binding SelectedSourceProposal.Description}"
+                         AcceptsReturn="True"
+                         Height="112"
+                         PlaceholderText="Add the context humans need to understand this work." />
+              </StackPanel>
+
+              <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                <StackPanel Spacing="5">
+                  <TextBlock Text="Target version" FontWeight="Bold" FontSize="11" />
+                  <ComboBox ItemsSource="{Binding Versions}"
+                            SelectedItem="{Binding SelectedSourceProposal.TargetVersion}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="models:WorkspaceVersionCard">
+                        <TextBlock Text="{Binding Name}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="5">
+                  <TextBlock Text="Work type" FontWeight="Bold" FontSize="11" />
+                  <ComboBox ItemsSource="{Binding AvailableItemTypes}"
+                            SelectedItem="{Binding SelectedSourceProposal.ItemTypeId}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Spacing="5">
+                  <TextBlock Text="Changelog group" FontWeight="Bold" FontSize="11" />
+                  <ComboBox ItemsSource="{Binding AvailableCategories}"
+                            SelectedItem="{Binding SelectedSourceProposal.CategoryId}" />
+                </StackPanel>
+              </Grid>
+
+              <CheckBox Content="Mark completed"
+                        IsChecked="{Binding SelectedSourceProposal.IsDone}" />
+
+              <Border Background="#ECF7FB" BorderBrush="#B9DCEB" BorderThickness="1" CornerRadius="6" Padding="12">
+                <StackPanel Spacing="4">
+                  <TextBlock Text="WHY BLUEPRINTS SUGGESTED THIS" Classes="eyebrow" />
+                  <TextBlock Text="{Binding SelectedSourceProposal.SourceContext}" TextWrapping="Wrap" />
+                  <TextBlock Text="{Binding SelectedSourceProposal.ConfidenceSummary}" Foreground="#277A67" FontWeight="Bold" FontSize="11" />
+                </StackPanel>
+              </Border>
+
+              <StackPanel Spacing="8">
+                <TextBlock Text="Connection health" Classes="eyebrow" />
+                <ItemsControl ItemsSource="{Binding Integrations}">
                   <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="models:SourceChangeSummary">
-                      <Grid ColumnDefinitions="72,*,110" ColumnSpacing="8" Margin="0,3,0,0">
-                        <TextBlock Classes="mono muted" Text="{Binding ShortHash}" />
-                        <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
-                        <TextBlock Grid.Column="2" Text="{Binding ItemKeySummary}" Classes="muted" />
+                    <DataTemplate x:DataType="models:IntegrationStatusCard">
+                      <Grid ColumnDefinitions="120,110,*" ColumnSpacing="10" Margin="0,3">
+                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
+                        <TextBlock Grid.Column="1" Text="{Binding State}" Foreground="#0B5D8B" />
+                        <TextBlock Grid.Column="2" Text="{Binding Summary}" Classes="muted" TextTrimming="CharacterEllipsis" />
                       </Grid>
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
                 </ItemsControl>
               </StackPanel>
+            </StackPanel>
+          </ScrollViewer>
 
-              <Border Grid.Row="3" Background="#F1F8FC" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="10">
-                <StackPanel Spacing="3">
-                  <TextBlock Classes="eyebrow" Text="AUTHORITY BOUNDARY" />
-                  <TextBlock Text="{Binding TrustBoundary}" Foreground="#214A64" TextWrapping="Wrap" FontSize="12" />
-                </StackPanel>
-              </Border>
-            </Grid>
+          <Border Grid.Row="2" Background="#082941" Padding="14,10">
+            <TextBlock Text="{Binding IntegrationMessage}" Foreground="#C9E4EF" TextWrapping="Wrap" />
           </Border>
-        </DataTemplate>
-      </ListBox.ItemTemplate>
-    </ListBox>
+        </Grid>
+      </Border>
+    </Grid>
   </Grid>
 </UserControl>

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -28,11 +28,16 @@
           <Button Classes="tool" Content="Fit view" Click="FitViewClick" />
           <Button Classes="tool" Content="Auto arrange" Click="AutoArrangeClick" IsEnabled="{Binding CanMutateWorkspace}" />
           <Button Classes="tool" Content="Save layout" Click="SaveLayoutClick" IsEnabled="{Binding CanMutateWorkspace}" />
+          <Button Classes="tool" Content="⌁ Source lens" Command="{Binding NavigateToIntegrationsCommand}" />
         </StackPanel>
 
         <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-          <Border Background="#0C3859" BorderBrush="#2E6A8D" BorderThickness="1" CornerRadius="12" Padding="9,4">
-            <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#B9D7E7" FontSize="11" TextTrimming="CharacterEllipsis" MaxWidth="330" />
+          <Border Background="#0C3859" BorderBrush="#2E6A8D" BorderThickness="1" CornerRadius="6" Padding="10,4"
+                  ToolTip.Tip="{Binding AdaptiveGuidanceDetail}">
+            <StackPanel MaxWidth="300">
+              <TextBlock Text="NEXT BEST ACTION" Foreground="#60D1ED" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
+              <TextBlock Text="{Binding AdaptiveGuidanceTitle}" Foreground="#E4F3F8" FontSize="11" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
+            </StackPanel>
           </Border>
           <Button Classes="tool" Content="↻ Refresh" Command="{Binding RefreshWorkspaceCommand}" />
         </StackPanel>

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -78,31 +78,30 @@
 
     <views:SetupView Grid.Row="1" IsVisible="{Binding IsSetupMode}" />
 
-    <Grid Grid.Row="1" ColumnDefinitions="74,*" IsVisible="{Binding HasActiveSession}">
+    <Grid Grid.Row="1" ColumnDefinitions="184,*" IsVisible="{Binding HasActiveSession}">
       <Border Background="#061C30" BorderBrush="#285A78" BorderThickness="0,0,1,0">
         <Grid RowDefinitions="Auto,*,Auto">
-          <Border Margin="10,12" Height="48" Background="#0D4166" BorderBrush="#5CCBE8" BorderThickness="1" CornerRadius="4">
-            <StackPanel VerticalAlignment="Center">
-              <TextBlock Text="{Binding CurrentProject.Code}" Classes="mono" Foreground="White" FontWeight="Black" HorizontalAlignment="Center" />
-              <TextBlock Text="MAP" Classes="mono" Foreground="#6DD6EF" FontSize="8" HorizontalAlignment="Center" />
+          <Border Margin="12" Padding="12,10" Background="#0D4166" BorderBrush="#5CCBE8" BorderThickness="1" CornerRadius="6">
+            <StackPanel>
+              <TextBlock Text="{Binding CurrentProject.Code}" Classes="mono" Foreground="White" FontWeight="Black" />
+              <TextBlock Text="{Binding CurrentProject.Name}" Foreground="#A9D4E5" FontSize="10" TextTrimming="CharacterEllipsis" />
             </StackPanel>
           </Border>
 
-          <StackPanel Grid.Row="1" Spacing="7" Margin="8,8">
-            <Button Classes="rail" Classes.active="{Binding IsOverviewSelected}" Content="⌘" ToolTip.Tip="Canvas" Command="{Binding NavigateToOverviewCommand}" />
-            <Button Classes="rail" Classes.active="{Binding IsReleasesSelected}" Content="V" ToolTip.Tip="Versions and releases" Command="{Binding NavigateToReleasesCommand}" />
-            <Button Classes="rail" Classes.active="{Binding IsTeamSelected}" Content="P" ToolTip.Tip="People and identities" Command="{Binding NavigateToTeamCommand}" />
-            <Button Classes="rail" Classes.active="{Binding IsSyncSelected}" Content="⇄" ToolTip.Tip="Sync exchange" Command="{Binding NavigateToSyncCommand}" />
-            <Button Classes="rail" Classes.active="{Binding IsTrustSelected}" Content="◇" ToolTip.Tip="Trust and audit" Command="{Binding NavigateToTrustCommand}" />
-            <Button Classes="rail" Classes.active="{Binding IsIntegrationsSelected}" Content="⌁" ToolTip.Tip="Integrations" Command="{Binding NavigateToIntegrationsCommand}" />
+          <StackPanel Grid.Row="1" Spacing="3" Margin="10,8">
+            <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Content="⌘  Blueprint map" Command="{Binding NavigateToOverviewCommand}" />
+            <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Content="⌁  Source lens" Command="{Binding NavigateToIntegrationsCommand}" />
+            <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Content="V  Releases" Command="{Binding NavigateToReleasesCommand}" />
+            <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Content="P  People" Command="{Binding NavigateToTeamCommand}" />
+            <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Content="⇄  Sync" Command="{Binding NavigateToSyncCommand}" />
+            <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Content="◇  Trust" Command="{Binding NavigateToTrustCommand}" />
           </StackPanel>
 
           <Button Grid.Row="2"
-                  Classes="rail"
-                  Content="←"
-                  ToolTip.Tip="Switch project"
+                  Classes="nav"
+                  Content="←  Switch project"
                   Command="{Binding ReturnToProjectSetupCommand}"
-                  Margin="8,0,8,12" />
+                  Margin="10,0,10,12" />
         </Grid>
       </Border>
 

--- a/Blueprints.Tests/MainWindowNavigationTests.cs
+++ b/Blueprints.Tests/MainWindowNavigationTests.cs
@@ -79,4 +79,24 @@ public sealed class MainWindowNavigationTests
         Assert.Empty(viewModel.ItemEditorTitle);
         Assert.Contains(version.Name, viewModel.WorkspaceMessage, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void SourceProposalCommands_KeepApprovalUnderUserControl()
+    {
+        var viewModel = new MainWindowViewModel();
+
+        Assert.Equal(3, viewModel.SourceImportProposals.Count);
+        Assert.Equal(3, viewModel.ApprovedSourceProposalCount);
+        Assert.Contains("source proposals", viewModel.AdaptiveGuidanceTitle, StringComparison.OrdinalIgnoreCase);
+
+        viewModel.ClearSourceProposalApprovalsCommand.Execute(null);
+
+        Assert.Equal(0, viewModel.ApprovedSourceProposalCount);
+        Assert.False(viewModel.CanApplyApprovedSourceProposals);
+
+        viewModel.ApproveAllSourceProposalsCommand.Execute(null);
+
+        Assert.Equal(3, viewModel.ApprovedSourceProposalCount);
+        Assert.True(viewModel.CanApplyApprovedSourceProposals);
+    }
 }

--- a/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
+++ b/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
@@ -1,0 +1,123 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "SourceDiscovery",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ParseRoadmap_MapsCheckboxStateAndContext()
+    {
+        var path = Write(
+            "Roadmap.md",
+            """
+            # Roadmap
+            ## Canvas interaction
+            - [ ] Add undo and redo
+            - [x] Fix selection crash
+            """);
+
+        var candidates = new MarkdownSourceDiscoveryParser().Parse(path, SourceArtifactKind.Roadmap);
+
+        Assert.Collection(
+            candidates,
+            first =>
+            {
+                Assert.Equal("Add undo and redo", first.Title);
+                Assert.False(first.IsDone);
+                Assert.Equal("feature", first.SuggestedItemTypeId);
+                Assert.Equal("Canvas interaction", first.SourceContext);
+            },
+            second =>
+            {
+                Assert.True(second.IsDone);
+                Assert.Equal("bug", second.SuggestedItemTypeId);
+                Assert.Equal("fixed", second.SuggestedCategoryId);
+            });
+    }
+
+    [Fact]
+    public void ParseChangelog_MapsSecurityAndCompletedState()
+    {
+        var path = Write(
+            "CHANGELOG.md",
+            """
+            # Changelog
+            ## Security
+            - Harden signature validation
+            """);
+
+        var candidate = Assert.Single(
+            new MarkdownSourceDiscoveryParser().Parse(path, SourceArtifactKind.Changelog));
+
+        Assert.True(candidate.IsDone);
+        Assert.Equal("security", candidate.SuggestedItemTypeId);
+        Assert.Equal("security", candidate.SuggestedCategoryId);
+        Assert.StartsWith("changelog:", candidate.SourceReference, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_NormalizesMarkdownLinksAndCode()
+    {
+        var path = Write(
+            "Roadmap.md",
+            """
+            ## Sources
+            - [ ] Add [`GitHub`](https://github.com) ingestion.
+            """);
+
+        var candidate = Assert.Single(
+            new MarkdownSourceDiscoveryParser().Parse(path, SourceArtifactKind.Roadmap));
+
+        Assert.Equal("Add GitHub ingestion", candidate.Title);
+    }
+
+    [Fact]
+    public void Discover_ReturnsLocalSourcesWhenGitHubIsUnavailable()
+    {
+        Write(
+            "CHANGELOG.md",
+            """
+            ## Added
+            - Signed import review
+            """);
+        Write(
+            "Roadmap.md",
+            """
+            ## Next
+            - [ ] Add provider-neutral references
+            """);
+
+        var result = new RepositorySourceDiscoveryService().Discover(_root);
+
+        Assert.Equal(2, result.Candidates.Count);
+        Assert.Equal(1, result.ChangelogCount);
+        Assert.Equal(1, result.RoadmapCount);
+        Assert.Equal(0, result.GitHubIssueCount);
+        Assert.Contains(
+            result.Warnings,
+            static warning => warning.Contains("GitHub", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private string Write(string name, string content)
+    {
+        Directory.CreateDirectory(_root);
+        var path = Path.Combine(_root, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -755,6 +755,105 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Equal(TrustState.Trusted, refreshed.LoadResult.TrustReport.State);
     }
 
+    [Fact]
+    public void ApplyApprovedSourceImport_CreatesSignedItemsWithProvenanceInOneAuditAction()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "source-import-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "source-import-shared", "BP");
+        var service = CreateService();
+        service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "0.2.0", ReleaseStatus.InProgress, null));
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
+
+        var updated = service.ApplyApprovedSourceImport(
+            localRoot,
+            sharedRoot,
+            new ApprovedSourceImportRequest(
+                [
+                    new ApprovedSourceImportItem(
+                        versionId,
+                        "feature",
+                        "added",
+                        "Visualize GitHub issues",
+                        "Approval-first source ingestion.",
+                        false,
+                        SourceArtifactKind.GitHubIssue,
+                        "github:#42"),
+                    new ApprovedSourceImportItem(
+                        versionId,
+                        "bug",
+                        "fixed",
+                        "Repair roadmap parsing",
+                        null,
+                        true,
+                        SourceArtifactKind.Roadmap,
+                        "roadmap:Roadmap.md:18"),
+                ]));
+
+        var items = updated.LoadResult.Workspace.Versions.Single().Items;
+        Assert.Equal(2, items.Count);
+        Assert.Contains(items, static item =>
+            item.Title == "Visualize GitHub issues" &&
+            item.Tags.Contains("source-import") &&
+            item.Tags.Contains("source:githubissue") &&
+            item.Tags.Contains("github:#42"));
+        Assert.Contains(items, static item => item.ItemKey.StartsWith("BUG-", StringComparison.Ordinal));
+
+        var auditEntries = Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json");
+        Assert.Single(
+            auditEntries,
+            path => File.ReadAllText(path)
+                .Contains("\"operation\":\"source.import.apply\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApplyApprovedSourceImport_RejectsUnknownProjectTaxonomy()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "source-invalid-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "source-invalid-shared", "BP");
+        var service = CreateService();
+        service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "0.2.0", ReleaseStatus.InProgress, null));
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => service.ApplyApprovedSourceImport(
+                localRoot,
+                sharedRoot,
+                new ApprovedSourceImportRequest(
+                    [
+                        new ApprovedSourceImportItem(
+                            versionId,
+                            "unknown",
+                            "added",
+                            "Invalid proposal",
+                            null,
+                            false,
+                            SourceArtifactKind.Roadmap,
+                            "roadmap:Roadmap.md:1"),
+                    ])));
+
+        Assert.Contains("not configured", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private ProjectWorkspaceCoordinatorService CreateService()
     {
         var identityRoot = Path.Combine(_rootDirectory, "identities");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Machine-local canvas zoom and viewport persistence that cannot create audit noise or collaboration conflicts.
 - Canvas-engine and troubleshooting documentation covering behavior, format, security, compatibility, conflicts, and recovery.
 - Native folder pickers for project creation and opening.
+- Source Lens discovery for changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
+- Editable proposal review with duplicate warnings, provenance, confidence, target-version selection, and explicit batch approval.
+- Adaptive next-action guidance based on workspace trust, conflicts, release state, source proposals, and sync status.
 
 ### Changed
 
 - Upgraded the application to .NET 10 LTS, Avalonia 12.1.1, and the latest stable direct dependencies.
 - Replaced the dashboard-style overview and wide navigation sidebar with a hands-on canvas, contextual inspector, compact tool rail, and focused secondary workspaces.
+- Reworked secondary navigation into a readable workflow rail and promoted source discovery from passive status cards to an approval-first workspace.
 - Made command feedback visible across the active workspace.
 - Clarified local-workspace and shared-exchange terminology.
 - Moved superseded planning and handoff documents into `docs/archive`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Release notes often live in scattered issues, commit messages, and private docum
 - generate stable human-readable item keys;
 - freeze and release versions with immutable released content;
 - export Markdown changelogs, optionally enriched by local Git history;
+- discover changelog, roadmap, GitHub issue, and Project signals as editable approval-first proposals;
 - validate signed project files and enter read-only mode when trust breaks;
 - exchange signed changes through a shared folder with explicit push, pull, and conflict resolution;
 - inspect membership, audit history, sync state, and integration boundaries in one desktop app.
@@ -43,7 +44,8 @@ Release notes often live in scattered issues, commit messages, and private docum
 | Shared-folder push/pull | Working foundation |
 | Conflict and audit diagnostics | Functional, needs UX polish |
 | Local Git awareness | Read-only integration available |
-| GitHub, GitLab, and VaultSync adapters | Planned |
+| Changelog, roadmap, and GitHub issue discovery | Working, explicit approval required |
+| Full GitHub, GitLab, and VaultSync adapters | Planned |
 | Installers and supported releases | Not ready |
 
 The canonical delivery plan is [ROADMAP.md](Roadmap.md). Older planning files remain as design history and are not the active backlog.
@@ -91,6 +93,7 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 - [Documentation index](docs/README.md)
 - [User guide](docs/user-guide.md)
 - [Canvas engine](docs/canvas-engine.md)
+- [Source Lens](docs/source-lens.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](docs/architecture.md)
 - [Workspace format](docs/workspace-format.md)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -22,6 +22,8 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Move the supported runtime to .NET 10 LTS and Avalonia 12.
 - [x] Make the primary workspace a draggable, diagram-first blueprint canvas backed by real version and item relationships.
 - [x] Persist, sign, audit, sync, validate, and restore shared node positions while keeping viewport preferences machine-local.
+- [x] Add approval-first Source Lens discovery for changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
+- [x] Replace icon-only navigation with a clear workflow rail and adaptive next-action guidance.
 - [ ] Add undo/redo, box selection, multi-select, keyboard movement, alignment guides, and a minimap.
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
@@ -69,7 +71,10 @@ Goal: connect release intent to source history without weakening local ownership
 - [ ] Link a Blueprints project to one or more repositories.
 - [ ] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [ ] Define provider-neutral issue, pull-request, and release references.
-- [ ] Add a read-only GitHub adapter, then carefully scope write operations.
+- [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
+- [ ] Replace the CLI-backed reader with a provider-neutral authenticated adapter and add pull-request/release references.
+- [ ] Add standalone GitHub Project draft-item discovery.
+- [ ] Define and separately approve any future provider write operations.
 - [ ] Add GitLab parity after the provider contract stabilizes.
 
 Exit criteria:

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use this directory as the canonical technical and user documentation.
 | --- | --- |
 | Trying the app | [User guide](user-guide.md) |
 | Understanding the visual workspace | [Canvas engine](canvas-engine.md) |
+| Importing issues and planning files | [Source Lens](source-lens.md) |
 | Diagnosing a problem | [Troubleshooting](troubleshooting.md) |
 | Building or contributing | [Development guide](development.md) |
 | Understanding the code | [Architecture](architecture.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,19 @@ There is no dependency-injection container. Constructor composition keeps the cu
 
 Zoom and scroll offsets follow a separate local-preference flow: validate bounded values, atomically replace `.blueprints/canvas-view.json`, and never include it in signatures, audit entries, manifests, or exchange analysis.
 
+### Source discovery and approval
+
+1. Resolve the linked local Git worktree.
+2. Parse bounded changelog and roadmap Markdown locally.
+3. Resolve a GitHub origin and query issue/project metadata through the authenticated `gh` CLI when available.
+4. Normalize source entries into transient `SourceDiscoveryCandidate` values.
+5. Present editable `SourceImportProposal` values and flag exact-title duplicates.
+6. Require the user to choose inclusion, target version, type, category, title, description, and completion state.
+7. Validate every approved proposal against the current trusted workspace before changing disk.
+8. Write the approved batch as signed item documents and append one signed `source.import.apply` audit entry.
+
+Discovery never mutates the repository, provider, or Blueprints workspace. Provider data remains an input suggestion and never becomes authoritative without the explicit apply action.
+
 ### Push
 
 1. Build local and shared snapshots.
@@ -100,6 +113,7 @@ Zoom and scroll offsets follow a separate local-preference flow: validate bounde
 - Hosted providers cannot become authoritative for signed project truth.
 - Local-only integration credentials and paths stay outside project files.
 - Canvas layout is shared signed presentation state; version and item documents remain authoritative content.
+- Source-discovery proposals are transient and untrusted; only reviewed, approved, signed Blueprints items become project truth.
 
 ## Known structural debt
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -20,6 +20,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 | Shared sync root | Untrusted exchange input until manifest and signatures validate |
 | Local identity directory | Sensitive local state protected by OS permissions and key protection |
 | Git/provider integration | Informational; not authoritative project truth |
+| Source Lens proposals | Untrusted transient suggestions; no persistence before explicit approval |
 | UI input | Validated by application workflows before persistence |
 | Canvas layout | Signed shared node positions; entity references and coordinate bounds validated before rendering or saving |
 | Canvas viewport | Unsigned machine-local preference; bounded and excluded from sync and trust decisions |
@@ -46,6 +47,9 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Canvas coordinates, node count, project identity, schema, and uniqueness are bounded and validated.
 - Local viewport values are bounded but cannot affect signed project truth or workspace trust.
 - Invalid canvas signatures place the workspace in read-only untrusted state.
+- Source discovery uses read-only local/GitHub commands and enforces count, line, and text bounds.
+- Source apply validates the complete batch before persistence and requires trusted, conflict-free, mutable targets.
+- GitHub CLI credentials remain outside Blueprints workspaces and settings.
 
 ## Important limitations
 
@@ -58,6 +62,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Canvas layout is a whole signed document; concurrent arrangements conflict as a unit and are not field-merged.
 - Conflict resolution currently exposes low-level previews and supports whole-document choices.
 - Blueprints does not encrypt project content.
+- Duplicate detection is an exact normalized-title warning, not semantic identity proof.
+- GitHub Project discovery currently sees project-linked repository issues, not standalone Project draft items.
 
 ## Reviewing security changes
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -1,0 +1,73 @@
+# Source Lens
+
+Source Lens converts existing project signals into editable Blueprints work-item proposals. It is an approval workflow, not an autonomous importer.
+
+## Supported sources
+
+| Source | How it is read | What becomes a proposal |
+| --- | --- | --- |
+| `CHANGELOG.md` | Local read-only Markdown parsing | Bullet entries, completed by default |
+| `Roadmap.md` | Local read-only Markdown parsing | Bullet and task-list entries with checkbox state |
+| GitHub issues | Authenticated `gh issue list` request | Open and closed issue metadata |
+| GitHub Projects | `projectItems` attached to returned issues | Project-linked issues with project context |
+
+The scanner checks the repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues. A scan returns at most 250 deduplicated proposals.
+
+Standalone GitHub Project draft items are not imported yet. Only issues visible through the repository issue query and linked to a Project are recognized.
+
+## Requirements
+
+- Link a local Git worktree in **Source Lens**.
+- Install Git.
+- For GitHub discovery, install and authenticate the GitHub CLI with `gh auth login`.
+- The Git worktree must have a recognizable `github.com` origin remote.
+
+Local Markdown discovery still works if GitHub is unavailable. Source Lens reports the skipped provider as a warning instead of failing the entire scan.
+
+## Approval workflow
+
+1. Open **Source Lens**.
+2. Link the local repository and select **Scan sources**.
+3. Select a proposal from the inbox.
+4. Review and edit its title, description, target version, work type, changelog category, and completion state.
+5. Include or exclude the proposal with **Approved**.
+6. Repeat for the remaining proposals.
+7. Select **Apply approved to blueprint**.
+
+Nothing is written to the workspace during discovery or editing. Apply requires a trusted, conflict-free workspace and an editable target version. All approved proposals are validated before persistence and are then written as one signed workspace mutation with one signed audit entry.
+
+## Suggestions and duplicate handling
+
+Blueprints infers:
+
+- security work from security and vulnerability terms;
+- bugs and fixes from bug/fix language or labels;
+- features from feature/enhancement language;
+- changelog categories from headings, labels, and issue state;
+- completion from Markdown checkboxes, changelog history, and closed GitHub issues.
+
+These are suggestions only. The user can replace every inferred field.
+
+An exact normalized title match against existing work is marked as a possible duplicate and excluded by default. The user may deliberately approve it. Blueprints does not silently merge, overwrite, or delete existing items.
+
+## Provenance
+
+Applied items retain tags that identify:
+
+- that the item came through Source Lens;
+- the source kind;
+- a compact source reference such as `github:#42` or `roadmap:Roadmap.md:18`.
+
+Source content remains informational. It does not inherit authority from GitHub, a roadmap, or a changelog.
+
+## Security and privacy
+
+- Discovery is read-only for the repository and GitHub.
+- Blueprints never invokes provider write commands during discovery or apply.
+- GitHub credentials remain owned by the GitHub CLI and are not copied into project files.
+- Untrusted source text is length- and count-bounded and rendered as text.
+- Proposals are transient UI state until explicit approval.
+- Invalid taxonomy, missing versions, frozen/released targets, broken trust, and sync conflicts block apply.
+- Apply signs Blueprints documents with the local member identity; it does not sign or modify source-provider data.
+
+Source Lens does not prove that imported statements are true. Review is the human trust decision.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,13 +56,19 @@ See [canvas engine](canvas-engine.md) for the exact model and [troubleshooting](
 
 Incomplete items are excluded by the current default rules. When a local Git repository is linked, recent commit subjects and matching item keys are added as source context.
 
-## Link local Git
+## Discover work with Source Lens
 
-1. Open **Integrations** from the tool rail.
+1. Open **Source Lens** from the navigation.
 2. Enter the path to a Git worktree.
-3. Select **Save connection**, then **Refresh all**.
+3. Select **Save link**, then **Scan sources**.
+4. Review the proposal inbox produced from changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
+5. Edit the selected proposal’s title, context, target version, type, changelog group, and completion state.
+6. Exclude anything that should not enter Blueprints.
+7. Select **Apply approved to blueprint**.
 
-This integration is read-only. It reads repository status and recent commit metadata; it does not commit, push, or modify the repository.
+Discovery is read-only. It does not commit, push, edit issues, change Projects, or modify planning files. Proposals are not project data until Apply. Apply requires a trusted workspace, adds the reviewed proposals as signed work items, records their provenance, and writes one audit action.
+
+GitHub discovery requires the authenticated GitHub CLI. Local changelog and roadmap discovery remains available if GitHub is not configured. See [Source Lens](source-lens.md) for limits, duplicate behavior, and security details.
 
 ## Exchange changes
 


### PR DESCRIPTION
## Summary

- add Source Lens discovery for local changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects
- normalize source signals into transient editable proposals with confidence, context, provenance, duplicate warnings, and suggested taxonomy
- require users to include/exclude, edit, choose a target version, and explicitly apply proposals
- validate approved batches against workspace trust, conflicts, taxonomy, lifecycle, and target versions before writing signed items
- record the approved batch as one `source.import.apply` audit action without modifying any source provider
- replace icon-only navigation with a readable workflow rail and add adaptive next-action guidance
- document requirements, limits, security boundaries, approval behavior, provenance, and current GitHub Projects limitations

## User control and security

Discovery is read-only. It invokes only local Git reads and `gh issue list`; GitHub credentials remain owned by the GitHub CLI. Proposal state is transient and no Blueprints workspace files change until the user explicitly applies an approved set. Source reads and proposal batches are bounded. Apply is blocked for untrusted/conflicted workspaces, invalid taxonomy, missing versions, and frozen or released targets.

## Verification

- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- `dotnet build Blueprints.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test Blueprints.sln --configuration Release --no-build --no-restore` (74 passed)
- `dotnet package list --project Blueprints.sln --vulnerable --include-transitive` (no known vulnerable packages)
- exercised GitHub issue/Project metadata fields against this repository
- production startup smoke test on macOS
- visual QA of Source Lens at the real desktop window size
