### PR TITLE
Prepare v0.2.0-alpha.2 and SonarQube Cloud analysis

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-sonarscanner": {
+      "version": "11.2.1",
+      "commands": [
+        "dotnet-sonarscanner"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Milestone Release
 
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    tags: ["v[0-9]*.[0-9]*.[0-9]*"]
 
 permissions:
   contents: read

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,87 @@
+name: SonarQube
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: sonarqube-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: SonarQube analysis
+    if: >-
+      ${{
+        vars.SONAR_ENABLED == 'true' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
+      SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            .config/dotnet-tools.json
+            global.json
+
+      - name: Validate configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SONAR_TOKEN"
+          test -n "$SONAR_ORGANIZATION"
+          test -n "$SONAR_PROJECT_KEY"
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Begin analysis
+        id: begin
+        shell: bash
+        run: >-
+          dotnet sonarscanner begin
+          /k:"$SONAR_PROJECT_KEY"
+          /o:"$SONAR_ORGANIZATION"
+          /d:sonar.token="$SONAR_TOKEN"
+          /d:sonar.cs.opencover.reportsPaths="TestResults/**/coverage.opencover.xml"
+          /d:sonar.qualitygate.wait=true
+
+      - name: Restore
+        run: dotnet restore Blueprints.sln
+
+      - name: Build
+        run: dotnet build Blueprints.sln --configuration Release --no-restore --no-incremental
+
+      - name: Test with coverage
+        run: >-
+          dotnet test Blueprints.Tests/Blueprints.Tests.csproj
+          --configuration Release
+          --no-build
+          --logger "trx;LogFileName=tests.trx"
+          --results-directory TestResults
+          --collect "XPlat Code Coverage;Format=opencover"
+
+      - name: Complete analysis
+        if: ${{ always() && steps.begin.outcome == 'success' }}
+        shell: bash
+        run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+No changes yet.
+
+## 0.2.0-alpha.2 — 2026-07-30
+
+Interactive workspace milestone. This prerelease makes Blueprints usable as a hands-on visual release planner and establishes the approval-first source-discovery workflow.
+
 ### Added
 
 - Canonical public documentation for users, contributors, architecture, workspace format, security, and releases.
@@ -19,6 +25,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Source Lens discovery for changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
 - Editable proposal review with duplicate warnings, provenance, confidence, target-version selection, and explicit batch approval.
 - Adaptive next-action guidance based on workspace trust, conflicts, release state, source proposals, and sync status.
+- A disabled-by-default SonarQube Cloud workflow template for .NET analysis and Coverlet coverage. It requires explicit repository activation and credentials.
 
 ### Changed
 
@@ -33,6 +40,20 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 - Repository-local SDK selection now works when only a newer compatible SDK is installed.
 - Shell helpers are executable.
+- Source discovery no longer parses the same planning file twice on case-insensitive filesystems.
+
+### Security
+
+- Shared canvas positions are signed, bounded, entity-validated, audited, and synchronized.
+- Source discovery remains read-only and bounded; imports require explicit human approval and trusted mutable targets.
+- CodeQL, dependency review, package vulnerability checks, and cross-platform tests remain required repository gates.
+
+### Known limitations
+
+- This release does not include installers or application binaries.
+- Identity onboarding, undo/redo, deletion/archive, guided recovery, and polished two-user collaboration remain incomplete.
+- GitHub Project discovery currently includes project-linked issues, not standalone draft items.
+- SonarQube Cloud is scaffolded but does not run until the project is imported and repository credentials are configured.
 
 ## 0.1.0-alpha.1 — 2026-02-28
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionSuffix>alpha.2</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 - [Architecture](docs/architecture.md)
 - [Workspace format](docs/workspace-format.md)
 - [Security model](docs/security-model.md)
+- [SonarQube Cloud](docs/sonarqube.md)
 - [Development guide](docs/development.md)
 - [Release process](docs/releasing.md)
 - [Release history](docs/releases.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Use this directory as the canonical technical and user documentation.
 | Understanding the code | [Architecture](architecture.md) |
 | Inspecting project files | [Workspace format](workspace-format.md) |
 | Reviewing trust boundaries | [Security model](security-model.md) |
+| Activating SonarQube Cloud | [SonarQube Cloud](sonarqube.md) |
 | Reviewing milestone accomplishments | [Release history](releases.md) |
 | Publishing a build | [Release process](releasing.md) |
 | Choosing the next work | [Roadmap](../Roadmap.md) |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,13 +6,14 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.2.0-alpha.2` | 2026-07-30 | Interactive workspace | Diagram-first canvas, signed shared layouts, machine-local viewport state, approval-first Source Lens, adaptive workflow navigation, .NET 10, Avalonia 12, and expanded security/user documentation |
 | [`v0.1.0-alpha.1`](https://github.com/ATAC-Helicopter/Blueprints/releases/tag/v0.1.0-alpha.1) | 2026-02-28 | Foundation | Domain contracts, canonical signed persistence, protected identities, shared-folder sync foundation, audit chaining, and the initial Avalonia application scaffold |
 
 ## Planned checkpoints
 
 | Version | Milestone outcome |
 | --- | --- |
-| `v0.2.0` | A coherent and usable solo release-planning workflow |
+| `v0.2.0` | Complete the coherent solo workflow with identity onboarding, editing history, archive/delete flows, and release polish |
 | `v0.3.0` | Collaboration that two users can understand and recover |
 | `v0.4.0` | Provider-neutral source-control awareness |
 | `v0.5.0` | Explicit VaultSync transport and backup-health integration |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,7 +21,7 @@ v0.2 milestone -> v0.2.0
 v0.3 milestone -> v0.3.0
 ```
 
-The historical foundation checkpoint used `v0.1.0-alpha.1`. Starting with the v0.2 milestone, use the clean `v0.x.0` form. GitHub records remain marked as prereleases until v1.0.
+Use SemVer prerelease identifiers for honest intermediate checkpoints, for example `v0.2.0-alpha.2`. Use the clean `v0.x.0` form only when that roadmap milestone's exit criteria are complete. GitHub records remain marked as prereleases until v1.0.
 
 Before tagging:
 
@@ -36,8 +36,8 @@ Create an annotated, signed tag from `main` when possible:
 ```sh
 git switch main
 git pull --ff-only
-git tag -s v0.2.0 -m "Blueprints v0.2.0 — coherent solo workflow"
-git push origin v0.2.0
+git tag -s v0.2.0-alpha.2 -m "Blueprints v0.2.0-alpha.2 — interactive workspace"
+git push origin v0.2.0-alpha.2
 ```
 
 The milestone workflow verifies that the tag belongs to `main`, requires a matching changelog heading, extracts that section, and creates a GitHub prerelease with no attached binaries.

--- a/docs/sonarqube.md
+++ b/docs/sonarqube.md
@@ -1,0 +1,51 @@
+# SonarQube Cloud
+
+Blueprints uses SonarQube Cloud as an additional code-quality and security-hotspot signal. It complements CodeQL, dependency review, NuGet vulnerability checks, tests, and human review; it does not replace them.
+
+The repository workflow is intentionally disabled until the external SonarQube Cloud project is imported and its first baseline can be reviewed.
+
+## One-time activation
+
+1. Sign in to SonarQube Cloud with the GitHub account that administers `ATAC-Helicopter`.
+2. Import `ATAC-Helicopter/Blueprints`.
+3. Choose CI-based analysis and disable automatic analysis to avoid duplicate results.
+4. Create a scoped analysis token.
+5. Add the token as the repository Actions secret `SONAR_TOKEN`.
+6. Add repository Actions variables:
+   - `SONAR_ORGANIZATION`: the SonarQube Cloud organization key;
+   - `SONAR_PROJECT_KEY`: the imported project key;
+   - `SONAR_ENABLED`: `true`.
+7. Run the **SonarQube** workflow manually.
+8. Review every baseline reliability, security, maintainability, hotspot, and coverage finding.
+9. Fix findings or record a justified disposition in SonarQube Cloud.
+10. Require the `SonarQube analysis` status check on `develop` and `main` only after a clean successful run.
+
+Do not store the token in Git, project files, logs, documentation, or signed Blueprints workspaces.
+
+## Workflow behavior
+
+- The scanner version is pinned in `.config/dotnet-tools.json`.
+- Analysis uses the full Git history for new-code attribution.
+- The workflow restores and builds the .NET 10 solution between SonarScanner begin/end steps.
+- Tests emit Coverlet OpenCover reports from `Blueprints.Tests`.
+- The job waits for the Sonar quality gate.
+- Pull requests from forks are skipped because GitHub does not expose repository secrets to them.
+- The workflow remains skipped while `SONAR_ENABLED` is not `true`.
+
+## Local verification
+
+The normal local verification does not require a Sonar token:
+
+```sh
+./scripts/verify.sh
+```
+
+Maintainers may reproduce analysis locally after exporting the three activation values, but must avoid shell history or diagnostic output that exposes `SONAR_TOKEN`.
+
+## Response policy
+
+- Treat new security findings and reviewed hotspots as release blockers until triaged.
+- Do not weaken a quality profile merely to make a gate green.
+- Do not classify a hotspot as safe without recording the relevant trust boundary and reasoning.
+- Keep CodeQL enabled even when SonarQube Cloud is healthy.
+- Never describe SonarQube output as a complete security audit.


### PR DESCRIPTION
## Summary

- set the repository/application version to `0.2.0-alpha.2`
- convert the current Unreleased accomplishments into the dated alpha.2 changelog record
- document delivered security boundaries, known limitations, and remaining v0.2 work
- update release history and prerelease instructions
- repair tag filtering so SemVer prerelease tags trigger the milestone release workflow
- pin SonarScanner for .NET 11.2.1 as a repository-local tool
- add a disabled-by-default SonarQube Cloud workflow with full history, .NET 10 build, Coverlet/OpenCover coverage, fork protection, and quality-gate waiting
- document external activation, credential handling, baseline triage, and when to add branch protection

## Sonar activation boundary

The workflow stays skipped until `SONAR_ENABLED=true` and the organization/project/token values are configured after importing the repository into SonarQube Cloud. It is intentionally not a required check yet. CodeQL, dependency review, package vulnerability checks, and the cross-platform test matrix remain authoritative repository gates during onboarding.

## Verification

- `dotnet tool restore` restored pinned `dotnet-sonarscanner` 11.2.1
- MSBuild reports version `0.2.0-alpha.2`
- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- `dotnet build Blueprints.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test Blueprints.sln --configuration Release --no-build --no-restore` (74 passed)
- `git diff --check`
