### PR TITLE
Canvas: add trusted layout undo and redo

### DIFF
--- a/Blueprints.App/Services/CanvasLayoutHistory.cs
+++ b/Blueprints.App/Services/CanvasLayoutHistory.cs
@@ -1,0 +1,110 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class CanvasLayoutHistory
+{
+    private readonly int _capacity;
+    private readonly List<IReadOnlyList<CanvasNodeLayoutEdit>> _undo = [];
+    private readonly List<IReadOnlyList<CanvasNodeLayoutEdit>> _redo = [];
+
+    public CanvasLayoutHistory(int capacity = 50)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        _capacity = capacity;
+    }
+
+    public bool CanUndo => _undo.Count > 0;
+
+    public bool CanRedo => _redo.Count > 0;
+
+    public bool Record(
+        IReadOnlyList<CanvasNodeLayoutEdit> previous,
+        IReadOnlyList<CanvasNodeLayoutEdit> current)
+    {
+        ArgumentNullException.ThrowIfNull(previous);
+        ArgumentNullException.ThrowIfNull(current);
+        if (AreEquivalent(previous, current))
+        {
+            return false;
+        }
+
+        AddBounded(_undo, Clone(previous));
+        _redo.Clear();
+        return true;
+    }
+
+    public bool TryUndo(
+        IReadOnlyList<CanvasNodeLayoutEdit> current,
+        out IReadOnlyList<CanvasNodeLayoutEdit> previous)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        if (_undo.Count == 0)
+        {
+            previous = [];
+            return false;
+        }
+
+        AddBounded(_redo, Clone(current));
+        previous = TakeLast(_undo);
+        return true;
+    }
+
+    public bool TryRedo(
+        IReadOnlyList<CanvasNodeLayoutEdit> current,
+        out IReadOnlyList<CanvasNodeLayoutEdit> next)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        if (_redo.Count == 0)
+        {
+            next = [];
+            return false;
+        }
+
+        AddBounded(_undo, Clone(current));
+        next = TakeLast(_redo);
+        return true;
+    }
+
+    public void Clear()
+    {
+        _undo.Clear();
+        _redo.Clear();
+    }
+
+    private static bool AreEquivalent(
+        IReadOnlyList<CanvasNodeLayoutEdit> left,
+        IReadOnlyList<CanvasNodeLayoutEdit> right) =>
+        left.Count == right.Count
+        && left
+            .OrderBy(static node => node.NodeType, StringComparer.Ordinal)
+            .ThenBy(static node => node.EntityId)
+            .SequenceEqual(
+                right
+                    .OrderBy(static node => node.NodeType, StringComparer.Ordinal)
+                    .ThenBy(static node => node.EntityId));
+
+    private static IReadOnlyList<CanvasNodeLayoutEdit> Clone(
+        IReadOnlyList<CanvasNodeLayoutEdit> snapshot) =>
+        snapshot.ToArray();
+
+    private static IReadOnlyList<CanvasNodeLayoutEdit> TakeLast(
+        List<IReadOnlyList<CanvasNodeLayoutEdit>> snapshots)
+    {
+        var index = snapshots.Count - 1;
+        var snapshot = snapshots[index];
+        snapshots.RemoveAt(index);
+        return snapshot;
+    }
+
+    private void AddBounded(
+        List<IReadOnlyList<CanvasNodeLayoutEdit>> snapshots,
+        IReadOnlyList<CanvasNodeLayoutEdit> snapshot)
+    {
+        snapshots.Add(snapshot);
+        if (snapshots.Count > _capacity)
+        {
+            snapshots.RemoveAt(0);
+        }
+    }
+}

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Blueprints.App.Models;
+using Blueprints.App.Services;
 using Blueprints.App.ViewModels;
 
 namespace Blueprints.App.Views.Components;
@@ -20,15 +21,24 @@ public partial class BlueprintCanvasSurface : UserControl
     private const double ItemNodeHeight = 82;
     private readonly Dictionary<Guid, Point> _positions = [];
     private readonly List<ConnectionVisual> _connections = [];
+    private readonly CanvasLayoutHistory _layoutHistory = new();
     private MainWindowViewModel? _viewModel;
     private Control? _draggedNode;
+    private IReadOnlyList<CanvasNodeLayoutEdit>? _dragStartLayout;
     private Point _dragOffset;
     private double _zoom = 1;
     private bool _isRestoringLayout;
+    private bool _isPersistingLayout;
     private readonly DispatcherTimer _viewportSaveTimer;
     private bool _isPanning;
     private Point _panStart;
     private Vector _panOrigin;
+
+    public event EventHandler? HistoryStateChanged;
+
+    public bool CanUndo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanUndo;
+
+    public bool CanRedo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanRedo;
 
     public BlueprintCanvasSurface()
     {
@@ -61,15 +71,49 @@ public partial class BlueprintCanvasSurface : UserControl
 
     public void AutoArrange()
     {
+        if (_viewModel?.CanMutateWorkspace != true)
+        {
+            return;
+        }
+
+        var previous = CaptureLayout();
         _positions.Clear();
         SetZoom(1);
         RenderGraph();
+        _layoutHistory.Record(previous, CaptureLayout());
+        NotifyHistoryStateChanged();
         Viewport.Offset = Vector.Zero;
         PersistLayout();
         PersistViewState();
     }
 
     public void SaveLayout() => PersistLayout();
+
+    public void UndoLayout()
+    {
+        if (_viewModel?.CanMutateWorkspace != true
+            || !_layoutHistory.TryUndo(CaptureLayout(), out var previous))
+        {
+            return;
+        }
+
+        ApplyLayout(previous);
+        PersistLayout();
+        NotifyHistoryStateChanged();
+    }
+
+    public void RedoLayout()
+    {
+        if (_viewModel?.CanMutateWorkspace != true
+            || !_layoutHistory.TryRedo(CaptureLayout(), out var next))
+        {
+            return;
+        }
+
+        ApplyLayout(next);
+        PersistLayout();
+        NotifyHistoryStateChanged();
+    }
 
     private void SetZoom(double value, bool persist = false)
     {
@@ -87,6 +131,7 @@ public partial class BlueprintCanvasSurface : UserControl
     private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
     {
         DetachViewModel();
+        ClearLayoutHistory();
         _viewModel = DataContext as MainWindowViewModel;
         if (_viewModel is not null)
         {
@@ -115,6 +160,11 @@ public partial class BlueprintCanvasSurface : UserControl
     {
         _viewportSaveTimer.Stop();
         _isRestoringLayout = true;
+        if (!_isPersistingLayout)
+        {
+            ClearLayoutHistory();
+        }
+
         RenderGraph();
         Dispatcher.UIThread.Post(
             () => _isRestoringLayout = false,
@@ -130,6 +180,11 @@ public partial class BlueprintCanvasSurface : UserControl
         }
         else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasLayout))
         {
+            if (!_isPersistingLayout)
+            {
+                ClearLayoutHistory();
+            }
+
             RestoreLayout();
             RenderGraph();
         }
@@ -141,6 +196,10 @@ public partial class BlueprintCanvasSurface : UserControl
             or nameof(MainWindowViewModel.ItemCount))
         {
             RenderGraph();
+        }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanMutateWorkspace))
+        {
+            NotifyHistoryStateChanged();
         }
     }
 
@@ -428,7 +487,13 @@ public partial class BlueprintCanvasSurface : UserControl
             PointerPressedEvent,
             (_, eventArgs) =>
             {
+                if (_viewModel?.CanMutateWorkspace != true)
+                {
+                    return;
+                }
+
                 _draggedNode = node;
+                _dragStartLayout = CaptureLayout();
                 var pointer = eventArgs.GetPosition(Surface);
                 _dragOffset = new Point(pointer.X - Canvas.GetLeft(node), pointer.Y - Canvas.GetTop(node));
                 eventArgs.Pointer.Capture(node);
@@ -436,7 +501,9 @@ public partial class BlueprintCanvasSurface : UserControl
             RoutingStrategies.Tunnel);
         node.PointerMoved += (_, eventArgs) =>
         {
-            if (_draggedNode != node || !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
+            if (_viewModel?.CanMutateWorkspace != true
+                || _draggedNode != node
+                || !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
             {
                 return;
             }
@@ -455,7 +522,14 @@ public partial class BlueprintCanvasSurface : UserControl
             {
                 _draggedNode = null;
                 eventArgs.Pointer.Capture(null);
-                PersistLayout();
+                if (_dragStartLayout is not null
+                    && _layoutHistory.Record(_dragStartLayout, CaptureLayout()))
+                {
+                    NotifyHistoryStateChanged();
+                    PersistLayout();
+                }
+
+                _dragStartLayout = null;
             }
         };
     }
@@ -585,6 +659,20 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             SaveLayout();
         }
+        else if (control
+                 && eventArgs.Key == Key.Z
+                 && eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            RedoLayout();
+        }
+        else if (control && eventArgs.Key == Key.Z)
+        {
+            UndoLayout();
+        }
+        else if (control && eventArgs.Key == Key.Y)
+        {
+            RedoLayout();
+        }
         else if (control && eventArgs.Key == Key.D0)
         {
             FitView();
@@ -623,9 +711,58 @@ public partial class BlueprintCanvasSurface : UserControl
             }
         }
 
-        _viewModel.SaveCanvasLayoutCommand.Execute(
-            new CanvasLayoutEditRequest(nodes));
+        _isPersistingLayout = true;
+        try
+        {
+            _viewModel.SaveCanvasLayoutCommand.Execute(
+                new CanvasLayoutEditRequest(nodes));
+        }
+        finally
+        {
+            _isPersistingLayout = false;
+        }
     }
+
+    private IReadOnlyList<CanvasNodeLayoutEdit> CaptureLayout()
+    {
+        if (_viewModel is null)
+        {
+            return [];
+        }
+
+        var nodes = new List<CanvasNodeLayoutEdit>();
+        AddLayoutNode(nodes, "project", _viewModel.CurrentProject.ProjectId);
+        foreach (var version in _viewModel.Versions)
+        {
+            AddLayoutNode(nodes, "version", version.VersionId);
+            foreach (var item in version.Items)
+            {
+                AddLayoutNode(nodes, "item", item.ItemId);
+            }
+        }
+
+        return nodes;
+    }
+
+    private void ApplyLayout(IReadOnlyList<CanvasNodeLayoutEdit> layout)
+    {
+        _positions.Clear();
+        foreach (var node in layout)
+        {
+            _positions[node.EntityId] = new Point(node.X, node.Y);
+        }
+
+        RenderGraph();
+    }
+
+    private void ClearLayoutHistory()
+    {
+        _layoutHistory.Clear();
+        NotifyHistoryStateChanged();
+    }
+
+    private void NotifyHistoryStateChanged() =>
+        HistoryStateChanged?.Invoke(this, EventArgs.Empty);
 
     private void PersistViewState()
     {

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -23,6 +23,8 @@
         <Border Grid.Column="1" Width="1" Background="#285E7D" Margin="8,0" />
 
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
+          <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl+Z)" />
+          <Button x:Name="RedoButton" Classes="tool square" Content="↷" Click="RedoClick" ToolTip.Tip="Redo layout change (Ctrl+Shift+Z or Ctrl+Y)" />
           <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" />
           <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" />
           <Button Classes="tool" Content="Fit view" Click="FitViewClick" />
@@ -141,7 +143,7 @@
             <StackPanel Spacing="4">
               <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
               <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#6DD6EF" FontSize="10" />
-              <TextBlock Text="Drag nodes · Middle-drag to pan · Ctrl+wheel to zoom · Ctrl+S to save layout"
+              <TextBlock Text="Drag nodes · Ctrl+Z / Ctrl+Shift+Z undo/redo · Middle-drag to pan · Ctrl+wheel to zoom"
                          Foreground="#8FBAD0"
                          FontSize="10"
                          TextWrapping="Wrap" />

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -8,7 +8,15 @@ public partial class OverviewView : UserControl
     public OverviewView()
     {
         InitializeComponent();
+        BlueprintSurface.HistoryStateChanged += (_, _) => UpdateHistoryButtons();
+        UpdateHistoryButtons();
     }
+
+    private void UndoClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.UndoLayout();
+
+    private void RedoClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.RedoLayout();
 
     private void ZoomInClick(object? sender, RoutedEventArgs eventArgs) =>
         BlueprintSurface.ZoomIn();
@@ -24,4 +32,10 @@ public partial class OverviewView : UserControl
 
     private void SaveLayoutClick(object? sender, RoutedEventArgs eventArgs) =>
         BlueprintSurface.SaveLayout();
+
+    private void UpdateHistoryButtons()
+    {
+        UndoButton.IsEnabled = BlueprintSurface.CanUndo;
+        RedoButton.IsEnabled = BlueprintSurface.CanRedo;
+    }
 }

--- a/Blueprints.Tests/CanvasLayoutHistoryTests.cs
+++ b/Blueprints.Tests/CanvasLayoutHistoryTests.cs
@@ -1,0 +1,92 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class CanvasLayoutHistoryTests
+{
+    [Fact]
+    public void RecordUndoAndRedo_RoundTripLayoutSnapshots()
+    {
+        var nodeId = Guid.NewGuid();
+        CanvasNodeLayoutEdit[] original = [new("version", nodeId, 100, 200)];
+        CanvasNodeLayoutEdit[] moved = [new("version", nodeId, 300, 400)];
+        var history = new CanvasLayoutHistory();
+
+        Assert.True(history.Record(original, moved));
+        Assert.True(history.CanUndo);
+        Assert.False(history.CanRedo);
+
+        Assert.True(history.TryUndo(moved, out var undone));
+        Assert.Equal(original, undone);
+        Assert.False(history.CanUndo);
+        Assert.True(history.CanRedo);
+
+        Assert.True(history.TryRedo(undone, out var redone));
+        Assert.Equal(moved, redone);
+        Assert.True(history.CanUndo);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void Record_IgnoresEquivalentLayoutsAndClearsRedoAfterANewEdit()
+    {
+        var firstNodeId = Guid.NewGuid();
+        var secondNodeId = Guid.NewGuid();
+        CanvasNodeLayoutEdit[] original =
+        [
+            new("item", firstNodeId, 10, 20),
+            new("version", secondNodeId, 30, 40),
+        ];
+        CanvasNodeLayoutEdit[] sameInAnotherOrder =
+        [
+            new("version", secondNodeId, 30, 40),
+            new("item", firstNodeId, 10, 20),
+        ];
+        CanvasNodeLayoutEdit[] moved =
+        [
+            new("item", firstNodeId, 30, 40),
+            new("version", secondNodeId, 30, 40),
+        ];
+        CanvasNodeLayoutEdit[] movedAgain =
+        [
+            new("item", firstNodeId, 50, 60),
+            new("version", secondNodeId, 30, 40),
+        ];
+        var history = new CanvasLayoutHistory();
+
+        Assert.False(history.Record(original, sameInAnotherOrder));
+        Assert.False(history.CanUndo);
+
+        history.Record(original, moved);
+        history.TryUndo(moved, out _);
+        Assert.True(history.CanRedo);
+
+        history.Record(original, movedAgain);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void Capacity_DiscardsTheOldestUndoSnapshot()
+    {
+        var nodeId = Guid.NewGuid();
+        var history = new CanvasLayoutHistory(capacity: 2);
+        var first = LayoutAt(nodeId, 10);
+        var second = LayoutAt(nodeId, 20);
+        var third = LayoutAt(nodeId, 30);
+        var fourth = LayoutAt(nodeId, 40);
+
+        history.Record(first, second);
+        history.Record(second, third);
+        history.Record(third, fourth);
+
+        Assert.True(history.TryUndo(fourth, out var undoThird));
+        Assert.Equal(third, undoThird);
+        Assert.True(history.TryUndo(undoThird, out var undoSecond));
+        Assert.Equal(second, undoSecond);
+        Assert.False(history.TryUndo(undoSecond, out _));
+    }
+
+    private static CanvasNodeLayoutEdit[] LayoutAt(Guid nodeId, double coordinate) =>
+        [new("project", nodeId, coordinate, coordinate)];
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- Session-scoped undo and redo for node drags and auto-arrangement, with toolbar controls and `Ctrl+Z`, `Ctrl+Shift+Z`, and `Ctrl+Y` shortcuts.
+- Every applied undo or redo is saved as a new signed, audited canvas-layout revision so history never bypasses workspace integrity.
+
+### Changed
+
+- Post-release development builds now identify themselves as `0.2.0-alpha.3-dev`.
+
+### Fixed
+
+- Canvas nodes can no longer be dragged when workspace trust or sync-conflict state forbids mutation.
 
 ## 0.2.0-alpha.2 — 2026-07-30
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>alpha.2</VersionSuffix>
+    <VersionSuffix>alpha.3-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -24,7 +24,7 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Persist, sign, audit, sync, validate, and restore shared node positions while keeping viewport preferences machine-local.
 - [x] Add approval-first Source Lens discovery for changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
 - [x] Replace icon-only navigation with a clear workflow rail and adaptive next-action guidance.
-- [ ] Add undo/redo, box selection, multi-select, keyboard movement, alignment guides, and a minimap.
+- [ ] Expand canvas editing beyond the completed session undo/redo foundation with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
 - [x] Add native folder pickers instead of requiring raw paths.

--- a/docs/canvas-engine.md
+++ b/docs/canvas-engine.md
@@ -31,8 +31,11 @@ Changing a node title, state, category, or completion value uses the existing ve
 | Ctrl+mouse wheel or zoom buttons | Change and save machine-local zoom |
 | Fit view | Use the standard local overview zoom and return to the origin |
 | Auto arrange | Rebuild deterministic default positions and save them |
+| Undo / redo | Restore the previous or next arrangement and save it as a new signed revision |
 | Save layout | Explicitly write the current shared node positions |
 | Ctrl+S | Save shared node positions |
+| Ctrl+Z | Undo the latest node drag or auto-arrangement |
+| Ctrl+Shift+Z or Ctrl+Y | Redo the latest undone layout change |
 | Ctrl+0 | Fit the local view |
 | Ctrl+plus/minus | Zoom the local view |
 
@@ -67,6 +70,8 @@ Each successful save:
 7. reloads displayed state from disk.
 
 Layout writes do not rewrite version or item documents.
+
+Undo and redo history is held only for the current application session, is capped at 50 layout changes, and is cleared when the workspace or graph structure changes. History snapshots are not a hidden source of truth. Applying one creates a normal signed layout revision and audit entry, preserving the same validation and collaboration guarantees as a direct drag.
 
 Zoom and viewport offsets are machine-local preferences stored in:
 
@@ -105,7 +110,7 @@ Version and work-item content remain separate documents. A layout conflict does 
 - There is one shared release-planning canvas per project.
 - Node positions are shared project state, not per-user preferences.
 - Connectors represent ownership and cannot yet be created as arbitrary edge types.
-- There is no undo/redo stack, minimap, box selection, grouping, or keyboard-driven movement yet.
+- There is no minimap, box selection, grouping, or keyboard-driven node movement yet.
 - Auto arrangement is deterministic but not a graph-optimization engine.
 - Layout conflict resolution is whole-document.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,8 +42,9 @@ The lines on the canvas represent real project relationships: a work item is con
 - **Fit view** returns to the standard overview without rearranging nodes.
 - **Auto arrange** deliberately replaces positions with deterministic defaults.
 - **Save layout** explicitly writes the current arrangement.
+- **Undo** and **redo** restore node drags or auto-arrangement changes made during the current session. Use the toolbar, `Ctrl+Z`, `Ctrl+Shift+Z`, or `Ctrl+Y`.
 
-The saved revision appears at the bottom of the inspector. Node positions are signed project state and participate in push, pull, trust validation, audit history, and conflicts. Zoom and scroll offsets stay machine-local so navigating does not create team conflicts. Older workspaces without a layout file use default positions until the first save.
+The saved revision appears at the bottom of the inspector. Node positions are signed project state and participate in push, pull, trust validation, audit history, and conflicts. Undo and redo create new signed revisions instead of rewriting history, and their in-memory stack resets when the app session or graph structure changes. Zoom and scroll offsets stay machine-local so navigating does not create team conflicts. Older workspaces without a layout file use default positions until the first save.
 
 See [canvas engine](canvas-engine.md) for the exact model and [troubleshooting](troubleshooting.md) for recovery.
 


### PR DESCRIPTION
## Outcome

Makes the blueprint map safer and more hands-on by allowing users to undo and redo node drags and auto-arrangement without bypassing signed workspace history.

## Changes

- add a bounded, session-scoped canvas layout history service
- expose toolbar controls plus Ctrl+Z, Ctrl+Shift+Z, and Ctrl+Y
- persist every applied undo/redo as a new signed and audited layout revision
- block node dragging whenever workspace trust or conflict state forbids mutation
- identify post-release builds as 0.2.0-alpha.3-dev
- update the changelog, roadmap, canvas engine, and user guide

## Verification

- [x] `./scripts/verify.sh`
- [x] Added or updated automated tests (77 passing)
- [x] Performed relevant manual verification (macOS launch and toolbar rendering)
- [x] Updated documentation
- [x] `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- [x] no known vulnerable direct or transitive NuGet packages

## Risk review

- Security/trust impact: layout interaction now respects `CanMutateWorkspace`; undo/redo uses the existing signed, validated, audited save path.
- Workspace-format or migration impact: none.
- Recovery/rollback: revert this commit; persisted layouts remain valid schema-1 documents.

## Checklist

- [x] This PR targets `develop` unless it is a release promotion.
- [x] The diff contains no secrets, private keys, tokens, or real confidential workspace data.
- [x] New dependencies are justified (none added).
