### PR TITLE
Release Blueprints 0.3.0 collaboration milestone

### DIFF
--- a/Blueprints.App/Models/ConflictFieldComparison.cs
+++ b/Blueprints.App/Models/ConflictFieldComparison.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.App.Models;
+
+public sealed record ConflictFieldComparison(
+    string Field,
+    string LocalValue,
+    string SharedValue,
+    bool IsDifferent)
+{
+    public string Status => IsDifferent ? "CHANGED" : "SAME";
+}

--- a/Blueprints.App/Models/ConflictRecoveryRecord.cs
+++ b/Blueprints.App/Models/ConflictRecoveryRecord.cs
@@ -1,0 +1,13 @@
+namespace Blueprints.App.Models;
+
+public sealed record ConflictRecoveryRecord(
+    int SchemaVersion,
+    string RecoveryId,
+    DateTimeOffset CreatedUtc,
+    string DocumentPath,
+    ConflictResolutionChoice Choice,
+    bool LocalDocumentPresent,
+    bool LocalSignaturePresent,
+    bool SharedDocumentPresent,
+    bool SharedSignaturePresent,
+    string Status);

--- a/Blueprints.App/Models/ConflictResolutionResult.cs
+++ b/Blueprints.App/Models/ConflictResolutionResult.cs
@@ -3,4 +3,5 @@ namespace Blueprints.App.Models;
 public sealed record ConflictResolutionResult(
     string DocumentPath,
     ConflictResolutionChoice Choice,
+    string RecoveryDirectory,
     string Summary);

--- a/Blueprints.App/Models/MemberInviteRequest.cs
+++ b/Blueprints.App/Models/MemberInviteRequest.cs
@@ -6,4 +6,5 @@ public sealed record MemberInviteRequest(
     string UserId,
     string DisplayName,
     string PublicKey,
-    MemberRole Role);
+    MemberRole Role,
+    string? KeyId = null);

--- a/Blueprints.App/Models/ProjectInvitationFile.cs
+++ b/Blueprints.App/Models/ProjectInvitationFile.cs
@@ -1,0 +1,7 @@
+using Blueprints.Security.Models;
+
+namespace Blueprints.App.Models;
+
+public sealed record ProjectInvitationFile(
+    ProjectInvitationPayload Project,
+    DetachedSignature Proof);

--- a/Blueprints.App/Models/ProjectInvitationPayload.cs
+++ b/Blueprints.App/Models/ProjectInvitationPayload.cs
@@ -1,0 +1,17 @@
+namespace Blueprints.App.Models;
+
+public sealed record ProjectInvitationPayload(
+    int SchemaVersion,
+    Guid ProjectId,
+    string ProjectName,
+    string ProjectCode,
+    string SharedWorkspaceRoot,
+    int MembershipRevision,
+    Guid InvitedUserId,
+    string InvitedKeyId,
+    Guid InviterUserId,
+    string InviterDisplayName,
+    string InviterKeyId,
+    string InviterPublicKeyBase64,
+    IReadOnlyList<TrustedProjectKey> TrustedKeys,
+    DateTimeOffset CreatedUtc);

--- a/Blueprints.App/Models/ProjectTrustDocument.cs
+++ b/Blueprints.App/Models/ProjectTrustDocument.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record ProjectTrustDocument(
+    int SchemaVersion,
+    Guid ProjectId,
+    IReadOnlyList<TrustedProjectKey> Keys,
+    DateTimeOffset UpdatedUtc);

--- a/Blueprints.App/Models/TrustedProjectKey.cs
+++ b/Blueprints.App/Models/TrustedProjectKey.cs
@@ -1,3 +1,5 @@
+using Blueprints.Core.Enums;
+
 namespace Blueprints.App.Models;
 
 public sealed record TrustedProjectKey(
@@ -5,4 +7,6 @@ public sealed record TrustedProjectKey(
     string DisplayName,
     string KeyId,
     string PublicKeyBase64,
-    DateTimeOffset FirstTrustedUtc);
+    DateTimeOffset FirstTrustedUtc,
+    MemberRole Role = MemberRole.Editor,
+    bool IsActive = true);

--- a/Blueprints.App/Models/TrustedProjectKey.cs
+++ b/Blueprints.App/Models/TrustedProjectKey.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public sealed record TrustedProjectKey(
+    Guid UserId,
+    string DisplayName,
+    string KeyId,
+    string PublicKeyBase64,
+    DateTimeOffset FirstTrustedUtc);

--- a/Blueprints.App/Models/WorkspaceArchiveRecord.cs
+++ b/Blueprints.App/Models/WorkspaceArchiveRecord.cs
@@ -1,0 +1,12 @@
+namespace Blueprints.App.Models;
+
+public sealed record WorkspaceArchiveRecord(
+    int SchemaVersion,
+    string ArchiveId,
+    string EntityType,
+    Guid EntityId,
+    string DisplayName,
+    DateTimeOffset CreatedUtc,
+    Guid ArchivedByUserId,
+    string ArchivedByDisplayName,
+    string Status);

--- a/Blueprints.App/Models/WorkspaceArchiveResult.cs
+++ b/Blueprints.App/Models/WorkspaceArchiveResult.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.App.Models;
+
+public sealed record WorkspaceArchiveResult(
+    LocalWorkspaceSession Session,
+    string ArchiveDirectory,
+    string Summary);

--- a/Blueprints.App/Models/WorkspaceItemCategoryGroup.cs
+++ b/Blueprints.App/Models/WorkspaceItemCategoryGroup.cs
@@ -1,0 +1,5 @@
+namespace Blueprints.App.Models;
+
+public sealed record WorkspaceItemCategoryGroup(
+    string CategoryId,
+    IReadOnlyList<WorkspaceItemCard> Items);

--- a/Blueprints.App/Models/WorkspaceVersionCard.cs
+++ b/Blueprints.App/Models/WorkspaceVersionCard.cs
@@ -9,4 +9,14 @@ public sealed record WorkspaceVersionCard(
     string? Notes,
     int ItemCount,
     int CompletedItemCount,
-    IReadOnlyList<WorkspaceItemCard> Items);
+    IReadOnlyList<WorkspaceItemCard> Items)
+{
+    public IReadOnlyList<WorkspaceItemCategoryGroup> ItemGroups =>
+        Items
+            .GroupBy(static item => item.CategoryId, StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+            .Select(group => new WorkspaceItemCategoryGroup(
+                group.Key,
+                group.OrderBy(static item => item.ItemKey, StringComparer.Ordinal).ToArray()))
+            .ToArray();
+}

--- a/Blueprints.App/Services/FileSystemProjectTrustStore.cs
+++ b/Blueprints.App/Services/FileSystemProjectTrustStore.cs
@@ -1,0 +1,146 @@
+using System.Text;
+using System.Text.Json;
+using Blueprints.App.Models;
+using Blueprints.Core.Models;
+using Blueprints.Security.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class FileSystemProjectTrustStore
+{
+    private const int CurrentSchemaVersion = 1;
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    public IReadOnlyDictionary<string, SignaturePublicKey> LoadKeys(
+        string localWorkspaceRoot,
+        StoredIdentity currentIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(currentIdentity);
+
+        var keys = new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+        {
+            [currentIdentity.PublicKey.KeyId] = currentIdentity.PublicKey,
+        };
+        var path = GetTrustPath(localWorkspaceRoot);
+        if (!File.Exists(path))
+        {
+            return keys;
+        }
+
+        var document = JsonSerializer.Deserialize<ProjectTrustDocument>(
+            File.ReadAllText(path, Encoding.UTF8),
+            SerializerOptions)
+            ?? throw new InvalidOperationException("Project trust anchors could not be read.");
+        if (document.SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported project trust-anchor schema {document.SchemaVersion}.");
+        }
+
+        foreach (var key in document.Keys)
+        {
+            try
+            {
+                keys[key.KeyId] = new SignaturePublicKey(
+                    key.KeyId,
+                    Convert.FromBase64String(key.PublicKeyBase64));
+            }
+            catch (FormatException exception)
+            {
+                throw new InvalidOperationException(
+                    $"Trusted public key {key.KeyId} is not valid Base64.",
+                    exception);
+            }
+        }
+
+        return keys;
+    }
+
+    public void Initialize(
+        string localWorkspaceRoot,
+        Guid projectId,
+        IEnumerable<TrustedProjectKey> keys)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(keys);
+
+        var existing = LoadDocument(localWorkspaceRoot);
+        if (existing is not null && existing.ProjectId != projectId)
+        {
+            throw new InvalidOperationException(
+                "The local trust-anchor file belongs to a different project.");
+        }
+
+        var merged = (existing?.Keys ?? [])
+            .Concat(keys)
+            .GroupBy(static key => key.KeyId, StringComparer.Ordinal)
+            .Select(static group => group.Last())
+            .OrderBy(static key => key.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static key => key.KeyId, StringComparer.Ordinal)
+            .ToArray();
+        Write(
+            localWorkspaceRoot,
+            new ProjectTrustDocument(
+                CurrentSchemaVersion,
+                projectId,
+                merged,
+                DateTimeOffset.UtcNow));
+    }
+
+    public void MergeVerifiedMembers(
+        string localWorkspaceRoot,
+        Guid projectId,
+        IEnumerable<ProjectMember> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        var trustedUtc = DateTimeOffset.UtcNow;
+        Initialize(
+            localWorkspaceRoot,
+            projectId,
+            members.Select(member => new TrustedProjectKey(
+                member.UserId,
+                member.DisplayName,
+                ResolveKeyId(member),
+                member.PublicKey,
+                trustedUtc)));
+    }
+
+    private static string ResolveKeyId(ProjectMember member) =>
+        string.IsNullOrWhiteSpace(member.KeyId)
+            ? member.UserId.ToString("N")
+            : member.KeyId;
+
+    private static ProjectTrustDocument? LoadDocument(string localWorkspaceRoot)
+    {
+        var path = GetTrustPath(localWorkspaceRoot);
+        return File.Exists(path)
+            ? JsonSerializer.Deserialize<ProjectTrustDocument>(
+                File.ReadAllText(path, Encoding.UTF8),
+                SerializerOptions)
+            : null;
+    }
+
+    private static void Write(
+        string localWorkspaceRoot,
+        ProjectTrustDocument document)
+    {
+        var path = GetTrustPath(localWorkspaceRoot);
+        var directory = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException("Project trust-anchor path has no parent.");
+        Directory.CreateDirectory(directory);
+        var tempPath = path + ".tmp";
+        File.WriteAllText(
+            tempPath,
+            JsonSerializer.Serialize(document, SerializerOptions),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    private static string GetTrustPath(string localWorkspaceRoot) =>
+        Path.Combine(localWorkspaceRoot, ".blueprints", "trusted-project-keys.json");
+}

--- a/Blueprints.App/Services/FileSystemProjectTrustStore.cs
+++ b/Blueprints.App/Services/FileSystemProjectTrustStore.cs
@@ -61,6 +61,44 @@ public sealed class FileSystemProjectTrustStore
         return keys;
     }
 
+    public IReadOnlyDictionary<string, SignaturePublicKey> LoadActiveContributorKeys(
+        string localWorkspaceRoot,
+        StoredIdentity currentIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(currentIdentity);
+
+        var document = LoadDocument(localWorkspaceRoot);
+        if (document is null)
+        {
+            return new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [currentIdentity.PublicKey.KeyId] = currentIdentity.PublicKey,
+            };
+        }
+
+        var keys = new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal);
+        foreach (var key in document.Keys.Where(static key =>
+                     key.IsActive &&
+                     key.Role is not Blueprints.Core.Enums.MemberRole.Viewer))
+        {
+            try
+            {
+                keys[key.KeyId] = new SignaturePublicKey(
+                    key.KeyId,
+                    Convert.FromBase64String(key.PublicKeyBase64));
+            }
+            catch (FormatException exception)
+            {
+                throw new InvalidOperationException(
+                    $"Trusted public key {key.KeyId} is not valid Base64.",
+                    exception);
+            }
+        }
+
+        return keys;
+    }
+
     public void Initialize(
         string localWorkspaceRoot,
         Guid projectId,
@@ -107,7 +145,9 @@ public sealed class FileSystemProjectTrustStore
                 member.DisplayName,
                 ResolveKeyId(member),
                 member.PublicKey,
-                trustedUtc)));
+                trustedUtc,
+                member.Role,
+                member.IsActive)));
     }
 
     private static string ResolveKeyId(ProjectMember member) =>

--- a/Blueprints.App/Services/LocalWorkspaceSessionService.cs
+++ b/Blueprints.App/Services/LocalWorkspaceSessionService.cs
@@ -43,7 +43,10 @@ public sealed class LocalWorkspaceSessionService
             DetermineHealth(analysis),
             analysis.OutgoingDocumentPaths.Count,
             analysis.IncomingDocumentPaths.Count,
-            analysis.PotentialConflictDocumentPaths.Count);
+            analysis.PotentialConflictDocumentPaths.Count,
+            syncState.LastPulledManifestVersion,
+            syncState.LastPushedManifestVersion,
+            syncState.LastSuccessfulTrustValidationUtc);
 
         return workspaceSession with
         {

--- a/Blueprints.App/Services/MarkdownChangelogBuilder.cs
+++ b/Blueprints.App/Services/MarkdownChangelogBuilder.cs
@@ -10,14 +10,15 @@ public static class MarkdownChangelogBuilder
     public static string Build(
         ProjectWorkspaceSnapshot workspace,
         VersionWorkspaceSnapshot versionSnapshot,
-        IReadOnlyList<SourceChangeSummary>? sourceChanges = null)
+        IReadOnlyList<SourceChangeSummary>? sourceChanges = null,
+        ChangelogRules? rulesOverride = null)
     {
         ArgumentNullException.ThrowIfNull(workspace);
         ArgumentNullException.ThrowIfNull(versionSnapshot);
 
         var builder = new StringBuilder();
         var project = workspace.Project;
-        var rules = project.ChangelogRules;
+        var rules = rulesOverride ?? project.ChangelogRules;
         var manualOrder = versionSnapshot.Version.ManualOrder
             .Select((itemId, index) => new { itemId, index })
             .ToDictionary(static entry => entry.itemId, static entry => entry.index);
@@ -39,24 +40,27 @@ public static class MarkdownChangelogBuilder
             .Append(' ')
             .Append(versionSnapshot.Version.Name)
             .AppendLine();
-        builder.AppendLine();
-        builder.Append("Generated: ")
-            .AppendLine(DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm 'UTC'"));
-        builder.Append("Status: ")
-            .AppendLine(versionSnapshot.Version.Status.ToString());
-
-        if (versionSnapshot.Version.ReleasedUtc is DateTimeOffset releasedUtc)
-        {
-            builder.Append("Released: ")
-                .AppendLine(releasedUtc.ToString("yyyy-MM-dd HH:mm 'UTC'"));
-        }
-
-        if (!string.IsNullOrWhiteSpace(versionSnapshot.Version.Notes))
+        if (!rules.CompactModeByDefault)
         {
             builder.AppendLine();
-            builder.AppendLine("## Notes");
-            builder.AppendLine();
-            builder.AppendLine(versionSnapshot.Version.Notes.Trim());
+            builder.Append("Generated: ")
+                .AppendLine(DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm 'UTC'"));
+            builder.Append("Status: ")
+                .AppendLine(versionSnapshot.Version.Status.ToString());
+
+            if (versionSnapshot.Version.ReleasedUtc is DateTimeOffset releasedUtc)
+            {
+                builder.Append("Released: ")
+                    .AppendLine(releasedUtc.ToString("yyyy-MM-dd HH:mm 'UTC'"));
+            }
+
+            if (!string.IsNullOrWhiteSpace(versionSnapshot.Version.Notes))
+            {
+                builder.AppendLine();
+                builder.AppendLine("## Notes");
+                builder.AppendLine();
+                builder.AppendLine(versionSnapshot.Version.Notes.Trim());
+            }
         }
 
         if (includedItems.Length == 0)

--- a/Blueprints.App/Services/ProjectInvitationService.cs
+++ b/Blueprints.App/Services/ProjectInvitationService.cs
@@ -1,0 +1,145 @@
+using System.Text;
+using System.Text.Json;
+using Blueprints.App.Models;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class ProjectInvitationService
+{
+    private const int CurrentSchemaVersion = 1;
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+    private static readonly JsonSerializerOptions PayloadSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+    private readonly ISignatureService _signatureService;
+
+    public ProjectInvitationService(ISignatureService signatureService)
+    {
+        _signatureService = signatureService;
+    }
+
+    public string Write(
+        string filePath,
+        ProjectInvitationPayload payload,
+        SignatureKeyMaterial signingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(signingKey);
+
+        var normalized = payload with
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            CreatedUtc = DateTimeOffset.UtcNow,
+        };
+        var proof = _signatureService.Sign(
+            SerializePayload(normalized),
+            signingKey);
+        WriteAtomically(
+            filePath,
+            JsonSerializer.Serialize(
+                new ProjectInvitationFile(normalized, proof),
+                SerializerOptions));
+        return Path.GetFullPath(filePath);
+    }
+
+    public ProjectInvitationPayload Read(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var invitation = JsonSerializer.Deserialize<ProjectInvitationFile>(
+            File.ReadAllText(filePath, Encoding.UTF8),
+            SerializerOptions)
+            ?? throw new InvalidOperationException("Project invitation could not be read.");
+        var payload = invitation.Project;
+        if (payload.SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported project invitation schema {payload.SchemaVersion}.");
+        }
+
+        if (payload.ProjectId == Guid.Empty ||
+            payload.InvitedUserId == Guid.Empty ||
+            payload.InviterUserId == Guid.Empty ||
+            string.IsNullOrWhiteSpace(payload.InvitedKeyId) ||
+            string.IsNullOrWhiteSpace(payload.InviterKeyId))
+        {
+            throw new InvalidOperationException("Project invitation is missing required trust fields.");
+        }
+
+        if (payload.TrustedKeys.Count == 0 || payload.TrustedKeys.Count > 1000)
+        {
+            throw new InvalidOperationException("Project invitation has an invalid trusted-key count.");
+        }
+
+        if (payload.TrustedKeys
+            .GroupBy(static key => key.KeyId, StringComparer.Ordinal)
+            .Any(static group => group.Count() > 1))
+        {
+            throw new InvalidOperationException("Project invitation contains duplicate key IDs.");
+        }
+
+        try
+        {
+            var inviterKey = new SignaturePublicKey(
+                payload.InviterKeyId,
+                Convert.FromBase64String(payload.InviterPublicKeyBase64));
+            if (!_signatureService.Verify(
+                    SerializePayload(payload),
+                    invitation.Proof,
+                    inviterKey))
+            {
+                throw new InvalidOperationException("Project invitation proof is invalid.");
+            }
+
+            foreach (var trustedKey in payload.TrustedKeys)
+            {
+                _ = Convert.FromBase64String(trustedKey.PublicKeyBase64);
+            }
+
+            if (!payload.TrustedKeys.Any(key =>
+                    string.Equals(key.KeyId, payload.InviterKeyId, StringComparison.Ordinal) &&
+                    string.Equals(
+                        key.PublicKeyBase64,
+                        payload.InviterPublicKeyBase64,
+                        StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException(
+                    "Project invitation does not include its signer in the trusted-key set.");
+            }
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException(
+                "Project invitation contains invalid key or proof data.",
+                exception);
+        }
+
+        return payload;
+    }
+
+    private static byte[] SerializePayload(ProjectInvitationPayload payload) =>
+        JsonSerializer.SerializeToUtf8Bytes(payload, PayloadSerializerOptions);
+
+    private static void WriteAtomically(string filePath, string json)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(fullPath)
+            ?? throw new InvalidOperationException("Invitation path has no parent.");
+        Directory.CreateDirectory(directory);
+        var tempPath = fullPath + ".tmp";
+        File.WriteAllText(
+            tempPath,
+            json,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(tempPath, fullPath, overwrite: true);
+    }
+}

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Blueprints.App.Models;
 using Blueprints.Collaboration.Enums;
 using Blueprints.Collaboration.Models;
@@ -94,7 +95,10 @@ public sealed class ProjectWorkspaceCoordinatorService
             DetermineHealth(analysis, conflictPaths.Length),
             analysis.OutgoingDocumentPaths.Count,
             analysis.IncomingDocumentPaths.Count,
-            conflictPaths.Length);
+            conflictPaths.Length,
+            syncState.LastPulledManifestVersion,
+            syncState.LastPushedManifestVersion,
+            syncState.LastSuccessfulTrustValidationUtc);
 
         var session = new LocalWorkspaceSession(
             identity,
@@ -636,16 +640,32 @@ public sealed class ProjectWorkspaceCoordinatorService
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureConflictExists(session, documentPath);
 
-        switch (choice)
+        var recoveryDirectory = CreateConflictRecovery(
+            localWorkspaceRoot,
+            sharedWorkspaceRoot,
+            documentPath,
+            choice);
+
+        try
         {
-            case ConflictResolutionChoice.KeepLocal:
-                CopyDocumentPair(localWorkspaceRoot, sharedWorkspaceRoot, documentPath);
-                break;
-            case ConflictResolutionChoice.AcceptShared:
-                CopyDocumentPair(sharedWorkspaceRoot, localWorkspaceRoot, documentPath);
-                break;
-            default:
-                throw new InvalidOperationException("Unknown conflict resolution choice.");
+            switch (choice)
+            {
+                case ConflictResolutionChoice.KeepLocal:
+                    MirrorDocumentPair(localWorkspaceRoot, sharedWorkspaceRoot, documentPath);
+                    break;
+                case ConflictResolutionChoice.AcceptShared:
+                    MirrorDocumentPair(sharedWorkspaceRoot, localWorkspaceRoot, documentPath);
+                    break;
+                default:
+                    throw new InvalidOperationException("Unknown conflict resolution choice.");
+            }
+
+            UpdateConflictRecoveryStatus(recoveryDirectory, "Applied");
+        }
+        catch (Exception exception)
+        {
+            UpdateConflictRecoveryStatus(recoveryDirectory, $"Failed: {exception.Message}");
+            throw;
         }
 
         var state = _syncStateStore.Load(localWorkspaceRoot);
@@ -662,9 +682,10 @@ public sealed class ProjectWorkspaceCoordinatorService
         return new ConflictResolutionResult(
             documentPath,
             choice,
+            recoveryDirectory,
             choice == ConflictResolutionChoice.KeepLocal
-                ? $"Kept local copy for {documentPath}."
-                : $"Accepted shared copy for {documentPath}.");
+                ? $"Kept local copy for {documentPath}. Recovery copy: {recoveryDirectory}"
+                : $"Accepted shared copy for {documentPath}. Recovery copy: {recoveryDirectory}");
     }
 
     public string GetSuggestedLocalWorkspaceRoot(string projectName, string projectCode) =>
@@ -1030,10 +1051,134 @@ public sealed class ProjectWorkspaceCoordinatorService
         CopyFile(sourceRoot, destinationRoot, Path.ChangeExtension(relativePath, ".sig"));
     }
 
+    private static string CreateConflictRecovery(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        string documentPath,
+        ConflictResolutionChoice choice)
+    {
+        var recoveryId = $"{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{Guid.NewGuid():N}";
+        var recoveryDirectory = Path.Combine(
+            localWorkspaceRoot,
+            ".blueprints",
+            "recovery",
+            "conflicts",
+            recoveryId);
+        var localState = SnapshotDocumentPair(
+            localWorkspaceRoot,
+            Path.Combine(recoveryDirectory, "local"),
+            documentPath);
+        var sharedState = SnapshotDocumentPair(
+            sharedWorkspaceRoot,
+            Path.Combine(recoveryDirectory, "shared"),
+            documentPath);
+        var record = new ConflictRecoveryRecord(
+            CurrentSchemaVersion,
+            recoveryId,
+            DateTimeOffset.UtcNow,
+            documentPath,
+            choice,
+            localState.DocumentPresent,
+            localState.SignaturePresent,
+            sharedState.DocumentPresent,
+            sharedState.SignaturePresent,
+            "Prepared");
+        WriteConflictRecoveryRecord(recoveryDirectory, record);
+        return recoveryDirectory;
+    }
+
+    private static (bool DocumentPresent, bool SignaturePresent) SnapshotDocumentPair(
+        string sourceRoot,
+        string recoveryRoot,
+        string documentPath)
+    {
+        var sourceDocumentPath = ResolveWorkspacePath(sourceRoot, documentPath);
+        var signaturePath = Path.ChangeExtension(documentPath, ".sig");
+        var sourceSignaturePath = ResolveWorkspacePath(sourceRoot, signaturePath);
+        var documentPresent = File.Exists(sourceDocumentPath);
+        var signaturePresent = File.Exists(sourceSignaturePath);
+
+        if (documentPresent)
+        {
+            CopyFile(sourceRoot, recoveryRoot, documentPath);
+        }
+
+        if (signaturePresent)
+        {
+            CopyFile(sourceRoot, recoveryRoot, signaturePath);
+        }
+
+        return (documentPresent, signaturePresent);
+    }
+
+    private static void MirrorDocumentPair(
+        string sourceRoot,
+        string destinationRoot,
+        string documentPath)
+    {
+        var signaturePath = Path.ChangeExtension(documentPath, ".sig");
+        var sourceDocumentPresent = File.Exists(ResolveWorkspacePath(sourceRoot, documentPath));
+        var sourceSignaturePresent = File.Exists(ResolveWorkspacePath(sourceRoot, signaturePath));
+
+        if (sourceDocumentPresent != sourceSignaturePresent)
+        {
+            throw new InvalidOperationException(
+                $"Cannot resolve {documentPath} because the selected source has an incomplete document/signature pair.");
+        }
+
+        if (!sourceDocumentPresent)
+        {
+            DeleteFileIfPresent(destinationRoot, documentPath);
+            DeleteFileIfPresent(destinationRoot, signaturePath);
+            return;
+        }
+
+        CopyFile(sourceRoot, destinationRoot, documentPath);
+        CopyFile(sourceRoot, destinationRoot, signaturePath);
+    }
+
+    private static void DeleteFileIfPresent(string workspaceRoot, string relativePath)
+    {
+        var path = ResolveWorkspacePath(workspaceRoot, relativePath);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void UpdateConflictRecoveryStatus(string recoveryDirectory, string status)
+    {
+        var manifestPath = Path.Combine(recoveryDirectory, "resolution.json");
+        var record = JsonSerializer.Deserialize<ConflictRecoveryRecord>(
+            File.ReadAllText(manifestPath),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+            ?? throw new InvalidOperationException("Conflict recovery metadata could not be read.");
+        WriteConflictRecoveryRecord(recoveryDirectory, record with { Status = status });
+    }
+
+    private static void WriteConflictRecoveryRecord(
+        string recoveryDirectory,
+        ConflictRecoveryRecord record)
+    {
+        Directory.CreateDirectory(recoveryDirectory);
+        var manifestPath = Path.Combine(recoveryDirectory, "resolution.json");
+        var tempPath = manifestPath + ".tmp";
+        File.WriteAllText(
+            tempPath,
+            JsonSerializer.Serialize(
+                record,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true,
+                }));
+        File.Move(tempPath, manifestPath, overwrite: true);
+    }
+
     private static void CopyFile(string sourceRoot, string destinationRoot, string relativePath)
     {
-        var sourcePath = Path.Combine(sourceRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
-        var destinationPath = Path.Combine(destinationRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var sourcePath = ResolveWorkspacePath(sourceRoot, relativePath);
+        var destinationPath = ResolveWorkspacePath(destinationRoot, relativePath);
         var directory = Path.GetDirectoryName(destinationPath);
         if (!string.IsNullOrWhiteSpace(directory))
         {
@@ -1048,5 +1193,21 @@ public sealed class ProjectWorkspaceCoordinatorService
         }
 
         File.Move(tempPath, destinationPath);
+    }
+
+    private static string ResolveWorkspacePath(string workspaceRoot, string relativePath)
+    {
+        var fullRoot = Path.GetFullPath(workspaceRoot);
+        var fullPath = Path.GetFullPath(
+            Path.Combine(fullRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var relativeToRoot = Path.GetRelativePath(fullRoot, fullPath);
+        if (relativeToRoot == ".." ||
+            relativeToRoot.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+            Path.IsPathRooted(relativePath))
+        {
+            throw new InvalidOperationException("Workspace document path escapes its expected root.");
+        }
+
+        return fullPath;
     }
 }

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -55,6 +55,24 @@ public sealed class ProjectWorkspaceCoordinatorService
     public IReadOnlyList<RecentProjectReference> GetRecentProjects() =>
         _recentProjectsStore.Load();
 
+    public bool HasLocalIdentity => _identityService.ListProfiles().Count > 0;
+
+    public IdentitySummary CreateInitialIdentity(string displayName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        if (HasLocalIdentity)
+        {
+            throw new InvalidOperationException(
+                "A local signing identity is already configured.");
+        }
+
+        var identity = _identityService.CreateIdentity(displayName.Trim());
+        return new IdentitySummary(
+            identity.Profile.DisplayName,
+            identity.Profile.UserId.ToString(),
+            identity.Profile.KeyStorageProvider);
+    }
+
     public string ExportIdentityInvitation(string filePath)
     {
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
@@ -515,11 +533,195 @@ public sealed class ProjectWorkspaceCoordinatorService
         }, "version.release", $"Released version {existing.Version.Name}.");
     }
 
+    public WorkspaceArchiveResult ArchiveVersion(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        Guid versionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var version = workspace.Versions.FirstOrDefault(entry =>
+            entry.Version.VersionId == versionId)
+            ?? throw new InvalidOperationException("The selected version was not found.");
+        EnsureArchivable(version.Version.Status, "version");
+
+        var archiveDirectory = CreateArchiveDirectory(
+            localWorkspaceRoot,
+            "version",
+            versionId);
+        var versionDirectory = Path.Combine(
+            localWorkspaceRoot,
+            "versions",
+            versionId.ToString("N"));
+        var archivedVersionDirectory = Path.Combine(
+            archiveDirectory,
+            "versions",
+            versionId.ToString("N"));
+        CopyDirectory(versionDirectory, archivedVersionDirectory);
+        WriteArchiveRecord(
+            archiveDirectory,
+            new WorkspaceArchiveRecord(
+                CurrentSchemaVersion,
+                Path.GetFileName(archiveDirectory),
+                "version",
+                versionId,
+                version.Version.Name,
+                DateTimeOffset.UtcNow,
+                identity.Profile.UserId,
+                identity.Profile.DisplayName,
+                "Prepared"));
+
+        Directory.Delete(versionDirectory, recursive: true);
+        try
+        {
+            var removedEntityIds = version.Items
+                .Select(static item => item.ItemId)
+                .Append(versionId)
+                .ToHashSet();
+            var updatedWorkspace = workspace with
+            {
+                Versions = workspace.Versions
+                    .Where(entry => entry.Version.VersionId != versionId)
+                    .ToArray(),
+                CanvasLayout = RemoveArchivedLayoutNodes(
+                    workspace.CanvasLayout,
+                    removedEntityIds,
+                    identity),
+            };
+            var updatedSession = SaveWorkspace(
+                localWorkspaceRoot,
+                sharedWorkspaceRoot,
+                identity,
+                updatedWorkspace,
+                "version.archive",
+                $"Archived draft version {version.Version.Name}.");
+            UpdateArchiveStatus(archiveDirectory, "Applied");
+            return new WorkspaceArchiveResult(
+                updatedSession,
+                archiveDirectory,
+                $"Archived version {version.Version.Name}. Recovery copy: {archiveDirectory}");
+        }
+        catch
+        {
+            if (!Directory.Exists(versionDirectory))
+            {
+                CopyDirectory(archivedVersionDirectory, versionDirectory);
+            }
+
+            UpdateArchiveStatus(archiveDirectory, "Failed and restored");
+            throw;
+        }
+    }
+
+    public WorkspaceArchiveResult ArchiveItem(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        Guid versionId,
+        Guid itemId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var versionIndex = workspace.Versions
+            .Select((entry, index) => (entry, index))
+            .FirstOrDefault(pair => pair.entry.Version.VersionId == versionId);
+        if (versionIndex.entry is null)
+        {
+            throw new InvalidOperationException("The selected version was not found.");
+        }
+
+        EnsureArchivable(versionIndex.entry.Version.Status, "item");
+        var item = versionIndex.entry.Items.FirstOrDefault(candidate =>
+            candidate.ItemId == itemId)
+            ?? throw new InvalidOperationException("The selected item was not found.");
+        var relativeDocumentPath =
+            $"versions/{versionId:N}/items/{itemId:N}.json";
+        var archiveDirectory = CreateArchiveDirectory(
+            localWorkspaceRoot,
+            "item",
+            itemId);
+        CopyDocumentPair(
+            localWorkspaceRoot,
+            archiveDirectory,
+            relativeDocumentPath);
+        WriteArchiveRecord(
+            archiveDirectory,
+            new WorkspaceArchiveRecord(
+                CurrentSchemaVersion,
+                Path.GetFileName(archiveDirectory),
+                "item",
+                itemId,
+                item.ItemKey,
+                DateTimeOffset.UtcNow,
+                identity.Profile.UserId,
+                identity.Profile.DisplayName,
+                "Prepared"));
+        DeleteFileIfPresent(localWorkspaceRoot, relativeDocumentPath);
+        DeleteFileIfPresent(
+            localWorkspaceRoot,
+            Path.ChangeExtension(relativeDocumentPath, ".sig"));
+
+        try
+        {
+            var versions = workspace.Versions.ToArray();
+            versions[versionIndex.index] = versionIndex.entry with
+            {
+                Version = versionIndex.entry.Version with
+                {
+                    ManualOrder = versionIndex.entry.Version.ManualOrder
+                        .Where(id => id != itemId)
+                        .ToArray(),
+                },
+                Items = versionIndex.entry.Items
+                    .Where(candidate => candidate.ItemId != itemId)
+                    .ToArray(),
+            };
+            var updatedSession = SaveWorkspace(
+                localWorkspaceRoot,
+                sharedWorkspaceRoot,
+                identity,
+                workspace with
+                {
+                    Versions = versions,
+                    CanvasLayout = RemoveArchivedLayoutNodes(
+                        workspace.CanvasLayout,
+                        new HashSet<Guid> { itemId },
+                        identity),
+                },
+                "item.archive",
+                $"Archived item {item.ItemKey}.");
+            UpdateArchiveStatus(archiveDirectory, "Applied");
+            return new WorkspaceArchiveResult(
+                updatedSession,
+                archiveDirectory,
+                $"Archived item {item.ItemKey}. Recovery copy: {archiveDirectory}");
+        }
+        catch
+        {
+            CopyDocumentPair(
+                archiveDirectory,
+                localWorkspaceRoot,
+                relativeDocumentPath);
+            UpdateArchiveStatus(archiveDirectory, "Failed and restored");
+            throw;
+        }
+    }
+
     public ChangelogExportResult ExportVersionChangelog(
         string localWorkspaceRoot,
         string sharedWorkspaceRoot,
         Guid versionId,
-        IReadOnlyList<SourceChangeSummary>? sourceChanges = null)
+        IReadOnlyList<SourceChangeSummary>? sourceChanges = null,
+        ChangelogRules? rulesOverride = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
         ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
@@ -533,7 +735,11 @@ public sealed class ProjectWorkspaceCoordinatorService
             throw new InvalidOperationException("The selected version was not found.");
         }
 
-        var markdown = MarkdownChangelogBuilder.Build(session.LoadResult.Workspace, version, sourceChanges);
+        var markdown = MarkdownChangelogBuilder.Build(
+            session.LoadResult.Workspace,
+            version,
+            sourceChanges,
+            rulesOverride);
         var exportsRoot = Path.Combine(localWorkspaceRoot, "exports");
         Directory.CreateDirectory(exportsRoot);
 
@@ -546,6 +752,28 @@ public sealed class ProjectWorkspaceCoordinatorService
             version.Version.Name,
             filePath,
             markdown);
+    }
+
+    public string PreviewVersionChangelog(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        Guid versionId,
+        IReadOnlyList<SourceChangeSummary>? sourceChanges = null,
+        ChangelogRules? rulesOverride = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureTrustedWorkspace(session);
+        var version = session.LoadResult.Workspace.Versions
+            .FirstOrDefault(entry => entry.Version.VersionId == versionId)
+            ?? throw new InvalidOperationException("The selected version was not found.");
+        return MarkdownChangelogBuilder.Build(
+            session.LoadResult.Workspace,
+            version,
+            sourceChanges,
+            rulesOverride);
     }
 
     public LocalWorkspaceSession InviteMember(
@@ -1147,6 +1375,37 @@ public sealed class ProjectWorkspaceCoordinatorService
         }
     }
 
+    private static void EnsureArchivable(ReleaseStatus status, string entityType)
+    {
+        if (status is ReleaseStatus.Frozen or ReleaseStatus.Released)
+        {
+            throw new InvalidOperationException(
+                $"Cannot archive a {entityType} from a frozen or released version.");
+        }
+    }
+
+    private static CanvasLayoutDocument? RemoveArchivedLayoutNodes(
+        CanvasLayoutDocument? layout,
+        IReadOnlySet<Guid> removedEntityIds,
+        Security.Models.StoredIdentity identity)
+    {
+        if (layout is null)
+        {
+            return null;
+        }
+
+        return layout with
+        {
+            Revision = layout.Revision + 1,
+            Nodes = layout.Nodes
+                .Where(node => !removedEntityIds.Contains(node.EntityId))
+                .ToArray(),
+            UpdatedUtc = DateTimeOffset.UtcNow,
+            LastModifiedByUserId = identity.Profile.UserId,
+            LastModifiedByName = identity.Profile.DisplayName,
+        };
+    }
+
     private static (int Major, int Minor) ParseVersion(string versionName)
     {
         var parts = versionName.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -1353,6 +1612,94 @@ public sealed class ProjectWorkspaceCoordinatorService
             "Prepared");
         WriteConflictRecoveryRecord(recoveryDirectory, record);
         return recoveryDirectory;
+    }
+
+    private static string CreateArchiveDirectory(
+        string localWorkspaceRoot,
+        string entityType,
+        Guid entityId)
+    {
+        var archiveId =
+            $"{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{entityType}-{entityId:N}-{Guid.NewGuid():N}";
+        var archiveDirectory = Path.Combine(
+            localWorkspaceRoot,
+            ".blueprints",
+            "archive",
+            archiveId);
+        Directory.CreateDirectory(archiveDirectory);
+        return archiveDirectory;
+    }
+
+    private static void UpdateArchiveStatus(
+        string archiveDirectory,
+        string status)
+    {
+        var recordPath = Path.Combine(archiveDirectory, "archive.json");
+        var record = JsonSerializer.Deserialize<WorkspaceArchiveRecord>(
+            File.ReadAllText(recordPath),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+            ?? throw new InvalidOperationException("Archive metadata could not be read.");
+        WriteArchiveRecord(
+            archiveDirectory,
+            record with { Status = status });
+    }
+
+    private static void WriteArchiveRecord(
+        string archiveDirectory,
+        WorkspaceArchiveRecord record)
+    {
+        Directory.CreateDirectory(archiveDirectory);
+        var path = Path.Combine(archiveDirectory, "archive.json");
+        var tempPath = path + ".tmp";
+        File.WriteAllText(
+            tempPath,
+            JsonSerializer.Serialize(
+                record,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true,
+                }));
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    private static void CopyDirectory(
+        string sourceDirectory,
+        string destinationDirectory)
+    {
+        if (!Directory.Exists(sourceDirectory))
+        {
+            throw new DirectoryNotFoundException(
+                $"Archive source directory was not found: {sourceDirectory}");
+        }
+
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var directory in Directory.EnumerateDirectories(
+                     sourceDirectory,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(Path.Combine(
+                destinationDirectory,
+                Path.GetRelativePath(sourceDirectory, directory)));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(
+                     sourceDirectory,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            var destination = Path.Combine(
+                destinationDirectory,
+                Path.GetRelativePath(sourceDirectory, file));
+            var parent = Path.GetDirectoryName(destination);
+            if (!string.IsNullOrWhiteSpace(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+
+            File.Copy(file, destination, overwrite: true);
+        }
     }
 
     private static (bool DocumentPresent, bool SignaturePresent) SnapshotDocumentPair(

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -97,7 +97,9 @@ public sealed class ProjectWorkspaceCoordinatorService
                     identity.Profile.DisplayName,
                     identity.Profile.KeyId,
                     identity.Profile.PublicKeyBase64,
-                    DateTimeOffset.UtcNow),
+                    DateTimeOffset.UtcNow,
+                    MemberRole.Admin,
+                    true),
             ]);
         AppendAuditEntry(localRoot, identity, snapshot, "project.create", $"Created project {snapshot.Project.Name}.");
         Directory.CreateDirectory(sharedRoot);
@@ -116,8 +118,11 @@ public sealed class ProjectWorkspaceCoordinatorService
         Directory.CreateDirectory(paths.SharedProjectRoot);
         var safetyReport = _sharedFolderSafetyInspector.Inspect(paths.SharedProjectRoot, paths.LocalWorkspaceRoot);
         var trustedKeys = _projectTrustStore.LoadKeys(paths.LocalWorkspaceRoot, identity);
+        var activeContributorKeys = _projectTrustStore.LoadActiveContributorKeys(
+            paths.LocalWorkspaceRoot,
+            identity);
 
-        var loadResult = _workspaceStore.Load(paths.LocalWorkspaceRoot, trustedKeys);
+        var loadResult = _workspaceStore.Load(paths.LocalWorkspaceRoot, activeContributorKeys);
         var auditValidation = _auditLogService.Validate(paths.LocalWorkspaceRoot, trustedKeys);
         loadResult = ApplyWorkspaceSafety(loadResult, safetyReport, auditValidation);
         if (loadResult.TrustReport.State == TrustState.Trusted)
@@ -133,6 +138,9 @@ public sealed class ProjectWorkspaceCoordinatorService
             .Union(analysis.PotentialConflictDocumentPaths, StringComparer.Ordinal)
             .OrderBy(static path => path, StringComparer.Ordinal)
             .ToArray();
+        var sharedManifest = _workspaceSyncService.InspectSharedManifest(
+            paths.SharedProjectRoot,
+            activeContributorKeys);
         var sync = new SyncSummary(
             DetermineHealth(analysis, conflictPaths.Length),
             analysis.OutgoingDocumentPaths.Count,
@@ -140,7 +148,12 @@ public sealed class ProjectWorkspaceCoordinatorService
             conflictPaths.Length,
             syncState.LastPulledManifestVersion,
             syncState.LastPushedManifestVersion,
-            syncState.LastSuccessfulTrustValidationUtc);
+            syncState.LastSuccessfulTrustValidationUtc,
+            sharedManifest.ManifestVersion,
+            sharedManifest.BatchId,
+            sharedManifest.Exists ? sharedManifest.SignatureValid : null,
+            auditValidation.IsValid,
+            auditValidation.EntryCount);
 
         var session = new LocalWorkspaceSession(
             identity,
@@ -668,7 +681,9 @@ public sealed class ProjectWorkspaceCoordinatorService
                 member.DisplayName,
                 ResolveMemberKeyId(member),
                 member.PublicKey,
-                member.JoinedUtc))
+                member.JoinedUtc,
+                member.Role,
+                member.IsActive))
             .ToArray();
         var project = session.LoadResult.Workspace.Project;
         var payload = new ProjectInvitationPayload(
@@ -736,8 +751,12 @@ public sealed class ProjectWorkspaceCoordinatorService
                 invitation.ProjectId,
                 invitation.TrustedKeys);
             var trustedKeys = _projectTrustStore.LoadKeys(stageRoot, identity);
+            var activeContributorKeys = _projectTrustStore.LoadActiveContributorKeys(
+                stageRoot,
+                identity);
             var pull = _workspaceSyncService.Pull(
                 new WorkspacePaths(stageRoot, resolvedSharedRoot),
+                activeContributorKeys,
                 trustedKeys);
             if (!pull.Success)
             {
@@ -745,7 +764,7 @@ public sealed class ProjectWorkspaceCoordinatorService
                     $"Project join was blocked: {pull.Summary}");
             }
 
-            var loadResult = _workspaceStore.Load(stageRoot, trustedKeys);
+            var loadResult = _workspaceStore.Load(stageRoot, activeContributorKeys);
             var auditValidation = _auditLogService.Validate(stageRoot, trustedKeys);
             if (loadResult.TrustReport.State != TrustState.Trusted ||
                 !auditValidation.IsValid)
@@ -789,6 +808,7 @@ public sealed class ProjectWorkspaceCoordinatorService
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureTrustedWorkspace(session);
+        EnsureCurrentIdentityCanContribute(session);
         var trustedKeys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
 
         return _workspaceSyncService.Push(
@@ -808,9 +828,12 @@ public sealed class ProjectWorkspaceCoordinatorService
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureTrustedWorkspace(session);
-        var trustedKeys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
+        var trustedKeys = _projectTrustStore.LoadActiveContributorKeys(
+            localWorkspaceRoot,
+            identity);
+        var auditKeys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
 
-        return _workspaceSyncService.Pull(session.Paths, trustedKeys);
+        return _workspaceSyncService.Pull(session.Paths, trustedKeys, auditKeys);
     }
 
     public ConflictResolutionResult ResolveConflict(
@@ -825,6 +848,7 @@ public sealed class ProjectWorkspaceCoordinatorService
 
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureConflictExists(session, documentPath);
+        EnsureCurrentIdentityCanContribute(session);
 
         var recoveryDirectory = CreateConflictRecovery(
             localWorkspaceRoot,
@@ -1159,6 +1183,7 @@ public sealed class ProjectWorkspaceCoordinatorService
         }
 
         EnsureNoSyncConflicts(session);
+        EnsureCurrentIdentityCanContribute(session);
     }
 
     private static void EnsureNoSyncConflicts(LocalWorkspaceSession session)
@@ -1178,6 +1203,20 @@ public sealed class ProjectWorkspaceCoordinatorService
         if (currentMember is null || currentMember.Role != MemberRole.Admin)
         {
             throw new InvalidOperationException("Only active admins can change project membership.");
+        }
+    }
+
+    private static void EnsureCurrentIdentityCanContribute(LocalWorkspaceSession session)
+    {
+        var currentMember = session.LoadResult.Workspace.Members.Members
+            .FirstOrDefault(member =>
+                member.UserId == session.Identity.Profile.UserId &&
+                member.IsActive);
+        if (currentMember is null ||
+            currentMember.Role is not MemberRole.Editor and not MemberRole.Admin)
+        {
+            throw new InvalidOperationException(
+                "Only active editors or administrators can change or publish this project.");
         }
     }
 

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -8,6 +8,7 @@ using Blueprints.Core.Models;
 using Blueprints.Core.Services;
 using Blueprints.Security.Abstractions;
 using Blueprints.Security.Models;
+using Blueprints.Security.Services;
 using Blueprints.Storage.Abstractions;
 using Blueprints.Storage.Models;
 using Blueprints.Storage.Services;
@@ -25,6 +26,11 @@ public sealed class ProjectWorkspaceCoordinatorService
     private readonly RecentProjectsStore _recentProjectsStore;
     private readonly FileSystemAuditLogService _auditLogService;
     private readonly SharedFolderSafetyInspector _sharedFolderSafetyInspector;
+    private readonly FileSystemProjectTrustStore _projectTrustStore = new();
+    private readonly IdentityInvitationService _identityInvitationService =
+        new(new Ed25519SignatureService());
+    private readonly ProjectInvitationService _projectInvitationService =
+        new(new Ed25519SignatureService());
 
     public ProjectWorkspaceCoordinatorService(
         IIdentityService identityService,
@@ -49,6 +55,23 @@ public sealed class ProjectWorkspaceCoordinatorService
     public IReadOnlyList<RecentProjectReference> GetRecentProjects() =>
         _recentProjectsStore.Load();
 
+    public string ExportIdentityInvitation(string filePath)
+    {
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        return _identityInvitationService.Write(filePath, identity);
+    }
+
+    public MemberInviteRequest ReadIdentityInvitation(string filePath)
+    {
+        var invitation = _identityInvitationService.Read(filePath);
+        return new MemberInviteRequest(
+            invitation.UserId.ToString(),
+            invitation.DisplayName,
+            invitation.PublicKeyBase64,
+            MemberRole.Editor,
+            invitation.KeyId);
+    }
+
     public LocalWorkspaceSession CreateProject(ProjectCreateRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -65,6 +88,17 @@ public sealed class ProjectWorkspaceCoordinatorService
 
         var snapshot = CreateProjectSnapshot(identity, request);
         _workspaceStore.Save(localRoot, snapshot, identity.SigningKey);
+        _projectTrustStore.Initialize(
+            localRoot,
+            snapshot.Project.ProjectId,
+            [
+                new TrustedProjectKey(
+                    identity.Profile.UserId,
+                    identity.Profile.DisplayName,
+                    identity.Profile.KeyId,
+                    identity.Profile.PublicKeyBase64,
+                    DateTimeOffset.UtcNow),
+            ]);
         AppendAuditEntry(localRoot, identity, snapshot, "project.create", $"Created project {snapshot.Project.Name}.");
         Directory.CreateDirectory(sharedRoot);
 
@@ -81,10 +115,18 @@ public sealed class ProjectWorkspaceCoordinatorService
         var paths = WorkspacePathResolver.Create(localWorkspaceRoot, sharedWorkspaceRoot);
         Directory.CreateDirectory(paths.SharedProjectRoot);
         var safetyReport = _sharedFolderSafetyInspector.Inspect(paths.SharedProjectRoot, paths.LocalWorkspaceRoot);
+        var trustedKeys = _projectTrustStore.LoadKeys(paths.LocalWorkspaceRoot, identity);
 
-        var loadResult = _workspaceStore.Load(paths.LocalWorkspaceRoot, identity.PublicKey);
-        var auditValidation = _auditLogService.Validate(paths.LocalWorkspaceRoot, identity.PublicKey);
+        var loadResult = _workspaceStore.Load(paths.LocalWorkspaceRoot, trustedKeys);
+        var auditValidation = _auditLogService.Validate(paths.LocalWorkspaceRoot, trustedKeys);
         loadResult = ApplyWorkspaceSafety(loadResult, safetyReport, auditValidation);
+        if (loadResult.TrustReport.State == TrustState.Trusted)
+        {
+            _projectTrustStore.MergeVerifiedMembers(
+                paths.LocalWorkspaceRoot,
+                loadResult.Workspace.Project.ProjectId,
+                loadResult.Workspace.Members.Members);
+        }
         var syncState = _syncStateStore.Load(paths.LocalWorkspaceRoot);
         var analysis = _syncAnalyzer.Analyze(paths, syncState.TrackedEntries);
         var conflictPaths = syncState.UnresolvedConflicts
@@ -515,6 +557,9 @@ public sealed class ProjectWorkspaceCoordinatorService
 
         var displayName = request.DisplayName.Trim();
         var publicKey = request.PublicKey.Trim();
+        var keyId = string.IsNullOrWhiteSpace(request.KeyId)
+            ? invitedUserId.ToString("N")
+            : request.KeyId.Trim();
         if (string.IsNullOrWhiteSpace(displayName))
         {
             throw new InvalidOperationException("Invitee display name is required.");
@@ -523,6 +568,11 @@ public sealed class ProjectWorkspaceCoordinatorService
         if (string.IsNullOrWhiteSpace(publicKey))
         {
             throw new InvalidOperationException("Invitee public key is required.");
+        }
+
+        if (keyId.Length > 128)
+        {
+            throw new InvalidOperationException("Invitee key ID is too long.");
         }
 
         ValidatePublicKey(publicKey);
@@ -545,7 +595,8 @@ public sealed class ProjectWorkspaceCoordinatorService
                 publicKey,
                 request.Role,
                 DateTimeOffset.UtcNow,
-                true));
+                true,
+                keyId));
 
         return SaveMembers(localWorkspaceRoot, sharedWorkspaceRoot, identity, session.LoadResult.Workspace, members);
     }
@@ -590,6 +641,139 @@ public sealed class ProjectWorkspaceCoordinatorService
         return SaveMembers(localWorkspaceRoot, sharedWorkspaceRoot, identity, session.LoadResult.Workspace, members);
     }
 
+    public string ExportProjectInvitation(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        Guid invitedUserId,
+        string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureTrustedWorkspace(session);
+        EnsureCurrentIdentityIsAdmin(session);
+        EnsureNoSyncConflicts(session);
+
+        var invitedMember = session.LoadResult.Workspace.Members.Members
+            .FirstOrDefault(member => member.UserId == invitedUserId && member.IsActive)
+            ?? throw new InvalidOperationException(
+                "Select an active invited member before exporting a project invitation.");
+        var members = session.LoadResult.Workspace.Members;
+        var trustedKeys = members.Members
+            .Select(member => new TrustedProjectKey(
+                member.UserId,
+                member.DisplayName,
+                ResolveMemberKeyId(member),
+                member.PublicKey,
+                member.JoinedUtc))
+            .ToArray();
+        var project = session.LoadResult.Workspace.Project;
+        var payload = new ProjectInvitationPayload(
+            1,
+            project.ProjectId,
+            project.Name,
+            project.ProjectCode,
+            session.Paths.SharedProjectRoot,
+            members.MembershipRevision,
+            invitedMember.UserId,
+            ResolveMemberKeyId(invitedMember),
+            identity.Profile.UserId,
+            identity.Profile.DisplayName,
+            identity.Profile.KeyId,
+            identity.Profile.PublicKeyBase64,
+            trustedKeys,
+            DateTimeOffset.UtcNow);
+        return _projectInvitationService.Write(filePath, payload, identity.SigningKey);
+    }
+
+    public LocalWorkspaceSession JoinProjectFromInvitation(
+        string invitationFilePath,
+        string localWorkspaceRoot,
+        string? sharedWorkspaceRoot = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(invitationFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var invitation = _projectInvitationService.Read(invitationFilePath);
+        if (invitation.InvitedUserId != identity.Profile.UserId ||
+            !string.Equals(
+                invitation.InvitedKeyId,
+                identity.Profile.KeyId,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "This project invitation targets a different local identity.");
+        }
+
+        var resolvedSharedRoot = string.IsNullOrWhiteSpace(sharedWorkspaceRoot)
+            ? invitation.SharedWorkspaceRoot
+            : sharedWorkspaceRoot.Trim();
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedSharedRoot);
+        EnsureSharedFolderSafe(localWorkspaceRoot, resolvedSharedRoot);
+        if (Directory.Exists(localWorkspaceRoot) &&
+            Directory.EnumerateFileSystemEntries(localWorkspaceRoot).Any())
+        {
+            throw new InvalidOperationException(
+                "The selected local workspace folder must be empty before joining.");
+        }
+
+        var fullLocalRoot = Path.GetFullPath(localWorkspaceRoot);
+        var parent = Path.GetDirectoryName(fullLocalRoot)
+            ?? throw new InvalidOperationException("Local workspace path has no parent.");
+        Directory.CreateDirectory(parent);
+        var stageRoot = Path.Combine(
+            parent,
+            $".blueprints-join-{Guid.NewGuid():N}");
+
+        try
+        {
+            _projectTrustStore.Initialize(
+                stageRoot,
+                invitation.ProjectId,
+                invitation.TrustedKeys);
+            var trustedKeys = _projectTrustStore.LoadKeys(stageRoot, identity);
+            var pull = _workspaceSyncService.Pull(
+                new WorkspacePaths(stageRoot, resolvedSharedRoot),
+                trustedKeys);
+            if (!pull.Success)
+            {
+                throw new InvalidOperationException(
+                    $"Project join was blocked: {pull.Summary}");
+            }
+
+            var loadResult = _workspaceStore.Load(stageRoot, trustedKeys);
+            var auditValidation = _auditLogService.Validate(stageRoot, trustedKeys);
+            if (loadResult.TrustReport.State != TrustState.Trusted ||
+                !auditValidation.IsValid)
+            {
+                throw new InvalidOperationException(
+                    "Project join was blocked because the staged workspace did not validate.");
+            }
+
+            ValidateJoinedWorkspace(invitation, identity, loadResult.Workspace);
+            if (Directory.Exists(fullLocalRoot))
+            {
+                Directory.Delete(fullLocalRoot);
+            }
+
+            Directory.Move(stageRoot, fullLocalRoot);
+            return OpenProject(fullLocalRoot, resolvedSharedRoot);
+        }
+        catch
+        {
+            if (Directory.Exists(stageRoot))
+            {
+                Directory.Delete(stageRoot, recursive: true);
+            }
+
+            throw;
+        }
+    }
+
     public LocalWorkspaceSession RefreshProject(
         string localWorkspaceRoot,
         string sharedWorkspaceRoot) =>
@@ -605,12 +789,13 @@ public sealed class ProjectWorkspaceCoordinatorService
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureTrustedWorkspace(session);
+        var trustedKeys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
 
         return _workspaceSyncService.Push(
             session.Paths,
             session.LoadResult.Workspace.Project.ProjectId,
             identity.SigningKey,
-            identity.PublicKey);
+            trustedKeys);
     }
 
     public WorkspaceSyncResult PullWorkspace(
@@ -623,8 +808,9 @@ public sealed class ProjectWorkspaceCoordinatorService
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
         var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
         EnsureTrustedWorkspace(session);
+        var trustedKeys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
 
-        return _workspaceSyncService.Pull(session.Paths, identity.PublicKey);
+        return _workspaceSyncService.Pull(session.Paths, trustedKeys);
     }
 
     public ConflictResolutionResult ResolveConflict(
@@ -774,7 +960,8 @@ public sealed class ProjectWorkspaceCoordinatorService
                         identity.Profile.PublicKeyBase64,
                         MemberRole.Admin,
                         createdUtc,
-                        true),
+                        true,
+                        identity.Profile.KeyId),
                 ]),
             []);
     }
@@ -1001,6 +1188,48 @@ public sealed class ProjectWorkspaceCoordinatorService
             throw new InvalidOperationException("At least one active admin must remain in the project.");
         }
     }
+
+    private static void ValidateJoinedWorkspace(
+        ProjectInvitationPayload invitation,
+        Security.Models.StoredIdentity identity,
+        ProjectWorkspaceSnapshot workspace)
+    {
+        if (workspace.Project.ProjectId != invitation.ProjectId ||
+            workspace.Members.ProjectId != invitation.ProjectId ||
+            workspace.Members.MembershipRevision < invitation.MembershipRevision)
+        {
+            throw new InvalidOperationException(
+                "The shared workspace does not match the project invitation.");
+        }
+
+        var invitedMember = workspace.Members.Members.FirstOrDefault(member =>
+            member.UserId == identity.Profile.UserId &&
+            member.IsActive &&
+            string.Equals(member.PublicKey, identity.Profile.PublicKeyBase64, StringComparison.Ordinal) &&
+            string.Equals(ResolveMemberKeyId(member), identity.Profile.KeyId, StringComparison.Ordinal));
+        if (invitedMember is null)
+        {
+            throw new InvalidOperationException(
+                "The current identity is not an active member of the invited project.");
+        }
+
+        var inviter = workspace.Members.Members.FirstOrDefault(member =>
+            member.UserId == invitation.InviterUserId &&
+            member.IsActive &&
+            member.Role == MemberRole.Admin &&
+            string.Equals(member.PublicKey, invitation.InviterPublicKeyBase64, StringComparison.Ordinal) &&
+            string.Equals(ResolveMemberKeyId(member), invitation.InviterKeyId, StringComparison.Ordinal));
+        if (inviter is null)
+        {
+            throw new InvalidOperationException(
+                "The project invitation signer is not an active project administrator.");
+        }
+    }
+
+    private static string ResolveMemberKeyId(ProjectMember member) =>
+        string.IsNullOrWhiteSpace(member.KeyId)
+            ? member.UserId.ToString("N")
+            : member.KeyId;
 
     private static void EnsureConflictExists(LocalWorkspaceSession session, string documentPath)
     {

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -43,6 +43,9 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _createSharedWorkspaceRoot = string.Empty;
     private string _openLocalWorkspaceRoot = string.Empty;
     private string _openSharedWorkspaceRoot = string.Empty;
+    private string _joinInvitationFilePath = string.Empty;
+    private string _joinLocalWorkspaceRoot = string.Empty;
+    private string _joinSharedWorkspaceRoot = string.Empty;
     private RecentProjectReference? _selectedRecentProject;
     private WorkspaceVersionCard? _selectedVersion;
     private WorkspaceItemCard? _selectedItem;
@@ -63,6 +66,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _inviteUserId = string.Empty;
     private string _inviteDisplayName = string.Empty;
     private string _invitePublicKey = string.Empty;
+    private string _inviteKeyId = string.Empty;
     private MemberRole _inviteRole = MemberRole.Editor;
     private string _memberEditorDisplayName = string.Empty;
     private MemberRole _memberEditorRole = MemberRole.Editor;
@@ -489,6 +493,24 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         get => _openSharedWorkspaceRoot;
         set => SetProperty(ref _openSharedWorkspaceRoot, value);
+    }
+
+    public string JoinInvitationFilePath
+    {
+        get => _joinInvitationFilePath;
+        set => SetProperty(ref _joinInvitationFilePath, value);
+    }
+
+    public string JoinLocalWorkspaceRoot
+    {
+        get => _joinLocalWorkspaceRoot;
+        set => SetProperty(ref _joinLocalWorkspaceRoot, value);
+    }
+
+    public string JoinSharedWorkspaceRoot
+    {
+        get => _joinSharedWorkspaceRoot;
+        set => SetProperty(ref _joinSharedWorkspaceRoot, value);
     }
 
     public RecentProjectReference? SelectedRecentProject
@@ -1047,6 +1069,37 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void JoinProject()
+    {
+        if (_coordinatorService is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(JoinInvitationFilePath) ||
+            string.IsNullOrWhiteSpace(JoinLocalWorkspaceRoot))
+        {
+            SetupMessage = "Choose a project invitation and an empty local workspace folder.";
+            return;
+        }
+
+        try
+        {
+            ApplySession(
+                _coordinatorService.JoinProjectFromInvitation(
+                    JoinInvitationFilePath,
+                    JoinLocalWorkspaceRoot,
+                    JoinSharedWorkspaceRoot));
+            RefreshRecentProjects();
+            SetupMessage = $"Joined project {CurrentProject.Name}.";
+        }
+        catch (Exception exception)
+        {
+            SetupMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
     private void ReturnToProjectSetup()
     {
         ApplySetupState("Choose a project to create or open.");
@@ -1413,9 +1466,82 @@ public partial class MainWindowViewModel : ViewModelBase
                         InviteUserId,
                         InviteDisplayName,
                         InvitePublicKey,
-                        InviteRole)));
+                        InviteRole,
+                        _inviteKeyId)));
             WorkspaceMessage = $"Invited member {InviteDisplayName.Trim()}.";
             ClearInviteEditor();
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ExportIdentityInvitation(string? filePath)
+    {
+        if (_coordinatorService is null || string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var exportedPath = _coordinatorService.ExportIdentityInvitation(filePath);
+            WorkspaceMessage = $"Exported signed identity invitation to {exportedPath}.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ImportIdentityInvitation(string? filePath)
+    {
+        if (_coordinatorService is null || string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var request = _coordinatorService.ReadIdentityInvitation(filePath);
+            InviteUserId = request.UserId;
+            InviteDisplayName = request.DisplayName;
+            InvitePublicKey = request.PublicKey;
+            InviteRole = request.Role;
+            _inviteKeyId = request.KeyId ?? string.Empty;
+            WorkspaceMessage =
+                $"Verified {request.DisplayName}'s signed identity invitation. Review the role, then invite.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ExportProjectInvitation(string? filePath)
+    {
+        if (_coordinatorService is null ||
+            _currentSession is null ||
+            SelectedMember is null ||
+            string.IsNullOrWhiteSpace(filePath))
+        {
+            WorkspaceMessage = "Select an active invited member first.";
+            return;
+        }
+
+        try
+        {
+            var exportedPath = _coordinatorService.ExportProjectInvitation(
+                _currentSession.Paths.LocalWorkspaceRoot,
+                _currentSession.Paths.SharedProjectRoot,
+                SelectedMember.UserId,
+                filePath);
+            WorkspaceMessage =
+                $"Exported signed project invitation for {SelectedMember.DisplayName} to {exportedPath}.";
         }
         catch (Exception exception)
         {
@@ -1973,6 +2099,7 @@ public partial class MainWindowViewModel : ViewModelBase
         InviteUserId = string.Empty;
         InviteDisplayName = string.Empty;
         InvitePublicKey = string.Empty;
+        _inviteKeyId = string.Empty;
         InviteRole = MemberRole.Editor;
     }
 

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -34,6 +34,8 @@ public partial class MainWindowViewModel : ViewModelBase
     private int _activeMemberCount;
     private int _membershipRevision;
     private bool _hasActiveSession;
+    private bool _hasLocalIdentity;
+    private string _identitySetupName = string.Empty;
     private string _setupMessage = string.Empty;
     private string _workspaceMessage = string.Empty;
     private string _createProjectName = "Blueprints";
@@ -49,6 +51,8 @@ public partial class MainWindowViewModel : ViewModelBase
     private RecentProjectReference? _selectedRecentProject;
     private WorkspaceVersionCard? _selectedVersion;
     private WorkspaceItemCard? _selectedItem;
+    private Guid? _pendingArchiveVersionId;
+    private Guid? _pendingArchiveItemId;
     private string _newVersionName = "1.0.0";
     private string _versionEditorName = string.Empty;
     private string _versionEditorNotes = string.Empty;
@@ -61,6 +65,10 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _changelogPreview = string.Empty;
     private string _lastChangelogExportPath = string.Empty;
     private string _gitChangelogSummary = string.Empty;
+    private bool _changelogIncludeIncomplete;
+    private bool _changelogIncludeItemKeys = true;
+    private bool _changelogIncludeDescriptions;
+    private bool _changelogCompactMode;
     private string _identityPublicKey = string.Empty;
     private WorkspaceMemberCard? _selectedMember;
     private string _inviteUserId = string.Empty;
@@ -133,6 +141,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RefreshRecentProjects();
         RefreshSuggestedPaths();
         RefreshIntegrations();
+        HasLocalIdentity = coordinatorService.HasLocalIdentity;
         ApplySetupState("Create a new project or open an existing workspace.");
     }
 
@@ -377,6 +386,32 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public bool IsSetupMode => !HasActiveSession;
 
+    public bool HasLocalIdentity
+    {
+        get => _hasLocalIdentity;
+        private set
+        {
+            if (SetProperty(ref _hasLocalIdentity, value))
+            {
+                OnPropertyChanged(nameof(IsIdentitySetupRequired));
+                OnPropertyChanged(nameof(LocalIdentitySetupSummary));
+            }
+        }
+    }
+
+    public bool IsIdentitySetupRequired => !HasLocalIdentity;
+
+    public string IdentitySetupName
+    {
+        get => _identitySetupName;
+        set => SetProperty(ref _identitySetupName, value);
+    }
+
+    public string LocalIdentitySetupSummary =>
+        HasLocalIdentity
+            ? "A protected local signing identity is ready."
+            : "Choose the name teammates will see on signed changes. This creates protected local key material.";
+
     public string SetupMessage
     {
         get => _setupMessage;
@@ -540,9 +575,14 @@ public partial class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(CanEditSelectedVersion));
                 OnPropertyChanged(nameof(CanEditItems));
                 OnPropertyChanged(nameof(CanReleaseSelectedVersion));
+                OnPropertyChanged(nameof(CanArchiveSelectedVersion));
+                OnPropertyChanged(nameof(CanArchiveSelectedItem));
+                OnPropertyChanged(nameof(IsSelectedVersionEmpty));
                 OnPropertyChanged(nameof(SelectedVersionStateSummary));
                 OnPropertyChanged(nameof(InspectorSelectionSummary));
                 RefreshVersionSourceChangeDiagnostics();
+                _pendingArchiveVersionId = null;
+                _pendingArchiveItemId = null;
             }
         }
     }
@@ -557,6 +597,8 @@ public partial class MainWindowViewModel : ViewModelBase
                 PopulateItemEditor();
                 OnPropertyChanged(nameof(HasSelectedItem));
                 OnPropertyChanged(nameof(InspectorSelectionSummary));
+                OnPropertyChanged(nameof(CanArchiveSelectedItem));
+                _pendingArchiveItemId = null;
             }
         }
     }
@@ -640,6 +682,30 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         get => _gitChangelogSummary;
         private set => SetProperty(ref _gitChangelogSummary, value);
+    }
+
+    public bool ChangelogIncludeIncomplete
+    {
+        get => _changelogIncludeIncomplete;
+        set => SetProperty(ref _changelogIncludeIncomplete, value);
+    }
+
+    public bool ChangelogIncludeItemKeys
+    {
+        get => _changelogIncludeItemKeys;
+        set => SetProperty(ref _changelogIncludeItemKeys, value);
+    }
+
+    public bool ChangelogIncludeDescriptions
+    {
+        get => _changelogIncludeDescriptions;
+        set => SetProperty(ref _changelogIncludeDescriptions, value);
+    }
+
+    public bool ChangelogCompactMode
+    {
+        get => _changelogCompactMode;
+        set => SetProperty(ref _changelogCompactMode, value);
     }
 
     public string? SelectedConflictPath
@@ -811,6 +877,18 @@ public partial class MainWindowViewModel : ViewModelBase
         CanMutateWorkspace &&
         SelectedVersion is not null &&
         SelectedVersion.Status != ReleaseStatus.Released;
+
+    public bool CanArchiveSelectedVersion =>
+        CanMutateWorkspace &&
+        SelectedVersion is { Status: ReleaseStatus.Planned or ReleaseStatus.InProgress };
+
+    public bool CanArchiveSelectedItem =>
+        CanArchiveSelectedVersion && SelectedItem is not null;
+
+    public bool IsProjectVersionEmpty => Versions.Count == 0;
+
+    public bool IsSelectedVersionEmpty =>
+        SelectedVersion is null || SelectedVersion.Items.Count == 0;
 
     public string SelectedVersionStateSummary =>
         !IsWorkspaceTrusted
@@ -1031,6 +1109,12 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
+        if (!HasLocalIdentity)
+        {
+            SetupMessage = "Create your local signing identity before creating a project.";
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(CreateProjectName) || string.IsNullOrWhiteSpace(CreateProjectCode))
         {
             SetupMessage = "Project name and project code are required.";
@@ -1061,6 +1145,12 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (_coordinatorService is null)
         {
+            return;
+        }
+
+        if (!HasLocalIdentity)
+        {
+            SetupMessage = "Create or restore the signing identity for this workspace before opening it.";
             return;
         }
 
@@ -1104,6 +1194,12 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
+        if (!HasLocalIdentity)
+        {
+            SetupMessage = "Create the local identity targeted by the project invitation before joining.";
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(JoinInvitationFilePath) ||
             string.IsNullOrWhiteSpace(JoinLocalWorkspaceRoot))
         {
@@ -1133,6 +1229,54 @@ public partial class MainWindowViewModel : ViewModelBase
         ApplySetupState("Choose a project to create or open.");
         RefreshRecentProjects();
         RefreshSuggestedPaths();
+    }
+
+    [RelayCommand]
+    private void CreateLocalIdentity()
+    {
+        if (_coordinatorService is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(IdentitySetupName))
+        {
+            SetupMessage = "Enter the display name for signed project changes.";
+            return;
+        }
+
+        try
+        {
+            var identity = _coordinatorService.CreateInitialIdentity(IdentitySetupName);
+            HasLocalIdentity = true;
+            SetupMessage =
+                $"Created protected signing identity {identity.DisplayName}. Back up the Blueprints application-data directory.";
+        }
+        catch (Exception exception)
+        {
+            SetupMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ExportSetupIdentityInvitation(string? filePath)
+    {
+        if (_coordinatorService is null ||
+            !HasLocalIdentity ||
+            string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var exportedPath = _coordinatorService.ExportIdentityInvitation(filePath);
+            SetupMessage = $"Exported signed identity invitation to {exportedPath}.";
+        }
+        catch (Exception exception)
+        {
+            SetupMessage = exception.Message;
+        }
     }
 
     [RelayCommand]
@@ -1223,6 +1367,113 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void ArchiveSelectedVersion()
+    {
+        if (_coordinatorService is null ||
+            _currentSession is null ||
+            SelectedVersion is null ||
+            !CanArchiveSelectedVersion)
+        {
+            WorkspaceMessage = "Select an editable draft version to archive.";
+            return;
+        }
+
+        if (_pendingArchiveVersionId != SelectedVersion.VersionId)
+        {
+            _pendingArchiveVersionId = SelectedVersion.VersionId;
+            WorkspaceMessage =
+                $"Archive {SelectedVersion.Name}? Select Archive version again to confirm. " +
+                "It will leave the active plan and a local recovery copy will be retained.";
+            return;
+        }
+
+        try
+        {
+            var result = _coordinatorService.ArchiveVersion(
+                _currentSession.Paths.LocalWorkspaceRoot,
+                _currentSession.Paths.SharedProjectRoot,
+                SelectedVersion.VersionId);
+            ApplySession(result.Session);
+            WorkspaceMessage = result.Summary;
+            _pendingArchiveVersionId = null;
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ArchiveSelectedItem()
+    {
+        if (_coordinatorService is null ||
+            _currentSession is null ||
+            SelectedVersion is null ||
+            SelectedItem is null ||
+            !CanArchiveSelectedItem)
+        {
+            WorkspaceMessage = "Select an item from an editable draft version to archive.";
+            return;
+        }
+
+        if (_pendingArchiveItemId != SelectedItem.ItemId)
+        {
+            _pendingArchiveItemId = SelectedItem.ItemId;
+            WorkspaceMessage =
+                $"Archive {SelectedItem.ItemKey}? Select Archive item again to confirm. " +
+                "It will leave the active plan and a local recovery copy will be retained.";
+            return;
+        }
+
+        try
+        {
+            var result = _coordinatorService.ArchiveItem(
+                _currentSession.Paths.LocalWorkspaceRoot,
+                _currentSession.Paths.SharedProjectRoot,
+                SelectedVersion.VersionId,
+                SelectedItem.ItemId);
+            ApplySession(result.Session);
+            WorkspaceMessage = result.Summary;
+            _pendingArchiveItemId = null;
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void PreviewSelectedVersionChangelog()
+    {
+        if (_coordinatorService is null || _currentSession is null || SelectedVersion is null)
+        {
+            WorkspaceMessage = "Select a version first.";
+            return;
+        }
+
+        try
+        {
+            var sourceChanges = GetLocalGitRecentChanges();
+            ChangelogPreview = _coordinatorService.PreviewVersionChangelog(
+                _currentSession.Paths.LocalWorkspaceRoot,
+                _currentSession.Paths.SharedProjectRoot,
+                SelectedVersion.VersionId,
+                sourceChanges,
+                CurrentChangelogRules());
+            LastChangelogExportPath = string.Empty;
+            GitChangelogSummary = sourceChanges.Count == 0
+                ? "No Local Git changes were available for this preview."
+                : $"{sourceChanges.Count} Local Git changes considered for this preview.";
+            WorkspaceMessage =
+                $"Previewed changelog for {SelectedVersion.Name} without writing a file.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
     private void ExportSelectedVersionChangelog()
     {
         if (_coordinatorService is null || _currentSession is null || SelectedVersion is null)
@@ -1238,7 +1489,8 @@ public partial class MainWindowViewModel : ViewModelBase
                 _currentSession.Paths.LocalWorkspaceRoot,
                 _currentSession.Paths.SharedProjectRoot,
                 SelectedVersion.VersionId,
-                sourceChanges);
+                sourceChanges,
+                CurrentChangelogRules());
             ChangelogPreview = export.Markdown;
             LastChangelogExportPath = export.FilePath;
             GitChangelogSummary = sourceChanges.Count == 0
@@ -1685,6 +1937,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private void ApplySession(LocalWorkspaceSession session)
     {
         var wasActiveSession = HasActiveSession;
+        var previousProjectId = CurrentProject.ProjectId;
         _currentSession = session;
 
         var workspace = session.LoadResult.Workspace;
@@ -1703,6 +1956,13 @@ public partial class MainWindowViewModel : ViewModelBase
             session.Identity.Profile.UserId.ToString(),
             session.Identity.Profile.KeyStorageProvider);
         IdentityPublicKey = session.Identity.Profile.PublicKeyBase64;
+        if (!wasActiveSession || previousProjectId != project.ProjectId)
+        {
+            ChangelogIncludeIncomplete = project.ChangelogRules.IncludeIncompleteByDefault;
+            ChangelogIncludeItemKeys = project.ChangelogRules.IncludeItemKeysByDefault;
+            ChangelogIncludeDescriptions = project.ChangelogRules.IncludeDescriptionsByDefault;
+            ChangelogCompactMode = project.ChangelogRules.CompactModeByDefault;
+        }
 
         Versions.Clear();
         foreach (var version in workspace.Versions
@@ -1819,6 +2079,10 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsWorkspaceReadOnly));
         OnPropertyChanged(nameof(HasConflicts));
         OnPropertyChanged(nameof(CanMutateWorkspace));
+        OnPropertyChanged(nameof(CanArchiveSelectedVersion));
+        OnPropertyChanged(nameof(CanArchiveSelectedItem));
+        OnPropertyChanged(nameof(IsProjectVersionEmpty));
+        OnPropertyChanged(nameof(IsSelectedVersionEmpty));
         OnPropertyChanged(nameof(WorkspaceModeSummary));
         OnPropertyChanged(nameof(CanResolveSelectedConflict));
         OnPropertyChanged(nameof(HasSyncDiagnostics));
@@ -1880,6 +2144,8 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(CanEditSelectedVersion));
         OnPropertyChanged(nameof(CanEditItems));
         OnPropertyChanged(nameof(CanReleaseSelectedVersion));
+        OnPropertyChanged(nameof(CanArchiveSelectedVersion));
+        OnPropertyChanged(nameof(CanArchiveSelectedItem));
         OnPropertyChanged(nameof(SelectedVersionStateSummary));
         OnPropertyChanged(nameof(CanManageMembers));
         OnPropertyChanged(nameof(CanEditSelectedMember));
@@ -2130,6 +2396,13 @@ public partial class MainWindowViewModel : ViewModelBase
         _inviteKeyId = string.Empty;
         InviteRole = MemberRole.Editor;
     }
+
+    private ChangelogRules CurrentChangelogRules() =>
+        new(
+            ChangelogIncludeIncomplete,
+            ChangelogIncludeItemKeys,
+            ChangelogIncludeDescriptions,
+            ChangelogCompactMode);
 
     private void ClearMemberEditor()
     {

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RecentProjects = new ObservableCollection<RecentProjectReference>();
         Members = new ObservableCollection<WorkspaceMemberCard>();
         Conflicts = new ObservableCollection<string>();
+        ConflictFieldComparisons = new ObservableCollection<ConflictFieldComparison>();
         SyncDiagnostics = new ObservableCollection<SyncDiagnosticCard>();
         TrustDiagnostics = new ObservableCollection<TrustDiagnosticCard>();
         Integrations = new ObservableCollection<IntegrationStatusCard>();
@@ -122,6 +123,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RecentProjects = new ObservableCollection<RecentProjectReference>();
         Members = new ObservableCollection<WorkspaceMemberCard>();
         Conflicts = new ObservableCollection<string>();
+        ConflictFieldComparisons = new ObservableCollection<ConflictFieldComparison>();
         SyncDiagnostics = new ObservableCollection<SyncDiagnosticCard>();
         TrustDiagnostics = new ObservableCollection<TrustDiagnosticCard>();
         Integrations = new ObservableCollection<IntegrationStatusCard>();
@@ -145,6 +147,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<WorkspaceMemberCard> Members { get; }
 
     public ObservableCollection<string> Conflicts { get; }
+
+    public ObservableCollection<ConflictFieldComparison> ConflictFieldComparisons { get; }
 
     public ObservableCollection<SyncDiagnosticCard> SyncDiagnostics { get; }
 
@@ -305,6 +309,8 @@ public partial class MainWindowViewModel : ViewModelBase
             {
                 OnPropertyChanged(nameof(SyncStatus));
                 OnPropertyChanged(nameof(SyncEvidenceSummary));
+                OnPropertyChanged(nameof(SyncAuditSummary));
+                OnPropertyChanged(nameof(SyncRecoveryGuidance));
             }
         }
     }
@@ -760,11 +766,33 @@ public partial class MainWindowViewModel : ViewModelBase
             var validation = Sync.LastSuccessfulTrustValidationUtc is DateTimeOffset validatedUtc
                 ? validatedUtc.ToLocalTime().ToString("g")
                 : "not yet validated";
-            return $"Last pulled manifest: {FormatManifestVersion(Sync.LastPulledManifestVersion)} · " +
+            var shared = Sync.SharedManifestVersion is int sharedVersion
+                ? $"v{sharedVersion}"
+                : "none";
+            return $"Shared manifest: {shared} · " +
+                   $"last pulled: {FormatManifestVersion(Sync.LastPulledManifestVersion)} · " +
                    $"last pushed manifest: {FormatManifestVersion(Sync.LastPushedManifestVersion)} · " +
                    $"trust check: {validation}";
         }
     }
+
+    public string SyncAuditSummary =>
+        Sync.AuditLogValid
+            ? $"Audit chain valid · {Sync.AuditEntryCount} signed entries"
+            : $"Audit chain blocked · {Sync.AuditEntryCount} valid entries before failure";
+
+    public string SyncRecoveryGuidance =>
+        Sync.SharedManifestSignatureValid == false
+            ? "Do not pull or overwrite files manually. Restore the shared manifest and matching content from a known pack or backup, then refresh."
+            : !Sync.AuditLogValid
+                ? "Restore the complete signed audit chain from a known-good workspace or backup before exchanging more changes."
+                : Sync.ConflictCount > 0
+                    ? "Review changed fields, choose one whole-document side, and retain the reported local recovery directory until the project is verified."
+                    : Sync.PendingIncomingChanges > 0
+                        ? "Pull validates the manifest, audit chain, and every incoming signer before changing local project files."
+                        : Sync.PendingOutgoingChanges > 0
+                            ? "Push publishes document pairs first and the signed manifest last. If publication is interrupted, restore or retry from the recorded pack."
+                            : "No recovery action is required. Keep the local workspace and protected identity included in separate backups.";
 
     private static string FormatManifestVersion(int version) =>
         version > 0 ? $"v{version}" : "none";
@@ -2188,6 +2216,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private void RefreshSelectedConflictPreview()
     {
+        ConflictFieldComparisons.Clear();
         if (_currentSession is null || string.IsNullOrWhiteSpace(SelectedConflictPath))
         {
             SelectedConflictSemanticSummary = "Select a diagnostic path to see the document summary.";
@@ -2207,10 +2236,19 @@ public partial class MainWindowViewModel : ViewModelBase
 
         SelectedConflictLocalPreview = localPreview;
         SelectedConflictSharedPreview = sharedPreview;
-        SelectedConflictSemanticSummary = BuildSemanticConflictSummary(
+        foreach (var comparison in BuildSemanticConflictComparisons(
             SelectedConflictPath,
             localPreview,
-            sharedPreview);
+            sharedPreview))
+        {
+            ConflictFieldComparisons.Add(comparison);
+        }
+
+        SelectedConflictSemanticSummary = ConflictFieldComparisons.Count == 0
+            ? "No document-aware comparison is available because one side is missing, invalid, or not yet supported."
+            : $"{GetDocumentKind(SelectedConflictPath)} · " +
+              $"{ConflictFieldComparisons.Count(static field => field.IsDifferent)} of " +
+              $"{ConflictFieldComparisons.Count} compared fields differ.";
     }
 
     private static string ReadWorkspacePreview(
@@ -2239,7 +2277,7 @@ public partial class MainWindowViewModel : ViewModelBase
             : text[..maxPreviewLength] + $"{Environment.NewLine}... preview truncated ...";
     }
 
-    private static string BuildSemanticConflictSummary(
+    private static IReadOnlyList<ConflictFieldComparison> BuildSemanticConflictComparisons(
         string relativePath,
         string localJson,
         string sharedJson)
@@ -2248,31 +2286,37 @@ public partial class MainWindowViewModel : ViewModelBase
         using var sharedDocument = TryParseJson(sharedJson);
         if (localDocument is null || sharedDocument is null)
         {
-            return "Document summary unavailable because one side is missing or is not valid JSON.";
+            return [];
         }
 
         var fields = GetSemanticFields(relativePath);
         if (fields.Count == 0)
         {
-            return "No semantic presenter exists for this document type yet. Use the raw local/shared previews below.";
+            return [];
         }
 
-        var lines = new List<string>
-        {
-            $"Document: {GetDocumentKind(relativePath)}",
-        };
+        return fields
+            .Select(field =>
+            {
+                var localValue = BoundComparisonValue(
+                    ReadJsonValue(localDocument.RootElement, field.PropertyPath));
+                var sharedValue = BoundComparisonValue(
+                    ReadJsonValue(sharedDocument.RootElement, field.PropertyPath));
+                return new ConflictFieldComparison(
+                    field.Label,
+                    localValue,
+                    sharedValue,
+                    !string.Equals(localValue, sharedValue, StringComparison.Ordinal));
+            })
+            .ToArray();
+    }
 
-        foreach (var (label, propertyPath) in fields)
-        {
-            var localValue = ReadJsonValue(localDocument.RootElement, propertyPath);
-            var sharedValue = ReadJsonValue(sharedDocument.RootElement, propertyPath);
-            var marker = string.Equals(localValue, sharedValue, StringComparison.Ordinal) ? "=" : "!=";
-            lines.Add($"{label}: local {marker} shared");
-            lines.Add($"  local: {localValue}");
-            lines.Add($"  shared: {sharedValue}");
-        }
-
-        return string.Join(Environment.NewLine, lines);
+    private static string BoundComparisonValue(string value)
+    {
+        const int maxLength = 500;
+        return value.Length <= maxLength
+            ? value
+            : value[..maxLength] + "…";
     }
 
     private static JsonDocument? TryParseJson(string text)

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -300,6 +300,7 @@ public partial class MainWindowViewModel : ViewModelBase
             if (SetProperty(ref _sync, value))
             {
                 OnPropertyChanged(nameof(SyncStatus));
+                OnPropertyChanged(nameof(SyncEvidenceSummary));
             }
         }
     }
@@ -729,6 +730,22 @@ public partial class MainWindowViewModel : ViewModelBase
             SyncHealth.Idle => "Sync baseline is current",
             _ => "Sync unavailable",
         };
+
+    public string SyncEvidenceSummary
+    {
+        get
+        {
+            var validation = Sync.LastSuccessfulTrustValidationUtc is DateTimeOffset validatedUtc
+                ? validatedUtc.ToLocalTime().ToString("g")
+                : "not yet validated";
+            return $"Last pulled manifest: {FormatManifestVersion(Sync.LastPulledManifestVersion)} · " +
+                   $"last pushed manifest: {FormatManifestVersion(Sync.LastPushedManifestVersion)} · " +
+                   $"trust check: {validation}";
+        }
+    }
+
+    private static string FormatManifestVersion(int version) =>
+        version > 0 ? $"v{version}" : "none";
 
     public bool CanEditSelectedVersion =>
         CanMutateWorkspace &&

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml
@@ -36,6 +36,13 @@
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
+        <TextBlock Grid.Row="2"
+                   Text="No versions yet. Add the next milestone above."
+                   Classes="muted"
+                   TextWrapping="Wrap"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   IsVisible="{Binding IsProjectVersionEmpty}" />
       </Grid>
     </Border>
 
@@ -50,6 +57,8 @@
               </StackPanel>
               <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
                 <Button Classes="danger" Content="Mark released" Command="{Binding ReleaseSelectedVersionCommand}" IsEnabled="{Binding CanReleaseSelectedVersion}" />
+                <Button Classes="danger" Content="Archive version…" Command="{Binding ArchiveSelectedVersionCommand}" IsEnabled="{Binding CanArchiveSelectedVersion}" />
+                <Button Classes="secondary" Content="Preview notes" Command="{Binding PreviewSelectedVersionChangelogCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" />
                 <Button Classes="primary" Content="Export notes" Command="{Binding ExportSelectedVersionChangelogCommand}" IsEnabled="{Binding IsWorkspaceTrusted}" />
               </StackPanel>
             </Grid>
@@ -84,6 +93,12 @@
               <Border Grid.Column="1" Classes="blueprint-card">
                 <StackPanel Spacing="7">
                   <TextBlock Classes="eyebrow" Text="CHANGELOG PREVIEW" />
+                  <WrapPanel>
+                    <CheckBox Content="Incomplete" IsChecked="{Binding ChangelogIncludeIncomplete}" Margin="0,0,10,0" />
+                    <CheckBox Content="Item keys" IsChecked="{Binding ChangelogIncludeItemKeys}" Margin="0,0,10,0" />
+                    <CheckBox Content="Descriptions" IsChecked="{Binding ChangelogIncludeDescriptions}" Margin="0,0,10,0" />
+                    <CheckBox Content="Compact" IsChecked="{Binding ChangelogCompactMode}" />
+                  </WrapPanel>
                   <TextBlock Text="{Binding LastChangelogExportPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
                   <TextBlock Text="{Binding GitChangelogSummary}" Classes="muted" FontSize="12" TextWrapping="Wrap" />
                   <TextBox Text="{Binding ChangelogPreview}"
@@ -144,7 +159,12 @@
               <StackPanel Orientation="Horizontal" Spacing="8">
                 <Button Classes="primary" Content="Add item" Command="{Binding AddItemCommand}" IsEnabled="{Binding CanEditItems}" />
                 <Button Classes="secondary" Content="Save selected" Command="{Binding SaveItemDetailsCommand}" IsEnabled="{Binding CanEditItems}" />
+                <Button Classes="danger" Content="Archive item…" Command="{Binding ArchiveSelectedItemCommand}" IsEnabled="{Binding CanArchiveSelectedItem}" />
               </StackPanel>
+              <TextBlock Text="Archiving requires a second click, removes the draft from the active plan, and keeps a machine-local signed recovery copy."
+                         Classes="muted"
+                         FontSize="11"
+                         TextWrapping="Wrap" />
             </StackPanel>
           </Border>
 
@@ -157,27 +177,45 @@
                 </StackPanel>
                 <TextBlock Grid.Column="1" Text="{Binding SelectedVersion.ItemCount, StringFormat='Mapped: {0}'}" Classes="mono muted" VerticalAlignment="Center" />
               </Grid>
-              <ListBox Grid.Row="1" ItemsSource="{Binding SelectedVersion.Items}" SelectedItem="{Binding SelectedItem}" MinHeight="260">
-                <ListBox.ItemTemplate>
-                  <DataTemplate x:DataType="models:WorkspaceItemCard">
-                    <Border Classes="blueprint-card" Margin="0,0,0,8">
-                      <Grid ColumnDefinitions="92,*,Auto,Auto" ColumnSpacing="10">
-                        <TextBlock Classes="mono" Text="{Binding ItemKey}" FontWeight="Bold" Foreground="#0B4F8A" />
-                        <StackPanel Grid.Column="1" Spacing="2">
-                          <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
-                          <TextBlock Text="{Binding Description}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" />
-                        </StackPanel>
-                        <Border Grid.Column="2" Background="#E7F3F9" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
-                          <TextBlock Text="{Binding CategoryId}" Foreground="#0B4F8A" FontSize="11" />
-                        </Border>
-                        <Border Grid.Column="3" Background="#EEF4F7" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
-                          <TextBlock Text="{Binding ItemTypeId}" Classes="muted" FontSize="11" />
-                        </Border>
-                      </Grid>
-                    </Border>
-                  </DataTemplate>
-                </ListBox.ItemTemplate>
-              </ListBox>
+              <ScrollViewer Grid.Row="1" MinHeight="260">
+                <ItemsControl ItemsSource="{Binding SelectedVersion.ItemGroups}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="models:WorkspaceItemCategoryGroup">
+                      <StackPanel Spacing="6" Margin="0,0,0,12">
+                        <TextBlock Text="{Binding CategoryId}" Classes="eyebrow" />
+                        <ItemsControl ItemsSource="{Binding Items}">
+                          <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="models:WorkspaceItemCard">
+                              <Button Classes="item-row"
+                                      Click="SelectReleaseItem_Click"
+                                      HorizontalContentAlignment="Stretch"
+                                      Margin="0,0,0,6">
+                                <Grid ColumnDefinitions="92,*,Auto" ColumnSpacing="10">
+                                  <TextBlock Classes="mono" Text="{Binding ItemKey}" FontWeight="Bold" Foreground="#0B4F8A" />
+                                  <StackPanel Grid.Column="1" Spacing="2">
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Description}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" />
+                                  </StackPanel>
+                                  <Border Grid.Column="2" Background="#EEF4F7" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding ItemTypeId}" Classes="muted" FontSize="11" />
+                                  </Border>
+                                </Grid>
+                              </Button>
+                            </DataTemplate>
+                          </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                      </StackPanel>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </ScrollViewer>
+              <TextBlock Grid.Row="1"
+                         Text="No connected items yet. Add the first accomplishment from the editor."
+                         Classes="muted"
+                         TextWrapping="Wrap"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         IsVisible="{Binding IsSelectedVersionEmpty}" />
             </Grid>
           </Border>
         </Grid>

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml.cs
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Blueprints.App.Models;
+using Blueprints.App.ViewModels;
 
 namespace Blueprints.App.Views.Components;
 
@@ -7,5 +9,16 @@ public partial class ReleasePlannerView : UserControl
     public ReleasePlannerView()
     {
         InitializeComponent();
+    }
+
+    private void SelectReleaseItem_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (sender is Button { DataContext: WorkspaceItemCard item } &&
+            DataContext is MainWindowViewModel viewModel)
+        {
+            viewModel.SelectItemNodeCommand.Execute(item);
+        }
     }
 }

--- a/Blueprints.App/Views/Components/SetupView.axaml
+++ b/Blueprints.App/Views/Components/SetupView.axaml
@@ -147,6 +147,40 @@
                            TextWrapping="Wrap" />
               </StackPanel>
             </Border>
+
+            <Border Height="1" Background="#BED8E8" Margin="0,4" />
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="JOIN A TEAM PROJECT" />
+              <TextBlock Text="Use a signed project invitation" FontSize="18" FontWeight="Bold" />
+              <TextBlock Text="The invitation anchors the administrator and member keys before any shared content enters the local workspace."
+                         Classes="muted"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+            <StackPanel Spacing="5">
+              <TextBlock Text="Project invitation" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding JoinInvitationFilePath}" IsReadOnly="True" />
+                <Button Grid.Column="1" Classes="secondary" Content="Choose…" Click="BrowseJoinInvitation_Click" />
+              </Grid>
+            </StackPanel>
+            <StackPanel Spacing="5">
+              <TextBlock Text="New empty local workspace" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding JoinLocalWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinLocal_Click" />
+              </Grid>
+            </StackPanel>
+            <StackPanel Spacing="5">
+              <TextBlock Text="Shared exchange override (optional)" FontWeight="SemiBold" />
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding JoinSharedWorkspaceRoot}" />
+                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinShared_Click" />
+              </Grid>
+            </StackPanel>
+            <Button Classes="primary"
+                    Content="Validate invitation and join  →"
+                    Command="{Binding JoinProjectCommand}"
+                    HorizontalAlignment="Left" />
           </StackPanel>
         </Border>
       </Grid>

--- a/Blueprints.App/Views/Components/SetupView.axaml
+++ b/Blueprints.App/Views/Components/SetupView.axaml
@@ -58,8 +58,31 @@
         </Border>
       </Grid>
 
-      <Grid Grid.Row="1" ColumnDefinitions="1.1*,0.9*" ColumnSpacing="20">
-        <Border Classes="card">
+      <Grid Grid.Row="1" ColumnDefinitions="1.1*,0.9*" RowDefinitions="Auto,Auto" ColumnSpacing="20" RowSpacing="20">
+        <Border Grid.ColumnSpan="2" Classes="card">
+          <Grid ColumnDefinitions="1.2*,1*,Auto,Auto" ColumnSpacing="12">
+            <StackPanel Spacing="3">
+              <TextBlock Classes="eyebrow" Text="LOCAL SIGNING IDENTITY" />
+              <TextBlock Text="{Binding LocalIdentitySetupSummary}" Classes="muted" TextWrapping="Wrap" />
+            </StackPanel>
+            <TextBox Grid.Column="1"
+                     PlaceholderText="Display name for signed changes"
+                     Text="{Binding IdentitySetupName}"
+                     IsEnabled="{Binding IsIdentitySetupRequired}" />
+            <Button Grid.Column="2"
+                    Classes="primary"
+                    Content="Create identity"
+                    Command="{Binding CreateLocalIdentityCommand}"
+                    IsEnabled="{Binding IsIdentitySetupRequired}" />
+            <Button Grid.Column="3"
+                    Classes="secondary"
+                    Content="Export identity invite…"
+                    Click="ExportSetupIdentityInvitation_Click"
+                    IsEnabled="{Binding HasLocalIdentity}" />
+          </Grid>
+        </Border>
+
+        <Border Grid.Row="1" Classes="card">
           <StackPanel Spacing="14">
             <StackPanel Spacing="3">
               <TextBlock Classes="eyebrow" Text="NEW PROJECT" />
@@ -108,7 +131,7 @@
           </StackPanel>
         </Border>
 
-        <Border Grid.Column="1" Classes="card">
+        <Border Grid.Row="1" Grid.Column="1" Classes="card">
           <StackPanel Spacing="14">
             <StackPanel Spacing="3">
               <TextBlock Classes="eyebrow" Text="EXISTING PROJECT" />

--- a/Blueprints.App/Views/Components/SetupView.axaml.cs
+++ b/Blueprints.App/Views/Components/SetupView.axaml.cs
@@ -74,6 +74,38 @@ public partial class SetupView : UserControl
         }
     }
 
+    private async void ExportSetupIdentityInvitation_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel)
+        {
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider is null)
+            {
+                return;
+            }
+
+            var file = await storageProvider.SaveFilePickerAsync(
+                new FilePickerSaveOptions
+                {
+                    Title = "Export signed identity invitation",
+                    SuggestedFileName = "identity.blueprints-identity.json",
+                    FileTypeChoices =
+                    [
+                        new FilePickerFileType("Blueprints identity invitation")
+                        {
+                            Patterns = ["*.blueprints-identity.json"],
+                        },
+                    ],
+                });
+            if (file?.TryGetLocalPath() is { } path)
+            {
+                viewModel.ExportSetupIdentityInvitationCommand.Execute(path);
+            }
+        }
+    }
+
     private async Task<string?> PickInvitationAsync()
     {
         var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;

--- a/Blueprints.App/Views/Components/SetupView.axaml.cs
+++ b/Blueprints.App/Views/Components/SetupView.axaml.cs
@@ -47,6 +47,57 @@ public partial class SetupView : UserControl
         }
     }
 
+    private async void BrowseJoinInvitation_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickInvitationAsync() is { } path)
+        {
+            viewModel.JoinInvitationFilePath = path;
+        }
+    }
+
+    private async void BrowseJoinLocal_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Choose a new empty local workspace") is { } path)
+        {
+            viewModel.JoinLocalWorkspaceRoot = path;
+        }
+    }
+
+    private async void BrowseJoinShared_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickFolderAsync("Override the invitation's shared exchange folder") is { } path)
+        {
+            viewModel.JoinSharedWorkspaceRoot = path;
+        }
+    }
+
+    private async Task<string?> PickInvitationAsync()
+    {
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return null;
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = "Choose a signed Blueprints project invitation",
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    new FilePickerFileType("Blueprints project invitation")
+                    {
+                        Patterns = ["*.blueprints-project.json"],
+                    },
+                ],
+            });
+        return files.FirstOrDefault()?.TryGetLocalPath();
+    }
+
     private async Task<string?> PickFolderAsync(string title)
     {
         var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;

--- a/Blueprints.App/Views/Components/SyncView.axaml
+++ b/Blueprints.App/Views/Components/SyncView.axaml
@@ -11,6 +11,7 @@
           <TextBlock Classes="eyebrow" Text="EXCHANGE CIRCUIT" Foreground="#62D3F0" />
           <TextBlock Text="{Binding SyncStatus}" FontSize="21" FontWeight="Bold" Foreground="White" TextWrapping="Wrap" />
           <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SyncEvidenceSummary}" Foreground="#A9C8DC" FontSize="11" TextWrapping="Wrap" />
 
           <Grid ColumnDefinitions="*,48,*" VerticalAlignment="Center" Margin="0,8">
             <Border Background="#0F4F7A" BorderBrush="#3C88B5" BorderThickness="1" CornerRadius="4" Padding="10">

--- a/Blueprints.App/Views/Components/SyncView.axaml
+++ b/Blueprints.App/Views/Components/SyncView.axaml
@@ -51,10 +51,18 @@
                      TextWrapping="Wrap" />
         </StackPanel>
       </Border>
+
+      <Border Classes="card">
+        <StackPanel Spacing="7">
+          <TextBlock Classes="eyebrow" Text="TRUSTED EXCHANGE EVIDENCE" />
+          <TextBlock Text="{Binding SyncAuditSummary}" FontWeight="Bold" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SyncRecoveryGuidance}" Classes="muted" FontSize="12" TextWrapping="Wrap" />
+        </StackPanel>
+      </Border>
     </StackPanel>
 
     <Border Grid.Column="1" Classes="card">
-      <Grid RowDefinitions="Auto,160,Auto,*" RowSpacing="12">
+      <Grid RowDefinitions="Auto,160,Auto,*,Auto" RowSpacing="12">
         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
           <StackPanel Spacing="3">
             <TextBlock Classes="eyebrow" Text="DIAGNOSTIC LAYER" />
@@ -87,9 +95,21 @@
         </ListBox>
 
         <Border Grid.Row="2" Background="#E7F3F9" BorderBrush="#9AC7DE" BorderThickness="1" CornerRadius="4" Padding="12">
-          <ScrollViewer MaxHeight="110">
-            <TextBlock Text="{Binding SelectedConflictSemanticSummary}" TextWrapping="Wrap" Classes="mono" FontSize="11" Foreground="#214A64" />
-          </ScrollViewer>
+          <StackPanel Spacing="8">
+            <TextBlock Text="{Binding SelectedConflictSemanticSummary}" TextWrapping="Wrap" FontWeight="Bold" Foreground="#214A64" />
+            <ItemsControl ItemsSource="{Binding ConflictFieldComparisons}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="models:ConflictFieldComparison">
+                  <Grid ColumnDefinitions="110,72,*,*" ColumnSpacing="8" Margin="0,2">
+                    <TextBlock Text="{Binding Field}" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="1" Text="{Binding Status}" Classes="mono" FontSize="10" Foreground="#A63D40" />
+                    <TextBlock Grid.Column="2" Text="{Binding LocalValue}" Classes="mono" FontSize="10" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="3" Text="{Binding SharedValue}" Classes="mono" FontSize="10" TextWrapping="Wrap" />
+                  </Grid>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </StackPanel>
         </Border>
 
         <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="12" MinHeight="240">
@@ -118,6 +138,11 @@
                      FontSize="11" />
           </StackPanel>
         </Grid>
+        <TextBlock Grid.Row="4"
+                   Text="Raw evidence is bounded to 8,000 characters per side. Resolution still replaces the whole signed document."
+                   Classes="muted"
+                   FontSize="11"
+                   TextWrapping="Wrap" />
       </Grid>
     </Border>
   </Grid>

--- a/Blueprints.App/Views/Components/TeamView.axaml
+++ b/Blueprints.App/Views/Components/TeamView.axaml
@@ -14,17 +14,14 @@
             <TextBlock Text="{Binding Identity.UserId}" Classes="mono" FontSize="11" Foreground="#A9C8DC" TextWrapping="Wrap" />
             <Border Height="1" Background="#245A7D" />
             <TextBlock Text="{Binding Identity.KeyStorageProvider, StringFormat='Protected by {0}'}" Foreground="#A9C8DC" />
-            <TextBlock Text="Share the bundle only with an administrator who is intentionally inviting this identity."
+            <TextBlock Text="Export a signed identity invitation for an administrator who is intentionally adding you."
                        Foreground="#A9C8DC"
                        TextWrapping="Wrap"
                        FontSize="12" />
-            <TextBox Text="{Binding IdentityBundle}"
-                     AcceptsReturn="True"
-                     IsReadOnly="True"
-                     Height="90"
-                     TextWrapping="Wrap"
-                     FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
-                     FontSize="11" />
+            <Button Classes="secondary"
+                    Content="Export identity invitation…"
+                    Click="ExportIdentityInvitation_Click"
+                    HorizontalAlignment="Left" />
           </StackPanel>
         </Border>
 
@@ -32,9 +29,14 @@
           <StackPanel Spacing="10">
             <StackPanel Spacing="3">
               <TextBlock Classes="eyebrow" Text="INVITATION NODE" />
-              <TextBlock Text="Add a signed member" FontSize="19" FontWeight="Bold" />
+              <TextBlock Text="Verify and add a member" FontSize="19" FontWeight="Bold" />
             </StackPanel>
-            <TextBox PlaceholderText="User ID" Text="{Binding InviteUserId}" IsEnabled="{Binding CanManageMembers}" />
+            <Button Classes="secondary"
+                    Content="Import signed identity invitation…"
+                    Click="ImportIdentityInvitation_Click"
+                    IsEnabled="{Binding CanManageMembers}"
+                    HorizontalAlignment="Left" />
+            <TextBox PlaceholderText="User ID" Text="{Binding InviteUserId}" IsReadOnly="True" />
             <TextBox PlaceholderText="Display name" Text="{Binding InviteDisplayName}" IsEnabled="{Binding CanManageMembers}" />
             <ComboBox ItemsSource="{Binding AvailableMemberRoles}" SelectedItem="{Binding InviteRole}" IsEnabled="{Binding CanManageMembers}" />
             <TextBox PlaceholderText="Public key (Base64)"
@@ -42,7 +44,7 @@
                      AcceptsReturn="True"
                      Height="88"
                      TextWrapping="Wrap"
-                     IsEnabled="{Binding CanManageMembers}"
+                     IsReadOnly="True"
                      FontFamily="Cascadia Mono, SFMono-Regular, Consolas, monospace"
                      FontSize="11" />
             <Button Classes="primary"
@@ -92,7 +94,7 @@
       </Border>
 
       <Border Grid.Row="1" Classes="card">
-        <Grid ColumnDefinitions="1.2*,1*,1*,Auto" ColumnSpacing="10">
+        <Grid ColumnDefinitions="1.2*,1*,1*,Auto,Auto" ColumnSpacing="10">
           <StackPanel Spacing="3">
             <TextBlock Classes="eyebrow" Text="SELECTED MEMBER" />
             <TextBlock Text="{Binding SelectedMemberStateSummary}" Classes="muted" TextWrapping="Wrap" />
@@ -107,6 +109,11 @@
                   Content="Save member"
                   Command="{Binding SaveMemberDetailsCommand}"
                   IsEnabled="{Binding CanEditSelectedMember}" />
+          <Button Grid.Column="4"
+                  Classes="secondary"
+                  Content="Export project invite…"
+                  Click="ExportProjectInvitation_Click"
+                  IsEnabled="{Binding CanManageMembers}" />
         </Grid>
       </Border>
     </Grid>

--- a/Blueprints.App/Views/Components/TeamView.axaml.cs
+++ b/Blueprints.App/Views/Components/TeamView.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Blueprints.App.ViewModels;
 
 namespace Blueprints.App.Views.Components;
 
@@ -7,5 +9,98 @@ public partial class TeamView : UserControl
     public TeamView()
     {
         InitializeComponent();
+    }
+
+    private async void ExportIdentityInvitation_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickSavePathAsync(
+                "Export signed identity invitation",
+                "identity.blueprints-identity.json",
+                "Blueprints identity invitation",
+                "*.blueprints-identity.json") is { } path)
+        {
+            viewModel.ExportIdentityInvitationCommand.Execute(path);
+        }
+    }
+
+    private async void ImportIdentityInvitation_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickOpenPathAsync(
+                "Import signed identity invitation",
+                "Blueprints identity invitation",
+                "*.blueprints-identity.json") is { } path)
+        {
+            viewModel.ImportIdentityInvitationCommand.Execute(path);
+        }
+    }
+
+    private async void ExportProjectInvitation_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickSavePathAsync(
+                "Export signed project invitation",
+                "project.blueprints-project.json",
+                "Blueprints project invitation",
+                "*.blueprints-project.json") is { } path)
+        {
+            viewModel.ExportProjectInvitationCommand.Execute(path);
+        }
+    }
+
+    private async Task<string?> PickOpenPathAsync(
+        string title,
+        string fileTypeName,
+        string pattern)
+    {
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return null;
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = title,
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    new FilePickerFileType(fileTypeName) { Patterns = [pattern] },
+                ],
+            });
+        return files.FirstOrDefault()?.TryGetLocalPath();
+    }
+
+    private async Task<string?> PickSavePathAsync(
+        string title,
+        string suggestedFileName,
+        string fileTypeName,
+        string pattern)
+    {
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return null;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = title,
+                SuggestedFileName = suggestedFileName,
+                FileTypeChoices =
+                [
+                    new FilePickerFileType(fileTypeName) { Patterns = [pattern] },
+                ],
+            });
+        return file?.TryGetLocalPath();
     }
 }

--- a/Blueprints.Collaboration/Models/SharedManifestStatus.cs
+++ b/Blueprints.Collaboration/Models/SharedManifestStatus.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.Collaboration.Models;
+
+public sealed record SharedManifestStatus(
+    bool Exists,
+    bool SignatureValid,
+    int? ManifestVersion,
+    string BatchId,
+    string Summary);

--- a/Blueprints.Collaboration/Models/SyncSummary.cs
+++ b/Blueprints.Collaboration/Models/SyncSummary.cs
@@ -6,4 +6,7 @@ public sealed record SyncSummary(
     SyncHealth Health,
     int PendingOutgoingChanges,
     int PendingIncomingChanges,
-    int ConflictCount);
+    int ConflictCount,
+    int LastPulledManifestVersion = 0,
+    int LastPushedManifestVersion = 0,
+    DateTimeOffset? LastSuccessfulTrustValidationUtc = null);

--- a/Blueprints.Collaboration/Models/SyncSummary.cs
+++ b/Blueprints.Collaboration/Models/SyncSummary.cs
@@ -9,4 +9,9 @@ public sealed record SyncSummary(
     int ConflictCount,
     int LastPulledManifestVersion = 0,
     int LastPushedManifestVersion = 0,
-    DateTimeOffset? LastSuccessfulTrustValidationUtc = null);
+    DateTimeOffset? LastSuccessfulTrustValidationUtc = null,
+    int? SharedManifestVersion = null,
+    string SharedBatchId = "",
+    bool? SharedManifestSignatureValid = null,
+    bool AuditLogValid = true,
+    int AuditEntryCount = 0);

--- a/Blueprints.Collaboration/Services/FileSystemAuditLogService.cs
+++ b/Blueprints.Collaboration/Services/FileSystemAuditLogService.cs
@@ -52,8 +52,21 @@ public sealed class FileSystemAuditLogService
 
     public AuditLogValidationResult Validate(string workspaceRoot, SignaturePublicKey publicKey)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
         ArgumentNullException.ThrowIfNull(publicKey);
+        return Validate(
+            workspaceRoot,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public AuditLogValidationResult Validate(
+        string workspaceRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         var entries = new List<(string Path, AuditLogEntry Entry, string Hash)>();
         var invalidPaths = new List<string>();
@@ -68,7 +81,7 @@ public sealed class FileSystemAuditLogService
         {
             try
             {
-                var read = _signedDocumentStore.Read<AuditLogEntry>(entryPath, publicKey);
+                var read = _signedDocumentStore.Read<AuditLogEntry>(entryPath, publicKeys);
                 if (!read.IsSignatureValid)
                 {
                     invalidPaths.Add(ToRelativePath(workspaceRoot, entryPath));

--- a/Blueprints.Collaboration/Services/FileSystemSyncManifestStore.cs
+++ b/Blueprints.Collaboration/Services/FileSystemSyncManifestStore.cs
@@ -30,6 +30,17 @@ public sealed class FileSystemSyncManifestStore
             publicKey);
     }
 
+    public SignedDocumentReadResult<SyncManifestDocument> Read(
+        string sharedProjectRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedProjectRoot);
+
+        return _signedDocumentStore.Read<SyncManifestDocument>(
+            GetManifestPath(sharedProjectRoot),
+            publicKeys);
+    }
+
     public SignedDocumentWriteResult Write(
         string sharedProjectRoot,
         Guid projectId,

--- a/Blueprints.Collaboration/Services/FileSystemSyncStateStore.cs
+++ b/Blueprints.Collaboration/Services/FileSystemSyncStateStore.cs
@@ -40,10 +40,12 @@ public sealed class FileSystemSyncStateStore
             Directory.CreateDirectory(directory);
         }
 
+        var tempPath = statePath + ".tmp";
         File.WriteAllText(
-            statePath,
+            tempPath,
             JsonSerializer.Serialize(state, SerializerOptions),
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(tempPath, statePath, overwrite: true);
     }
 
     public SyncStateDocument CreateDefault() =>

--- a/Blueprints.Collaboration/Services/FileSystemWorkspaceSyncService.cs
+++ b/Blueprints.Collaboration/Services/FileSystemWorkspaceSyncService.cs
@@ -35,9 +35,26 @@ public sealed class FileSystemWorkspaceSyncService
         SignatureKeyMaterial signingKey,
         SignaturePublicKey publicKey)
     {
+        ArgumentNullException.ThrowIfNull(publicKey);
+        return Push(
+            workspacePaths,
+            projectId,
+            signingKey,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public WorkspaceSyncResult Push(
+        WorkspacePaths workspacePaths,
+        Guid projectId,
+        SignatureKeyMaterial signingKey,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
         ArgumentNullException.ThrowIfNull(workspacePaths);
         ArgumentNullException.ThrowIfNull(signingKey);
-        ArgumentNullException.ThrowIfNull(publicKey);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         Directory.CreateDirectory(workspacePaths.SharedProjectRoot);
 
@@ -78,7 +95,7 @@ public sealed class FileSystemWorkspaceSyncService
             CopyDocumentPair(workspacePaths.LocalWorkspaceRoot, packRoot, documentPath);
         }
 
-        var currentManifestVersion = TryReadManifestVersion(workspacePaths.SharedProjectRoot, publicKey);
+        var currentManifestVersion = TryReadManifestVersion(workspacePaths.SharedProjectRoot, publicKeys);
         var nextManifestVersion = currentManifestVersion + 1;
         var manifestWrite = _manifestStore.Write(
             workspacePaths.SharedProjectRoot,
@@ -116,15 +133,28 @@ public sealed class FileSystemWorkspaceSyncService
         WorkspacePaths workspacePaths,
         SignaturePublicKey publicKey)
     {
-        ArgumentNullException.ThrowIfNull(workspacePaths);
         ArgumentNullException.ThrowIfNull(publicKey);
+        return Pull(
+            workspacePaths,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public WorkspaceSyncResult Pull(
+        WorkspacePaths workspacePaths,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
+        ArgumentNullException.ThrowIfNull(workspacePaths);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         var state = _syncStateStore.Load(workspacePaths.LocalWorkspaceRoot);
         SignedManifestReadResult manifestResult;
 
         try
         {
-            manifestResult = ReadManifest(workspacePaths.SharedProjectRoot, publicKey);
+            manifestResult = ReadManifest(workspacePaths.SharedProjectRoot, publicKeys);
         }
         catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
         {
@@ -165,7 +195,7 @@ public sealed class FileSystemWorkspaceSyncService
                 "Pull blocked because the shared manifest no longer matches the shared folder content.");
         }
 
-        var auditValidation = _auditLogService.Validate(workspacePaths.SharedProjectRoot, publicKey);
+        var auditValidation = _auditLogService.Validate(workspacePaths.SharedProjectRoot, publicKeys);
         if (!auditValidation.IsValid)
         {
             return new WorkspaceSyncResult(
@@ -213,7 +243,7 @@ public sealed class FileSystemWorkspaceSyncService
         var validationResult = _exchangeValidator.Validate(
             workspacePaths.SharedProjectRoot,
             analysis.IncomingDocumentPaths,
-            publicKey);
+            publicKeys);
         if (!validationResult.IsValid)
         {
             return new WorkspaceSyncResult(
@@ -256,17 +286,21 @@ public sealed class FileSystemWorkspaceSyncService
             $"Pulled {analysis.IncomingDocumentPaths.Count} documents from manifest {manifestResult.Document.ManifestVersion}.");
     }
 
-    private SignedManifestReadResult ReadManifest(string sharedProjectRoot, SignaturePublicKey publicKey)
+    private SignedManifestReadResult ReadManifest(
+        string sharedProjectRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
     {
-        var result = _manifestStore.Read(sharedProjectRoot, publicKey);
+        var result = _manifestStore.Read(sharedProjectRoot, publicKeys);
         return new SignedManifestReadResult(result.Document, result.IsSignatureValid);
     }
 
-    private int TryReadManifestVersion(string sharedProjectRoot, SignaturePublicKey publicKey)
+    private int TryReadManifestVersion(
+        string sharedProjectRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
     {
         try
         {
-            var result = _manifestStore.Read(sharedProjectRoot, publicKey);
+            var result = _manifestStore.Read(sharedProjectRoot, publicKeys);
             return result.IsSignatureValid ? result.Document.ManifestVersion : 0;
         }
         catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)

--- a/Blueprints.Collaboration/Services/FileSystemWorkspaceSyncService.cs
+++ b/Blueprints.Collaboration/Services/FileSystemWorkspaceSyncService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Blueprints.Collaboration.Models;
 using Blueprints.Security.Models;
 using Blueprints.Storage.Models;
@@ -84,18 +85,59 @@ public sealed class FileSystemWorkspaceSyncService
                 "No outgoing changes detected.");
         }
 
+        var deletedRequiredDocuments = analysis.OutgoingDocumentPaths
+            .Where(path =>
+                IsRequiredDocument(path) &&
+                !File.Exists(ResolveWorkspacePath(workspacePaths.LocalWorkspaceRoot, path)))
+            .ToArray();
+        if (deletedRequiredDocuments.Length > 0)
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "push",
+                0,
+                state.LastPushedManifestVersion,
+                string.Empty,
+                deletedRequiredDocuments,
+                "Push blocked because required project documents cannot be deleted.");
+        }
+
+        var currentManifestVersion = TryReadManifestVersion(workspacePaths.SharedProjectRoot, publicKeys);
+        var lastKnownManifestVersion = Math.Max(
+            state.LastPulledManifestVersion,
+            state.LastPushedManifestVersion);
+        if (currentManifestVersion < lastKnownManifestVersion)
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "push",
+                0,
+                state.LastPushedManifestVersion,
+                string.Empty,
+                [],
+                $"Push blocked because the shared manifest rolled back from known version {lastKnownManifestVersion} to {currentManifestVersion}.");
+        }
+
         var batchId = CreateBatchId();
         var stageRoot = Path.Combine(workspacePaths.LocalWorkspaceRoot, "sync", "staging", batchId);
         var packRoot = Path.Combine(workspacePaths.SharedProjectRoot, "packs", batchId);
 
         foreach (var documentPath in analysis.OutgoingDocumentPaths)
         {
-            CopyDocumentPair(workspacePaths.LocalWorkspaceRoot, stageRoot, documentPath);
-            CopyDocumentPair(workspacePaths.LocalWorkspaceRoot, workspacePaths.SharedProjectRoot, documentPath);
-            CopyDocumentPair(workspacePaths.LocalWorkspaceRoot, packRoot, documentPath);
+            SnapshotOrMarkDeletion(
+                workspacePaths.LocalWorkspaceRoot,
+                stageRoot,
+                documentPath);
+            MirrorDocumentPair(
+                workspacePaths.LocalWorkspaceRoot,
+                workspacePaths.SharedProjectRoot,
+                documentPath);
+            SnapshotOrMarkDeletion(
+                workspacePaths.LocalWorkspaceRoot,
+                packRoot,
+                documentPath);
         }
 
-        var currentManifestVersion = TryReadManifestVersion(workspacePaths.SharedProjectRoot, publicKeys);
         var nextManifestVersion = currentManifestVersion + 1;
         var manifestWrite = _manifestStore.Write(
             workspacePaths.SharedProjectRoot,
@@ -146,8 +188,17 @@ public sealed class FileSystemWorkspaceSyncService
         WorkspacePaths workspacePaths,
         IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
     {
+        return Pull(workspacePaths, publicKeys, publicKeys);
+    }
+
+    public WorkspaceSyncResult Pull(
+        WorkspacePaths workspacePaths,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys,
+        IReadOnlyDictionary<string, SignaturePublicKey> auditPublicKeys)
+    {
         ArgumentNullException.ThrowIfNull(workspacePaths);
         ArgumentNullException.ThrowIfNull(publicKeys);
+        ArgumentNullException.ThrowIfNull(auditPublicKeys);
 
         var state = _syncStateStore.Load(workspacePaths.LocalWorkspaceRoot);
         SignedManifestReadResult manifestResult;
@@ -180,6 +231,34 @@ public sealed class FileSystemWorkspaceSyncService
                 "Pull blocked because the shared manifest signature is invalid.");
         }
 
+        if (manifestResult.Document.ManifestVersion < state.LastPulledManifestVersion)
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "pull",
+                0,
+                state.LastPulledManifestVersion,
+                manifestResult.Document.BatchId,
+                [],
+                $"Pull blocked because the shared manifest rolled back from version {state.LastPulledManifestVersion} to {manifestResult.Document.ManifestVersion}.");
+        }
+
+        if (manifestResult.Document.ManifestVersion == state.LastPulledManifestVersion &&
+            state.LastPulledManifestVersion > 0 &&
+            !state.KnownRemoteBatchIds.Contains(
+                manifestResult.Document.BatchId,
+                StringComparer.Ordinal))
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "pull",
+                0,
+                state.LastPulledManifestVersion,
+                manifestResult.Document.BatchId,
+                [],
+                "Pull blocked because a known manifest version was reused with an unknown batch.");
+        }
+
         var manifestContinuityFailures = FindManifestContinuityFailures(
             workspacePaths.SharedProjectRoot,
             manifestResult.Document.Entries);
@@ -195,7 +274,9 @@ public sealed class FileSystemWorkspaceSyncService
                 "Pull blocked because the shared manifest no longer matches the shared folder content.");
         }
 
-        var auditValidation = _auditLogService.Validate(workspacePaths.SharedProjectRoot, publicKeys);
+        var auditValidation = _auditLogService.Validate(
+            workspacePaths.SharedProjectRoot,
+            auditPublicKeys);
         if (!auditValidation.IsValid)
         {
             return new WorkspaceSyncResult(
@@ -228,6 +309,23 @@ public sealed class FileSystemWorkspaceSyncService
                 "Pull blocked because local and shared changes overlap.");
         }
 
+        var deletedRequiredDocuments = analysis.IncomingDocumentPaths
+            .Where(path =>
+                IsRequiredDocument(path) &&
+                !File.Exists(ResolveWorkspacePath(workspacePaths.SharedProjectRoot, path)))
+            .ToArray();
+        if (deletedRequiredDocuments.Length > 0)
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "pull",
+                0,
+                state.LastPulledManifestVersion,
+                manifestResult.Document.BatchId,
+                deletedRequiredDocuments,
+                "Pull blocked because required project documents are missing from the shared workspace.");
+        }
+
         if (!analysis.HasIncomingChanges && manifestResult.Document.ManifestVersion <= state.LastPulledManifestVersion)
         {
             return new WorkspaceSyncResult(
@@ -242,7 +340,8 @@ public sealed class FileSystemWorkspaceSyncService
 
         var validationResult = _exchangeValidator.Validate(
             workspacePaths.SharedProjectRoot,
-            analysis.IncomingDocumentPaths,
+            analysis.IncomingDocumentPaths.Where(path =>
+                File.Exists(ResolveWorkspacePath(workspacePaths.SharedProjectRoot, path))),
             publicKeys);
         if (!validationResult.IsValid)
         {
@@ -256,25 +355,94 @@ public sealed class FileSystemWorkspaceSyncService
                 "Pull blocked because one or more incoming document signatures are invalid.");
         }
 
-        var inboxRoot = Path.Combine(workspacePaths.LocalWorkspaceRoot, "sync", "inbox", manifestResult.Document.BatchId);
+        var inboxRoot = Path.Combine(
+            workspacePaths.LocalWorkspaceRoot,
+            "sync",
+            "inbox",
+            manifestResult.Document.BatchId);
+        var incomingRoot = Path.Combine(inboxRoot, "incoming");
+        var rollbackRoot = Path.Combine(inboxRoot, "rollback");
         foreach (var documentPath in analysis.IncomingDocumentPaths)
         {
-            CopyDocumentPair(workspacePaths.SharedProjectRoot, inboxRoot, documentPath);
-            CopyDocumentPair(workspacePaths.SharedProjectRoot, workspacePaths.LocalWorkspaceRoot, documentPath);
+            if (File.Exists(ResolveWorkspacePath(workspacePaths.SharedProjectRoot, documentPath)))
+            {
+                CopyDocumentPair(
+                    workspacePaths.SharedProjectRoot,
+                    incomingRoot,
+                    documentPath);
+            }
+            else
+            {
+                WriteDeletionMarker(
+                    incomingRoot,
+                    documentPath);
+            }
+
+            SnapshotOrMarkDeletion(
+                workspacePaths.LocalWorkspaceRoot,
+                rollbackRoot,
+                documentPath);
         }
 
-        _syncStateStore.Save(
-            workspacePaths.LocalWorkspaceRoot,
-            state with
-            {
-                LastPulledManifestVersion = manifestResult.Document.ManifestVersion,
-                LastSuccessfulTrustValidationUtc = DateTimeOffset.UtcNow,
-                KnownRemoteBatchIds = AppendUnique(state.KnownRemoteBatchIds, manifestResult.Document.BatchId),
-                UnresolvedConflicts = [],
-                TrackedEntries = manifestResult.Document.Entries
-                    .Select(static entry => new SyncTrackedEntry(entry.DocumentPath, entry.DocumentHash, entry.SignatureHash))
+        var stagedValidation = _exchangeValidator.Validate(
+            incomingRoot,
+            analysis.IncomingDocumentPaths.Where(path =>
+                File.Exists(ResolveWorkspacePath(incomingRoot, path))),
+            publicKeys);
+        var stagedContinuityFailures = FindStagedContinuityFailures(
+            incomingRoot,
+            analysis.IncomingDocumentPaths,
+            manifestResult.Document.Entries);
+        if (!stagedValidation.IsValid || stagedContinuityFailures.Count > 0)
+        {
+            return new WorkspaceSyncResult(
+                false,
+                "pull",
+                0,
+                state.LastPulledManifestVersion,
+                manifestResult.Document.BatchId,
+                stagedValidation.InvalidDocumentPaths
+                    .Concat(stagedContinuityFailures)
+                    .Distinct(StringComparer.Ordinal)
                     .ToArray(),
-            });
+                "Pull blocked because the staged inbox no longer matches the signed shared manifest.");
+        }
+
+        try
+        {
+            foreach (var documentPath in analysis.IncomingDocumentPaths)
+            {
+                MirrorDocumentPair(
+                    incomingRoot,
+                    workspacePaths.LocalWorkspaceRoot,
+                    documentPath);
+            }
+
+            _syncStateStore.Save(
+                workspacePaths.LocalWorkspaceRoot,
+                state with
+                {
+                    LastPulledManifestVersion = manifestResult.Document.ManifestVersion,
+                    LastSuccessfulTrustValidationUtc = DateTimeOffset.UtcNow,
+                    KnownRemoteBatchIds = AppendUnique(state.KnownRemoteBatchIds, manifestResult.Document.BatchId),
+                    UnresolvedConflicts = [],
+                    TrackedEntries = manifestResult.Document.Entries
+                        .Select(static entry => new SyncTrackedEntry(entry.DocumentPath, entry.DocumentHash, entry.SignatureHash))
+                        .ToArray(),
+                });
+        }
+        catch
+        {
+            foreach (var documentPath in analysis.IncomingDocumentPaths)
+            {
+                MirrorDocumentPair(
+                    rollbackRoot,
+                    workspacePaths.LocalWorkspaceRoot,
+                    documentPath);
+            }
+
+            throw;
+        }
 
         return new WorkspaceSyncResult(
             true,
@@ -284,6 +452,47 @@ public sealed class FileSystemWorkspaceSyncService
             manifestResult.Document.BatchId,
             [],
             $"Pulled {analysis.IncomingDocumentPaths.Count} documents from manifest {manifestResult.Document.ManifestVersion}.");
+    }
+
+    public SharedManifestStatus InspectSharedManifest(
+        string sharedProjectRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedProjectRoot);
+        ArgumentNullException.ThrowIfNull(publicKeys);
+
+        try
+        {
+            var result = _manifestStore.Read(sharedProjectRoot, publicKeys);
+            return new SharedManifestStatus(
+                true,
+                result.IsSignatureValid,
+                result.Document.ManifestVersion,
+                result.Document.BatchId,
+                result.IsSignatureValid
+                    ? $"Shared manifest {result.Document.ManifestVersion} is signed by a trusted project key."
+                    : "The shared manifest signature is not trusted.");
+        }
+        catch (Exception exception) when (
+            exception is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return new SharedManifestStatus(
+                false,
+                false,
+                null,
+                string.Empty,
+                "No shared manifest has been published yet.");
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or JsonException)
+        {
+            return new SharedManifestStatus(
+                true,
+                false,
+                null,
+                string.Empty,
+                $"The shared manifest could not be read: {exception.Message}");
+        }
     }
 
     private SignedManifestReadResult ReadManifest(
@@ -329,6 +538,46 @@ public sealed class FileSystemWorkspaceSyncService
         }
     }
 
+    private IReadOnlyList<string> FindStagedContinuityFailures(
+        string incomingRoot,
+        IReadOnlyList<string> incomingDocumentPaths,
+        IReadOnlyList<SyncManifestEntry> manifestEntries)
+    {
+        var expected = manifestEntries.ToDictionary(
+            static entry => entry.DocumentPath,
+            StringComparer.Ordinal);
+        var staged = _snapshotBuilder.Build(incomingRoot).ToDictionary(
+            static entry => entry.DocumentPath,
+            StringComparer.Ordinal);
+        var failures = new List<string>();
+
+        foreach (var path in incomingDocumentPaths)
+        {
+            var expectsDocument = expected.TryGetValue(path, out var expectedEntry);
+            var hasStagedDocument = staged.TryGetValue(path, out var stagedEntry);
+            if (expectsDocument != hasStagedDocument)
+            {
+                failures.Add(path);
+                continue;
+            }
+
+            if (expectsDocument &&
+                (!string.Equals(
+                    expectedEntry!.DocumentHash,
+                    stagedEntry!.DocumentHash,
+                    StringComparison.Ordinal) ||
+                 !string.Equals(
+                    expectedEntry.SignatureHash,
+                    stagedEntry.SignatureHash,
+                    StringComparison.Ordinal)))
+            {
+                failures.Add(path);
+            }
+        }
+
+        return failures;
+    }
+
     private static bool Matches(SyncManifestEntry left, SyncManifestEntry right) =>
         string.Equals(left.DocumentHash, right.DocumentHash, StringComparison.Ordinal)
         && string.Equals(left.SignatureHash, right.SignatureHash, StringComparison.Ordinal);
@@ -339,10 +588,82 @@ public sealed class FileSystemWorkspaceSyncService
         CopyFile(sourceRoot, destinationRoot, Path.ChangeExtension(documentPath, ".sig"));
     }
 
+    private static void SnapshotOrMarkDeletion(
+        string sourceRoot,
+        string destinationRoot,
+        string documentPath)
+    {
+        var signaturePath = Path.ChangeExtension(documentPath, ".sig");
+        var documentExists = File.Exists(ResolveWorkspacePath(sourceRoot, documentPath));
+        var signatureExists = File.Exists(ResolveWorkspacePath(sourceRoot, signaturePath));
+        if (documentExists != signatureExists)
+        {
+            throw new InvalidOperationException(
+                $"Document/signature pair is incomplete for {documentPath}.");
+        }
+
+        if (!documentExists)
+        {
+            WriteDeletionMarker(destinationRoot, documentPath);
+            return;
+        }
+
+        CopyDocumentPair(sourceRoot, destinationRoot, documentPath);
+    }
+
+    private static void MirrorDocumentPair(
+        string sourceRoot,
+        string destinationRoot,
+        string documentPath)
+    {
+        var signaturePath = Path.ChangeExtension(documentPath, ".sig");
+        var documentExists = File.Exists(ResolveWorkspacePath(sourceRoot, documentPath));
+        var signatureExists = File.Exists(ResolveWorkspacePath(sourceRoot, signaturePath));
+        if (documentExists != signatureExists)
+        {
+            throw new InvalidOperationException(
+                $"Document/signature pair is incomplete for {documentPath}.");
+        }
+
+        if (!documentExists)
+        {
+            DeleteFileIfPresent(destinationRoot, documentPath);
+            DeleteFileIfPresent(destinationRoot, signaturePath);
+            return;
+        }
+
+        CopyDocumentPair(sourceRoot, destinationRoot, documentPath);
+    }
+
+    private static void WriteDeletionMarker(string root, string documentPath)
+    {
+        var markerPath = ResolveWorkspacePath(root, documentPath + ".deleted");
+        var directory = Path.GetDirectoryName(markerPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(markerPath, documentPath);
+    }
+
+    private static void DeleteFileIfPresent(string root, string relativePath)
+    {
+        var path = ResolveWorkspacePath(root, relativePath);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static bool IsRequiredDocument(string documentPath) =>
+        string.Equals(documentPath, "project/project.json", StringComparison.Ordinal) ||
+        string.Equals(documentPath, "project/members.json", StringComparison.Ordinal);
+
     private static void CopyFile(string sourceRoot, string destinationRoot, string relativePath)
     {
-        var sourcePath = Path.Combine(sourceRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
-        var destinationPath = Path.Combine(destinationRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var sourcePath = ResolveWorkspacePath(sourceRoot, relativePath);
+        var destinationPath = ResolveWorkspacePath(destinationRoot, relativePath);
         var directory = Path.GetDirectoryName(destinationPath);
         if (!string.IsNullOrWhiteSpace(directory))
         {
@@ -358,6 +679,27 @@ public sealed class FileSystemWorkspaceSyncService
         }
 
         File.Move(tempPath, destinationPath);
+    }
+
+    private static string ResolveWorkspacePath(string workspaceRoot, string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath))
+        {
+            throw new InvalidOperationException("Workspace document path must be relative.");
+        }
+
+        var fullRoot = Path.GetFullPath(workspaceRoot);
+        var fullPath = Path.GetFullPath(
+            Path.Combine(fullRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var relativeToRoot = Path.GetRelativePath(fullRoot, fullPath);
+        if (relativeToRoot == ".." ||
+            relativeToRoot.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Workspace document path escapes its expected root.");
+        }
+
+        return fullPath;
     }
 
     private static string CreateBatchId() =>

--- a/Blueprints.Collaboration/Services/WorkspaceExchangeValidator.cs
+++ b/Blueprints.Collaboration/Services/WorkspaceExchangeValidator.cs
@@ -25,9 +25,24 @@ public sealed class WorkspaceExchangeValidator
         IEnumerable<string> documentPaths,
         SignaturePublicKey publicKey)
     {
+        ArgumentNullException.ThrowIfNull(publicKey);
+        return Validate(
+            workspaceRoot,
+            documentPaths,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public ExchangeValidationResult Validate(
+        string workspaceRoot,
+        IEnumerable<string> documentPaths,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
         ArgumentNullException.ThrowIfNull(documentPaths);
-        ArgumentNullException.ThrowIfNull(publicKey);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         var invalidPaths = new List<string>();
 
@@ -47,7 +62,9 @@ public sealed class WorkspaceExchangeValidator
                 File.ReadAllText(absoluteSignaturePath, Encoding.UTF8),
                 SignatureSerializerOptions);
 
-            if (signature is null || !_signatureService.Verify(payload, signature, publicKey))
+            if (signature is null ||
+                !publicKeys.TryGetValue(signature.KeyId, out var publicKey) ||
+                !_signatureService.Verify(payload, signature, publicKey))
             {
                 invalidPaths.Add(documentPath);
             }

--- a/Blueprints.Core/Models/ProjectMember.cs
+++ b/Blueprints.Core/Models/ProjectMember.cs
@@ -8,4 +8,5 @@ public sealed record ProjectMember(
     string PublicKey,
     MemberRole Role,
     DateTimeOffset JoinedUtc,
-    bool IsActive);
+    bool IsActive,
+    string? KeyId = null);

--- a/Blueprints.Security/Abstractions/IIdentityService.cs
+++ b/Blueprints.Security/Abstractions/IIdentityService.cs
@@ -4,6 +4,8 @@ namespace Blueprints.Security.Abstractions;
 
 public interface IIdentityService
 {
+    StoredIdentity CreateIdentity(string displayName);
+
     StoredIdentity GetOrCreateDefaultIdentity(string displayName);
 
     IReadOnlyList<IdentityProfile> ListProfiles();

--- a/Blueprints.Security/Models/IdentityInvitationFile.cs
+++ b/Blueprints.Security/Models/IdentityInvitationFile.cs
@@ -1,0 +1,5 @@
+namespace Blueprints.Security.Models;
+
+public sealed record IdentityInvitationFile(
+    IdentityInvitationPayload Identity,
+    DetachedSignature Proof);

--- a/Blueprints.Security/Models/IdentityInvitationPayload.cs
+++ b/Blueprints.Security/Models/IdentityInvitationPayload.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.Security.Models;
+
+public sealed record IdentityInvitationPayload(
+    int SchemaVersion,
+    Guid UserId,
+    string DisplayName,
+    string KeyId,
+    string PublicKeyBase64,
+    DateTimeOffset CreatedUtc);

--- a/Blueprints.Security/Services/IdentityInvitationService.cs
+++ b/Blueprints.Security/Services/IdentityInvitationService.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using System.Text.Json;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Services;
+
+public sealed class IdentityInvitationService
+{
+    private const int CurrentSchemaVersion = 1;
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+    private static readonly JsonSerializerOptions PayloadSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+    private readonly ISignatureService _signatureService;
+
+    public IdentityInvitationService(ISignatureService signatureService)
+    {
+        _signatureService = signatureService;
+    }
+
+    public string Write(string filePath, StoredIdentity identity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(identity);
+
+        var payload = new IdentityInvitationPayload(
+            CurrentSchemaVersion,
+            identity.Profile.UserId,
+            identity.Profile.DisplayName,
+            identity.Profile.KeyId,
+            identity.Profile.PublicKeyBase64,
+            identity.Profile.CreatedUtc);
+        var proof = _signatureService.Sign(
+            SerializePayload(payload),
+            identity.SigningKey);
+        WriteAtomically(
+            filePath,
+            JsonSerializer.Serialize(
+                new IdentityInvitationFile(payload, proof),
+                SerializerOptions));
+        return Path.GetFullPath(filePath);
+    }
+
+    public IdentityInvitationPayload Read(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var invitation = JsonSerializer.Deserialize<IdentityInvitationFile>(
+            File.ReadAllText(filePath, Encoding.UTF8),
+            SerializerOptions)
+            ?? throw new InvalidOperationException("Identity invitation could not be read.");
+        var payload = invitation.Identity;
+        if (payload.SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported identity invitation schema {payload.SchemaVersion}.");
+        }
+
+        if (payload.UserId == Guid.Empty ||
+            string.IsNullOrWhiteSpace(payload.DisplayName) ||
+            string.IsNullOrWhiteSpace(payload.KeyId))
+        {
+            throw new InvalidOperationException("Identity invitation is missing required identity fields.");
+        }
+
+        try
+        {
+            var publicKey = new SignaturePublicKey(
+                payload.KeyId,
+                Convert.FromBase64String(payload.PublicKeyBase64));
+            if (!_signatureService.Verify(SerializePayload(payload), invitation.Proof, publicKey))
+            {
+                throw new InvalidOperationException(
+                    "Identity invitation proof is invalid.");
+            }
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException(
+                "Identity invitation contains invalid key or proof data.",
+                exception);
+        }
+
+        return payload;
+    }
+
+    private static byte[] SerializePayload(IdentityInvitationPayload payload) =>
+        JsonSerializer.SerializeToUtf8Bytes(payload, PayloadSerializerOptions);
+
+    private static void WriteAtomically(string filePath, string json)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(fullPath)
+            ?? throw new InvalidOperationException("Invitation path has no parent.");
+        Directory.CreateDirectory(directory);
+        var tempPath = fullPath + ".tmp";
+        File.WriteAllText(
+            tempPath,
+            json,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(tempPath, fullPath, overwrite: true);
+    }
+}

--- a/Blueprints.Security/Services/IdentityService.cs
+++ b/Blueprints.Security/Services/IdentityService.cs
@@ -27,6 +27,9 @@ public sealed class IdentityService : IIdentityService
             : _identityStore.Load(existingProfile.UserId);
     }
 
+    public StoredIdentity CreateIdentity(string displayName) =>
+        _identityStore.Create(displayName);
+
     public IReadOnlyList<IdentityProfile> ListProfiles()
     {
         if (!Directory.Exists(_rootDirectory))

--- a/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
@@ -15,6 +15,10 @@ public interface IProjectWorkspaceStore
         string workspaceRoot,
         SignaturePublicKey publicKey);
 
+    ProjectWorkspaceLoadResult Load(
+        string workspaceRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys);
+
     void SaveCanvasLayout(
         string workspaceRoot,
         CanvasLayoutDocument layout,

--- a/Blueprints.Storage/Abstractions/ISignedDocumentStore.cs
+++ b/Blueprints.Storage/Abstractions/ISignedDocumentStore.cs
@@ -13,4 +13,8 @@ public interface ISignedDocumentStore
     SignedDocumentReadResult<T> Read<T>(
         string documentPath,
         SignaturePublicKey publicKey);
+
+    SignedDocumentReadResult<T> Read<T>(
+        string documentPath,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys);
 }

--- a/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
@@ -20,16 +20,30 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
         string workspaceRoot,
         SignaturePublicKey publicKey)
     {
+        ArgumentNullException.ThrowIfNull(publicKey);
+        return Load(
+            workspaceRoot,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public ProjectWorkspaceLoadResult Load(
+        string workspaceRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         try
         {
             var projectResult = _signedDocumentStore.Read<ProjectConfigurationDocument>(
                 GetProjectDocumentPath(workspaceRoot),
-                publicKey);
+                publicKeys);
             var membersResult = _signedDocumentStore.Read<MemberDocument>(
                 GetMembersDocumentPath(workspaceRoot),
-                publicKey);
+                publicKeys);
 
             var versionSnapshots = new List<VersionWorkspaceSnapshot>();
             var allSignaturesValid = projectResult.IsSignatureValid && membersResult.IsSignatureValid;
@@ -42,7 +56,7 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
             {
                 var canvasLayoutResult = _signedDocumentStore.Read<CanvasLayoutDocument>(
                     canvasLayoutPath,
-                    publicKey);
+                    publicKeys);
                 CanvasLayoutValidator.Validate(canvasLayoutResult.Document, projectResult.Document.ProjectId);
                 canvasLayout = canvasLayoutResult.Document;
                 totalDocuments++;
@@ -60,7 +74,7 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                 {
                     var versionResult = _signedDocumentStore.Read<VersionDocument>(
                         GetVersionDocumentPath(versionDirectory),
-                        publicKey);
+                        publicKeys);
 
                     totalDocuments++;
                     if (!versionResult.IsSignatureValid)
@@ -75,7 +89,7 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                     {
                         foreach (var itemPath in Directory.EnumerateFiles(itemsRoot, "*.json").OrderBy(static path => path, StringComparer.Ordinal))
                         {
-                            var itemResult = _signedDocumentStore.Read<ItemDocument>(itemPath, publicKey);
+                            var itemResult = _signedDocumentStore.Read<ItemDocument>(itemPath, publicKeys);
                             totalDocuments++;
                             if (!itemResult.IsSignatureValid)
                             {

--- a/Blueprints.Storage/Services/FileSystemSignedDocumentStore.cs
+++ b/Blueprints.Storage/Services/FileSystemSignedDocumentStore.cs
@@ -30,15 +30,31 @@ public sealed class FileSystemSignedDocumentStore : ISignedDocumentStore
         string documentPath,
         SignaturePublicKey publicKey)
     {
+        ArgumentNullException.ThrowIfNull(publicKey);
+        return Read<T>(
+            documentPath,
+            new Dictionary<string, SignaturePublicKey>(StringComparer.Ordinal)
+            {
+                [publicKey.KeyId] = publicKey,
+            });
+    }
+
+    public SignedDocumentReadResult<T> Read<T>(
+        string documentPath,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(documentPath);
+        ArgumentNullException.ThrowIfNull(publicKeys);
 
         var canonicalJson = File.ReadAllText(documentPath, Encoding.UTF8);
         var document = _canonicalJsonSerializer.Deserialize<T>(canonicalJson);
         var signature = ReadSignature(GetSignaturePath(documentPath));
-        var isSignatureValid = _signatureService.Verify(
-            Encoding.UTF8.GetBytes(canonicalJson),
-            signature,
-            publicKey);
+        var isSignatureValid =
+            publicKeys.TryGetValue(signature.KeyId, out var publicKey) &&
+            _signatureService.Verify(
+                Encoding.UTF8.GetBytes(canonicalJson),
+                signature,
+                publicKey);
 
         return new SignedDocumentReadResult<T>(
             document,

--- a/Blueprints.Tests/Blueprints.Tests.csproj
+++ b/Blueprints.Tests/Blueprints.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Blueprints.Tests/DistinctIdentityCollaborationTests.cs
+++ b/Blueprints.Tests/DistinctIdentityCollaborationTests.cs
@@ -91,6 +91,31 @@ public sealed class DistinctIdentityCollaborationTests : IDisposable
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         Assert.NotNull(signature);
         Assert.Equal(joined.Identity.Profile.KeyId, signature.KeyId);
+
+        alice.UpdateMember(
+            aliceLocal,
+            sharedRoot,
+            new MemberUpdateRequest(
+                bobMember.UserId,
+                bobMember.DisplayName,
+                MemberRole.Editor,
+                false));
+        Assert.True(alice.PushWorkspace(aliceLocal, sharedRoot).Success);
+        Assert.True(bob.PullWorkspace(bobLocal, sharedRoot).Success);
+
+        var deactivatedException = Assert.Throws<InvalidOperationException>(
+            () => bob.SaveVersion(
+                bobLocal,
+                sharedRoot,
+                new VersionEditRequest(
+                    null,
+                    "0.3.1",
+                    ReleaseStatus.InProgress,
+                    "Should be blocked")));
+        Assert.Contains(
+            "active editors or administrators",
+            deactivatedException.Message,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/Blueprints.Tests/DistinctIdentityCollaborationTests.cs
+++ b/Blueprints.Tests/DistinctIdentityCollaborationTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+using Blueprints.Collaboration.Services;
+using Blueprints.Core.Enums;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class DistinctIdentityCollaborationTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "DistinctIdentityCollaboration",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void SignedInvitations_EnableTwoDistinctIdentitiesToExchangeChanges()
+    {
+        var alice = CreateCoordinator("alice");
+        var bob = CreateCoordinator("bob");
+        var aliceLocal = Path.Combine(_rootDirectory, "workspaces", "alice", "BP");
+        var bobLocal = Path.Combine(_rootDirectory, "workspaces", "bob", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "shared", "BP");
+        var identityRequestPath = Path.Combine(_rootDirectory, "invites", "bob.identity.json");
+        var projectInvitationPath = Path.Combine(_rootDirectory, "invites", "BP.project.json");
+
+        var created = alice.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                aliceLocal,
+                sharedRoot));
+        bob.ExportIdentityInvitation(identityRequestPath);
+        var bobRequest = alice.ReadIdentityInvitation(identityRequestPath);
+        var membership = alice.InviteMember(
+            aliceLocal,
+            sharedRoot,
+            bobRequest with { Role = MemberRole.Editor });
+        var bobMember = Assert.Single(
+            membership.LoadResult.Workspace.Members.Members,
+            member => member.UserId.ToString() == bobRequest.UserId);
+
+        var initialPush = alice.PushWorkspace(aliceLocal, sharedRoot);
+        alice.ExportProjectInvitation(
+            aliceLocal,
+            sharedRoot,
+            bobMember.UserId,
+            projectInvitationPath);
+        var joined = bob.JoinProjectFromInvitation(
+            projectInvitationPath,
+            bobLocal);
+
+        Assert.True(initialPush.Success);
+        Assert.Equal(created.LoadResult.Workspace.Project.ProjectId, joined.LoadResult.Workspace.Project.ProjectId);
+        Assert.Contains(
+            joined.LoadResult.Workspace.Members.Members,
+            member => member.UserId == joined.Identity.Profile.UserId);
+
+        bob.SaveVersion(
+            bobLocal,
+            sharedRoot,
+            new VersionEditRequest(
+                null,
+                "0.3.0",
+                ReleaseStatus.InProgress,
+                "Distinct identity collaboration"));
+        var bobPush = bob.PushWorkspace(bobLocal, sharedRoot);
+        var alicePull = alice.PullWorkspace(aliceLocal, sharedRoot);
+        var refreshedAlice = alice.OpenProject(aliceLocal, sharedRoot);
+
+        Assert.True(bobPush.Success);
+        Assert.True(alicePull.Success);
+        Assert.Contains(
+            refreshedAlice.LoadResult.Workspace.Versions,
+            static version => version.Version.Name == "0.3.0");
+        Assert.Equal(TrustState.Trusted, refreshedAlice.LoadResult.TrustReport.State);
+
+        var bobVersionDirectory = Directory.EnumerateDirectories(
+            Path.Combine(bobLocal, "versions"))
+            .Single(directory =>
+                File.ReadAllText(Path.Combine(directory, "version.json"))
+                    .Contains("\"name\":\"0.3.0\"", StringComparison.Ordinal));
+        var signature = JsonSerializer.Deserialize<DetachedSignature>(
+            File.ReadAllText(Path.Combine(bobVersionDirectory, "version.sig")),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        Assert.NotNull(signature);
+        Assert.Equal(joined.Identity.Profile.KeyId, signature.KeyId);
+    }
+
+    [Fact]
+    public void ProjectInvitation_RejectsTheWrongLocalIdentityBeforeCreatingAWorkspace()
+    {
+        var alice = CreateCoordinator("target-alice");
+        var bob = CreateCoordinator("target-bob");
+        var charlie = CreateCoordinator("target-charlie");
+        var aliceLocal = Path.Combine(_rootDirectory, "target-workspaces", "alice", "BP");
+        var charlieLocal = Path.Combine(_rootDirectory, "target-workspaces", "charlie", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "target-shared", "BP");
+        var identityRequestPath = Path.Combine(_rootDirectory, "target-invites", "bob.identity.json");
+        var projectInvitationPath = Path.Combine(_rootDirectory, "target-invites", "BP.project.json");
+
+        alice.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                aliceLocal,
+                sharedRoot));
+        bob.ExportIdentityInvitation(identityRequestPath);
+        var request = alice.ReadIdentityInvitation(identityRequestPath);
+        var membership = alice.InviteMember(aliceLocal, sharedRoot, request);
+        var bobMember = Assert.Single(
+            membership.LoadResult.Workspace.Members.Members,
+            member => member.UserId.ToString() == request.UserId);
+        alice.PushWorkspace(aliceLocal, sharedRoot);
+        alice.ExportProjectInvitation(
+            aliceLocal,
+            sharedRoot,
+            bobMember.UserId,
+            projectInvitationPath);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => charlie.JoinProjectFromInvitation(
+                projectInvitationPath,
+                charlieLocal));
+
+        Assert.Contains("different local identity", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(charlieLocal));
+    }
+
+    private ProjectWorkspaceCoordinatorService CreateCoordinator(string name)
+    {
+        var identityRoot = Path.Combine(_rootDirectory, "identities", name);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var identityService = new IdentityService(
+            identityRoot,
+            new FileSystemIdentityStore(
+                identityRoot,
+                new Ed25519KeyPairGenerator(),
+                new TestPrivateKeyProtector()));
+        var snapshotBuilder = new WorkspaceExchangeSnapshotBuilder();
+        var syncStateStore = new FileSystemSyncStateStore();
+        var syncAnalyzer = new WorkspaceSyncAnalyzer(snapshotBuilder);
+        var auditLog = new FileSystemAuditLogService(signedStore);
+        var syncService = new FileSystemWorkspaceSyncService(
+            snapshotBuilder,
+            syncAnalyzer,
+            new FileSystemSyncManifestStore(signedStore, snapshotBuilder),
+            syncStateStore,
+            new WorkspaceExchangeValidator(new Ed25519SignatureService()),
+            auditLog);
+
+        return new ProjectWorkspaceCoordinatorService(
+            identityService,
+            workspaceStore,
+            syncStateStore,
+            syncAnalyzer,
+            syncService,
+            new RecentProjectsStore(
+                Path.Combine(_rootDirectory, "recent", $"{name}.json")),
+            auditLog,
+            new SharedFolderSafetyInspector());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private sealed class TestPrivateKeyProtector : IPrivateKeyProtector
+    {
+        public string ProviderName => "Test";
+
+        public byte[] Protect(ReadOnlySpan<byte> privateKeyBytes) =>
+            privateKeyBytes.ToArray();
+
+        public byte[] Unprotect(ReadOnlySpan<byte> protectedBytes) =>
+            protectedBytes.ToArray();
+    }
+}

--- a/Blueprints.Tests/FileSystemWorkspaceSyncServiceTests.cs
+++ b/Blueprints.Tests/FileSystemWorkspaceSyncServiceTests.cs
@@ -162,6 +162,78 @@ public sealed class FileSystemWorkspaceSyncServiceTests : IDisposable
     }
 
     [Fact]
+    public void Pull_BlocksAPartialSharedCopyWithoutMutatingLocalState()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "partial-local");
+        var sharedRoot = Path.Combine(_rootDirectory, "partial-shared");
+        var keyPair = new Ed25519KeyPairGenerator().Generate("partial-admin");
+        var signingKey = new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes);
+        var publicKey = new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        workspaceStore.Save(sharedRoot, workspace, signingKey);
+        var manifestStore = new FileSystemSyncManifestStore(
+            signedStore,
+            new WorkspaceExchangeSnapshotBuilder());
+        manifestStore.Write(
+            sharedRoot,
+            workspace.Project.ProjectId,
+            1,
+            "batch-partial",
+            signingKey);
+        var versionSignature = Directory.EnumerateFiles(
+            Path.Combine(sharedRoot, "versions"),
+            "version.sig",
+            SearchOption.AllDirectories).Single();
+        File.Delete(versionSignature);
+
+        var result = CreateService(signedStore).Pull(
+            new WorkspacePaths(localRoot, sharedRoot),
+            publicKey);
+
+        Assert.False(result.Success);
+        Assert.Contains("no longer matches", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(localRoot, "project", "project.json")));
+    }
+
+    [Fact]
+    public void Push_BlocksDeletionOfRequiredProjectDocuments()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "required-local");
+        var sharedRoot = Path.Combine(_rootDirectory, "required-shared");
+        var keyPair = new Ed25519KeyPairGenerator().Generate("required-admin");
+        var signingKey = new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes);
+        var publicKey = new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        workspaceStore.Save(localRoot, workspace, signingKey);
+        var service = CreateService(signedStore);
+        Assert.True(service.Push(
+            new WorkspacePaths(localRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey).Success);
+
+        File.Delete(Path.Combine(localRoot, "project", "project.json"));
+        File.Delete(Path.Combine(localRoot, "project", "project.sig"));
+        var blocked = service.Push(
+            new WorkspacePaths(localRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey);
+
+        Assert.False(blocked.Success);
+        Assert.Contains("required", blocked.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(Path.Combine(sharedRoot, "project", "project.json")));
+    }
+
+    [Fact]
     public void Pull_BlocksWhenSharedAuditLogChainIsInvalid()
     {
         var localRoot = Path.Combine(_rootDirectory, "audit-local");
@@ -208,6 +280,127 @@ public sealed class FileSystemWorkspaceSyncServiceTests : IDisposable
         Assert.False(result.Success);
         Assert.Contains("audit log", result.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("log/", result.Conflicts.Single(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeletedItem_RoundTripsAsAnExplicitRecoverableDeletion()
+    {
+        var aliceRoot = Path.Combine(_rootDirectory, "delete-alice");
+        var bobRoot = Path.Combine(_rootDirectory, "delete-bob");
+        var sharedRoot = Path.Combine(_rootDirectory, "delete-shared");
+        var keyPair = new Ed25519KeyPairGenerator().Generate("delete-admin");
+        var signingKey = new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes);
+        var publicKey = new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        workspaceStore.Save(aliceRoot, workspace, signingKey);
+        var service = CreateService(signedStore);
+
+        Assert.True(service.Push(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey).Success);
+        Assert.True(service.Pull(new WorkspacePaths(bobRoot, sharedRoot), publicKey).Success);
+
+        var itemPath = Directory.EnumerateFiles(
+            Path.Combine(aliceRoot, "versions"),
+            "*.json",
+            SearchOption.AllDirectories)
+            .Single(path => path.Contains(
+                $"{Path.DirectorySeparatorChar}items{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal));
+        var relativeItemPath = Path.GetRelativePath(aliceRoot, itemPath).Replace('\\', '/');
+        File.Delete(itemPath);
+        File.Delete(Path.ChangeExtension(itemPath, ".sig"));
+
+        var deletionPush = service.Push(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey);
+        var deletionPull = service.Pull(
+            new WorkspacePaths(bobRoot, sharedRoot),
+            publicKey);
+
+        Assert.True(deletionPush.Success);
+        Assert.True(deletionPull.Success);
+        Assert.False(File.Exists(Path.Combine(
+            bobRoot,
+            relativeItemPath.Replace('/', Path.DirectorySeparatorChar))));
+        Assert.True(Directory.EnumerateFiles(
+            Path.Combine(bobRoot, "sync", "inbox"),
+            "*.deleted",
+            SearchOption.AllDirectories).Any());
+        Assert.True(Directory.EnumerateFiles(
+            Path.Combine(bobRoot, "sync", "inbox"),
+            Path.GetFileName(relativeItemPath),
+            SearchOption.AllDirectories).Any());
+    }
+
+    [Fact]
+    public void Pull_BlocksAValidlySignedManifestRollback()
+    {
+        var aliceRoot = Path.Combine(_rootDirectory, "rollback-alice");
+        var bobRoot = Path.Combine(_rootDirectory, "rollback-bob");
+        var sharedRoot = Path.Combine(_rootDirectory, "rollback-shared");
+        var keyPair = new Ed25519KeyPairGenerator().Generate("rollback-admin");
+        var signingKey = new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes);
+        var publicKey = new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        workspaceStore.Save(aliceRoot, workspace, signingKey);
+        var service = CreateService(signedStore);
+
+        Assert.True(service.Push(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey).Success);
+        Assert.True(service.Pull(new WorkspacePaths(bobRoot, sharedRoot), publicKey).Success);
+        var manifestPath = Path.Combine(sharedRoot, "manifest", "sync-manifest.json");
+        var manifestSignaturePath = Path.ChangeExtension(manifestPath, ".sig");
+        var versionOneManifest = File.ReadAllBytes(manifestPath);
+        var versionOneSignature = File.ReadAllBytes(manifestSignaturePath);
+
+        var version = workspace.Versions.Single();
+        workspaceStore.Save(
+            aliceRoot,
+            workspace with
+            {
+                Versions =
+                [
+                    version with
+                    {
+                        Version = version.Version with { Notes = "Manifest version two" },
+                    },
+                ],
+            },
+            signingKey);
+        Assert.True(service.Push(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            signingKey,
+            publicKey).Success);
+        Assert.True(service.Pull(new WorkspacePaths(bobRoot, sharedRoot), publicKey).Success);
+
+        File.WriteAllBytes(manifestPath, versionOneManifest);
+        File.WriteAllBytes(manifestSignaturePath, versionOneSignature);
+        var rollbackPull = service.Pull(
+            new WorkspacePaths(bobRoot, sharedRoot),
+            publicKey);
+
+        Assert.False(rollbackPull.Success);
+        Assert.Contains("rolled back", rollbackPull.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(
+            "Manifest version two",
+            workspaceStore.Load(bobRoot, publicKey).Workspace.Versions.Single().Version.Notes);
     }
 
     private static FileSystemWorkspaceSyncService CreateService(FileSystemSignedDocumentStore signedStore)

--- a/Blueprints.Tests/IdentityInvitationServiceTests.cs
+++ b/Blueprints.Tests/IdentityInvitationServiceTests.cs
@@ -1,0 +1,72 @@
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class IdentityInvitationServiceTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "IdentityInvitations",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void WriteAndRead_RoundTripsAProofOfKeyPossession()
+    {
+        var identity = CreateIdentity("Bob");
+        var service = new IdentityInvitationService(new Ed25519SignatureService());
+        var path = Path.Combine(_rootDirectory, "bob.blueprints-identity.json");
+
+        service.Write(path, identity);
+        var invitation = service.Read(path);
+
+        Assert.Equal(identity.Profile.UserId, invitation.UserId);
+        Assert.Equal(identity.Profile.KeyId, invitation.KeyId);
+        Assert.Equal(identity.Profile.PublicKeyBase64, invitation.PublicKeyBase64);
+    }
+
+    [Fact]
+    public void Read_RejectsTamperedIdentityFields()
+    {
+        var identity = CreateIdentity("Bob");
+        var service = new IdentityInvitationService(new Ed25519SignatureService());
+        var path = Path.Combine(_rootDirectory, "tampered.blueprints-identity.json");
+        service.Write(path, identity);
+        File.WriteAllText(
+            path,
+            File.ReadAllText(path).Replace("\"Bob\"", "\"Mallory\"", StringComparison.Ordinal));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Read(path));
+
+        Assert.Contains("proof", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private Blueprints.Security.Models.StoredIdentity CreateIdentity(string displayName)
+    {
+        var identityRoot = Path.Combine(_rootDirectory, "identities");
+        return new FileSystemIdentityStore(
+            identityRoot,
+            new Ed25519KeyPairGenerator(),
+            new TestPrivateKeyProtector()).Create(displayName);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private sealed class TestPrivateKeyProtector : IPrivateKeyProtector
+    {
+        public string ProviderName => "Test";
+
+        public byte[] Protect(ReadOnlySpan<byte> privateKeyBytes) =>
+            privateKeyBytes.ToArray();
+
+        public byte[] Unprotect(ReadOnlySpan<byte> protectedBytes) =>
+            protectedBytes.ToArray();
+    }
+}

--- a/Blueprints.Tests/MainWindowWorkflowTests.cs
+++ b/Blueprints.Tests/MainWindowWorkflowTests.cs
@@ -1,0 +1,117 @@
+using Blueprints.App.Services;
+using Blueprints.App.ViewModels;
+using Blueprints.Collaboration.Services;
+using Blueprints.Core.Enums;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class MainWindowWorkflowTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "MainWindowWorkflow",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Commands_CreateEditFreezeReleasePreviewAndExport()
+    {
+        var viewModel = new MainWindowViewModel(
+            CreateCoordinator(),
+            new IntegrationStatusService());
+        var localRoot = Path.Combine(_rootDirectory, "local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "shared", "BP");
+
+        viewModel.IdentitySetupName = "Release Admin";
+        viewModel.CreateLocalIdentityCommand.Execute(null);
+        viewModel.CreateProjectName = "Blueprints";
+        viewModel.CreateProjectCode = "BP";
+        viewModel.CreateVersioningScheme = "SemVer";
+        viewModel.CreateLocalWorkspaceRoot = localRoot;
+        viewModel.CreateSharedWorkspaceRoot = sharedRoot;
+        viewModel.CreateProjectCommand.Execute(null);
+
+        Assert.True(viewModel.HasActiveSession);
+        Assert.Equal("Release Admin", viewModel.Identity.DisplayName);
+
+        viewModel.NewVersionName = "0.3.0";
+        viewModel.CreateVersionCommand.Execute(null);
+        var created = Assert.Single(viewModel.Versions);
+        viewModel.SelectedVersion = created;
+        viewModel.VersionEditorNotes = "Collaboration milestone";
+        viewModel.SaveVersionDetailsCommand.Execute(null);
+
+        viewModel.VersionEditorStatus = ReleaseStatus.Frozen;
+        viewModel.SaveVersionDetailsCommand.Execute(null);
+        Assert.Equal(ReleaseStatus.Frozen, viewModel.SelectedVersion?.Status);
+
+        viewModel.ReleaseSelectedVersionCommand.Execute(null);
+        Assert.Equal(ReleaseStatus.Released, viewModel.SelectedVersion?.Status);
+
+        viewModel.ChangelogCompactMode = true;
+        viewModel.PreviewSelectedVersionChangelogCommand.Execute(null);
+        Assert.Contains("# Blueprints 0.3.0", viewModel.ChangelogPreview, StringComparison.Ordinal);
+        Assert.Empty(viewModel.LastChangelogExportPath);
+
+        viewModel.ExportSelectedVersionChangelogCommand.Execute(null);
+        Assert.True(File.Exists(viewModel.LastChangelogExportPath));
+        Assert.Contains("Exported changelog", viewModel.WorkspaceMessage, StringComparison.Ordinal);
+    }
+
+    private ProjectWorkspaceCoordinatorService CreateCoordinator()
+    {
+        var identityRoot = Path.Combine(_rootDirectory, "identities");
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var identityService = new IdentityService(
+            identityRoot,
+            new FileSystemIdentityStore(
+                identityRoot,
+                new Ed25519KeyPairGenerator(),
+                new TestPrivateKeyProtector()));
+        var snapshotBuilder = new WorkspaceExchangeSnapshotBuilder();
+        var stateStore = new FileSystemSyncStateStore();
+        var analyzer = new WorkspaceSyncAnalyzer(snapshotBuilder);
+        var auditLog = new FileSystemAuditLogService(signedStore);
+        var syncService = new FileSystemWorkspaceSyncService(
+            snapshotBuilder,
+            analyzer,
+            new FileSystemSyncManifestStore(signedStore, snapshotBuilder),
+            stateStore,
+            new WorkspaceExchangeValidator(new Ed25519SignatureService()),
+            auditLog);
+        return new ProjectWorkspaceCoordinatorService(
+            identityService,
+            workspaceStore,
+            stateStore,
+            analyzer,
+            syncService,
+            new RecentProjectsStore(Path.Combine(_rootDirectory, "recent.json")),
+            auditLog,
+            new SharedFolderSafetyInspector());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private sealed class TestPrivateKeyProtector : IPrivateKeyProtector
+    {
+        public string ProviderName => "Test";
+
+        public byte[] Protect(ReadOnlySpan<byte> privateKeyBytes) =>
+            privateKeyBytes.ToArray();
+
+        public byte[] Unprotect(ReadOnlySpan<byte> protectedBytes) =>
+            protectedBytes.ToArray();
+    }
+}

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -345,6 +345,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Equal(0, refreshed.Sync.PendingOutgoingChanges);
         Assert.Equal(0, refreshed.Sync.PendingIncomingChanges);
         Assert.Equal(1, refreshed.Sync.LastPushedManifestVersion);
+        Assert.Equal(1, refreshed.Sync.SharedManifestVersion);
+        Assert.True(refreshed.Sync.SharedManifestSignatureValid);
         Assert.NotNull(refreshed.Sync.LastSuccessfulTrustValidationUtc);
     }
 
@@ -391,6 +393,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Equal(0, refreshed.Sync.PendingIncomingChanges);
         Assert.Equal(0, refreshed.Sync.PendingOutgoingChanges);
         Assert.Equal(2, refreshed.Sync.LastPulledManifestVersion);
+        Assert.Equal(2, refreshed.Sync.SharedManifestVersion);
+        Assert.True(refreshed.Sync.SharedManifestSignatureValid);
         Assert.NotNull(refreshed.Sync.LastSuccessfulTrustValidationUtc);
     }
 

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -344,6 +344,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         var refreshed = service.OpenProject(localRoot, sharedRoot);
         Assert.Equal(0, refreshed.Sync.PendingOutgoingChanges);
         Assert.Equal(0, refreshed.Sync.PendingIncomingChanges);
+        Assert.Equal(1, refreshed.Sync.LastPushedManifestVersion);
+        Assert.NotNull(refreshed.Sync.LastSuccessfulTrustValidationUtc);
     }
 
     [Fact]
@@ -388,6 +390,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Contains(refreshed.LoadResult.Workspace.Versions, static version => version.Version.Name == "1.1.0");
         Assert.Equal(0, refreshed.Sync.PendingIncomingChanges);
         Assert.Equal(0, refreshed.Sync.PendingOutgoingChanges);
+        Assert.Equal(2, refreshed.Sync.LastPulledManifestVersion);
+        Assert.NotNull(refreshed.Sync.LastSuccessfulTrustValidationUtc);
     }
 
     [Fact]
@@ -749,10 +753,55 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
             ConflictResolutionChoice.KeepLocal);
 
         Assert.Contains("Kept local", resolution.Summary, StringComparison.Ordinal);
+        Assert.True(Directory.Exists(resolution.RecoveryDirectory));
+        Assert.True(File.Exists(Path.Combine(resolution.RecoveryDirectory, "resolution.json")));
+        Assert.True(File.Exists(Path.Combine(
+            resolution.RecoveryDirectory,
+            "local",
+            conflictPath.Replace('/', Path.DirectorySeparatorChar))));
+        Assert.True(File.Exists(Path.Combine(
+            resolution.RecoveryDirectory,
+            "shared",
+            conflictPath.Replace('/', Path.DirectorySeparatorChar))));
+        Assert.Contains(
+            "\"status\": \"Applied\"",
+            File.ReadAllText(Path.Combine(resolution.RecoveryDirectory, "resolution.json")),
+            StringComparison.Ordinal);
 
         var refreshed = service.OpenProject(localRoot, sharedRoot);
         Assert.Empty(refreshed.ConflictPaths);
         Assert.Equal(TrustState.Trusted, refreshed.LoadResult.TrustReport.State);
+    }
+
+    [Fact]
+    public void ResolveConflict_RejectsAConflictPathOutsideTheWorkspace()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "conflict-path-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "conflict-path-shared", "BP");
+        var service = CreateService();
+        service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+
+        var stateStore = new Blueprints.Collaboration.Services.FileSystemSyncStateStore();
+        var state = stateStore.Load(localRoot);
+        stateStore.Save(
+            localRoot,
+            state with { UnresolvedConflicts = ["../outside.json"] });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => service.ResolveConflict(
+                localRoot,
+                sharedRoot,
+                "../outside.json",
+                ConflictResolutionChoice.KeepLocal));
+
+        Assert.Contains("escapes", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(_rootDirectory, "conflict-path-local", "outside.json")));
     }
 
     [Fact]

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -21,6 +21,20 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Guid.NewGuid().ToString("N"));
 
     [Fact]
+    public void CreateInitialIdentity_RequiresAnExplicitNameAndCreatesItOnce()
+    {
+        var service = CreateService();
+
+        Assert.False(service.HasLocalIdentity);
+        var identity = service.CreateInitialIdentity("Flavio");
+
+        Assert.True(service.HasLocalIdentity);
+        Assert.Equal("Flavio", identity.DisplayName);
+        Assert.Throws<InvalidOperationException>(
+            () => service.CreateInitialIdentity("Replacement"));
+    }
+
+    [Fact]
     public void CreateProject_CreatesConfiguredWorkspaceAndRecordsRecentProject()
     {
         var localRoot = Path.Combine(_rootDirectory, "local", "AP");
@@ -456,6 +470,81 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
     }
 
     [Fact]
+    public void ArchiveDrafts_RemovesThemFromThePlanAndKeepsRecoveryCopies()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "archive-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "archive-shared", "BP");
+        var service = CreateService();
+        service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(
+                null,
+                "0.3.0",
+                ReleaseStatus.InProgress,
+                "Archive coverage"));
+        var version = Assert.Single(versionSession.LoadResult.Workspace.Versions);
+        var itemSession = service.SaveItem(
+            localRoot,
+            sharedRoot,
+            new ItemEditRequest(
+                version.Version.VersionId,
+                null,
+                "feature",
+                "added",
+                "Recoverable archive",
+                null,
+                false));
+        var item = Assert.Single(itemSession.LoadResult.Workspace.Versions.Single().Items);
+
+        var itemArchive = service.ArchiveItem(
+            localRoot,
+            sharedRoot,
+            version.Version.VersionId,
+            item.ItemId);
+
+        Assert.Empty(itemArchive.Session.LoadResult.Workspace.Versions.Single().Items);
+        Assert.True(File.Exists(Path.Combine(itemArchive.ArchiveDirectory, "archive.json")));
+        Assert.True(Directory.EnumerateFiles(
+            itemArchive.ArchiveDirectory,
+            $"{item.ItemId:N}.json",
+            SearchOption.AllDirectories).Any());
+        Assert.False(File.Exists(Path.Combine(
+            localRoot,
+            "versions",
+            version.Version.VersionId.ToString("N"),
+            "items",
+            $"{item.ItemId:N}.json")));
+
+        var versionArchive = service.ArchiveVersion(
+            localRoot,
+            sharedRoot,
+            version.Version.VersionId);
+
+        Assert.Empty(versionArchive.Session.LoadResult.Workspace.Versions);
+        Assert.True(File.Exists(Path.Combine(versionArchive.ArchiveDirectory, "archive.json")));
+        Assert.False(Directory.Exists(Path.Combine(
+            localRoot,
+            "versions",
+            version.Version.VersionId.ToString("N"))));
+        Assert.Contains(
+            Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json")
+                .Select(File.ReadAllText),
+            text => text.Contains("\"operation\":\"item.archive\"", StringComparison.Ordinal));
+        Assert.Contains(
+            Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json")
+                .Select(File.ReadAllText),
+            text => text.Contains("\"operation\":\"version.archive\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExportVersionChangelog_WritesMarkdownAndExcludesIncompleteItemsByDefault()
     {
         var localRoot = Path.Combine(_rootDirectory, "changelog-local", "BP");
@@ -503,6 +592,18 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
                 "Deferred bugfix",
                 "Still in progress.",
                 false));
+
+        var preview = service.PreviewVersionChangelog(
+            localRoot,
+            sharedRoot,
+            versionId,
+            rulesOverride: new ChangelogRules(true, false, true, true));
+
+        Assert.False(Directory.Exists(Path.Combine(localRoot, "exports")));
+        Assert.Contains("Deferred bugfix", preview, StringComparison.Ordinal);
+        Assert.Contains("Still in progress.", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("Generated:", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("`BP-", preview, StringComparison.Ordinal);
 
         var export = service.ExportVersionChangelog(localRoot, sharedRoot, versionId);
 

--- a/Blueprints.Tests/TwoWorkspaceCollaborationTests.cs
+++ b/Blueprints.Tests/TwoWorkspaceCollaborationTests.cs
@@ -1,0 +1,155 @@
+using Blueprints.Collaboration.Services;
+using Blueprints.Security.Models;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Models;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class TwoWorkspaceCollaborationTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "TwoWorkspaceCollaboration",
+        Guid.NewGuid().ToString("N"));
+    private readonly SignatureKeyMaterial _signingKey;
+    private readonly SignaturePublicKey _publicKey;
+    private readonly FileSystemProjectWorkspaceStore _workspaceStore;
+    private readonly FileSystemAuditLogService _auditLog;
+    private readonly FileSystemWorkspaceSyncService _syncService;
+
+    public TwoWorkspaceCollaborationTests()
+    {
+        var keyPair = new Ed25519KeyPairGenerator().Generate("collaboration-admin");
+        _signingKey = new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes);
+        _publicKey = new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        _workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        _auditLog = new FileSystemAuditLogService(signedStore);
+
+        var snapshotBuilder = new WorkspaceExchangeSnapshotBuilder();
+        _syncService = new FileSystemWorkspaceSyncService(
+            snapshotBuilder,
+            new WorkspaceSyncAnalyzer(snapshotBuilder),
+            new FileSystemSyncManifestStore(signedStore, snapshotBuilder),
+            new FileSystemSyncStateStore(),
+            new WorkspaceExchangeValidator(new Ed25519SignatureService()),
+            _auditLog);
+    }
+
+    [Fact]
+    public void TwoWorkspaces_CanRoundTripChangesAndRejectAnOverlappingEdit()
+    {
+        var aliceRoot = Path.Combine(_rootDirectory, "alice");
+        var bobRoot = Path.Combine(_rootDirectory, "bob");
+        var sharedRoot = Path.Combine(_rootDirectory, "shared");
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        var member = Assert.Single(workspace.Members.Members);
+
+        _workspaceStore.Save(aliceRoot, workspace, _signingKey);
+        _auditLog.Append(
+            aliceRoot,
+            workspace.Project.ProjectId,
+            "project.create",
+            "Created collaboration test project.",
+            member.UserId,
+            member.DisplayName,
+            workspace.Members.MembershipRevision,
+            _signingKey);
+
+        var alicePush = _syncService.Push(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            _signingKey,
+            _publicKey);
+        var bobPull = _syncService.Pull(new WorkspacePaths(bobRoot, sharedRoot), _publicKey);
+
+        Assert.True(alicePush.Success);
+        Assert.True(bobPull.Success);
+        Assert.Equal("1.0.0", LoadWorkspace(bobRoot).Versions.Single().Version.Name);
+
+        SaveVersionNotes(bobRoot, "Prepared by Bob", appendAuditEntry: true);
+        var bobPush = _syncService.Push(
+            new WorkspacePaths(bobRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            _signingKey,
+            _publicKey);
+        var alicePull = _syncService.Pull(new WorkspacePaths(aliceRoot, sharedRoot), _publicKey);
+
+        Assert.True(bobPush.Success);
+        Assert.True(alicePull.Success);
+        Assert.Equal("Prepared by Bob", LoadWorkspace(aliceRoot).Versions.Single().Version.Notes);
+
+        SaveVersionNotes(aliceRoot, "Alice local edit", appendAuditEntry: false);
+        SaveVersionNotes(bobRoot, "Bob shared edit", appendAuditEntry: false);
+        var secondBobPush = _syncService.Push(
+            new WorkspacePaths(bobRoot, sharedRoot),
+            workspace.Project.ProjectId,
+            _signingKey,
+            _publicKey);
+        var blockedAlicePull = _syncService.Pull(
+            new WorkspacePaths(aliceRoot, sharedRoot),
+            _publicKey);
+
+        Assert.True(secondBobPush.Success);
+        Assert.False(blockedAlicePull.Success);
+        Assert.Contains(
+            blockedAlicePull.Conflicts,
+            static path => path.EndsWith("/version.json", StringComparison.Ordinal));
+        Assert.Equal("Alice local edit", LoadWorkspace(aliceRoot).Versions.Single().Version.Notes);
+    }
+
+    private ProjectWorkspaceSnapshot LoadWorkspace(string workspaceRoot)
+    {
+        var result = _workspaceStore.Load(workspaceRoot, _publicKey);
+        Assert.Equal(Blueprints.Core.Enums.TrustState.Trusted, result.TrustReport.State);
+        return result.Workspace;
+    }
+
+    private void SaveVersionNotes(
+        string workspaceRoot,
+        string notes,
+        bool appendAuditEntry)
+    {
+        var workspace = LoadWorkspace(workspaceRoot);
+        var version = Assert.Single(workspace.Versions);
+        var updated = workspace with
+        {
+            Versions =
+            [
+                version with
+                {
+                    Version = version.Version with { Notes = notes },
+                },
+            ],
+        };
+        _workspaceStore.Save(workspaceRoot, updated, _signingKey);
+
+        if (!appendAuditEntry)
+        {
+            return;
+        }
+
+        var member = Assert.Single(workspace.Members.Members);
+        _auditLog.Append(
+            workspaceRoot,
+            workspace.Project.ProjectId,
+            "version.save",
+            $"Changed version notes to {notes}.",
+            member.UserId,
+            member.DisplayName,
+            workspace.Members.MembershipRevision,
+            _signingKey);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Signed identity-request and project-invitation files with proof-of-key-possession validation.
 - Member-key-aware workspace, manifest, incoming-document, and audit validation for distinct local identities.
 - A staged join flow that validates invitation targets, trust anchors, membership, signatures, manifest continuity, and audit history before creating the final local workspace.
+- Document-aware conflict comparisons for project configuration, membership, versions, items, and audit entries, with bounded raw evidence retained for diagnosis.
+- Explicit member-key rotation, compromise, and lost-key operating rules.
+- Backup, shared-exchange restoration, conflict reversal, identity recovery, and recovery-drill procedures.
 
 ### Changed
 
@@ -20,6 +23,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Conflict resolution reports the recovery-copy location and writes its status metadata atomically.
 - The exchange view now shows the last pulled and pushed manifest versions and the last successful trust-validation time persisted for the local workspace.
 - Team setup now uses native invitation-file import/export instead of identity-bundle copy and paste.
+- The exchange workspace now surfaces current shared manifest evidence, local push/pull versions, audit-chain status, and state-specific recovery guidance.
 
 ### Fixed
 
@@ -28,6 +32,11 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Conflict recovery rejects paths that escape the expected workspace root.
 - Project invitations targeting another local identity are rejected before a workspace is created.
 - Tampered identity invitation fields are rejected when their proof no longer verifies.
+- Signed manifest rollback and same-version unknown-batch replay are rejected.
+- Item deletions propagate with local recovery copies and deletion markers while required project-document deletion remains blocked.
+- Workspace exchange paths are contained beneath their expected roots.
+- Pull stages and revalidates a complete inbox before local mutation, records rollback pairs, and restores them if application or sync-state persistence fails.
+- Viewer and inactive-member keys are excluded from current workspace and incoming-change authority while remaining available for historical audit verification.
 
 ## 0.2.0-alpha.2 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 - Session-scoped undo and redo for node drags and auto-arrangement, with toolbar controls and `Ctrl+Z`, `Ctrl+Shift+Z`, and `Ctrl+Y` shortcuts.
 - Every applied undo or redo is saved as a new signed, audited canvas-layout revision so history never bypasses workspace integrity.
+- A two-workspace collaboration harness covering push, pull, sequential edits, overlapping edits, and preservation of the blocked local copy.
+- Automatic machine-local conflict recovery snapshots containing both available document/signature pairs and resolution metadata before a whole-document choice is applied.
 
 ### Changed
 
-- Post-release development builds now identify themselves as `0.2.0-alpha.3-dev`.
+- Alpha 3 development builds now identify themselves as `0.3.0-alpha.3-dev`.
+- Conflict resolution reports the recovery-copy location and writes its status metadata atomically.
+- The exchange view now shows the last pulled and pushed manifest versions and the last successful trust-validation time persisted for the local workspace.
 
 ### Fixed
 
 - Canvas nodes can no longer be dragged when workspace trust or sync-conflict state forbids mutation.
+- Clean test builds now reference the command toolkit explicitly instead of relying on a transitive compile asset.
+- Conflict recovery rejects paths that escape the expected workspace root.
 
 ## 0.2.0-alpha.2 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Document-aware conflict comparisons for project configuration, membership, versions, items, and audit entries, with bounded raw evidence retained for diagnosis.
 - Explicit member-key rotation, compromise, and lost-key operating rules.
 - Backup, shared-exchange restoration, conflict reversal, identity recovery, and recovery-drill procedures.
+- Explicit first-run identity creation and pre-project signed identity-invitation export.
+- Two-step recoverable archive flows for draft versions and items, including layout cleanup and signed audit records.
+- Changelog preview without file output plus incomplete-item, item-key, description, and compact export controls.
+- End-to-end view-model command coverage for identity setup, project creation, version editing, freezing, releasing, previewing, and exporting.
+- Category-grouped release items and actionable empty states for projects without versions or connected accomplishments.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,24 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Every applied undo or redo is saved as a new signed, audited canvas-layout revision so history never bypasses workspace integrity.
 - A two-workspace collaboration harness covering push, pull, sequential edits, overlapping edits, and preservation of the blocked local copy.
 - Automatic machine-local conflict recovery snapshots containing both available document/signature pairs and resolution metadata before a whole-document choice is applied.
+- Signed identity-request and project-invitation files with proof-of-key-possession validation.
+- Member-key-aware workspace, manifest, incoming-document, and audit validation for distinct local identities.
+- A staged join flow that validates invitation targets, trust anchors, membership, signatures, manifest continuity, and audit history before creating the final local workspace.
 
 ### Changed
 
 - Alpha 3 development builds now identify themselves as `0.3.0-alpha.3-dev`.
 - Conflict resolution reports the recovery-copy location and writes its status metadata atomically.
 - The exchange view now shows the last pulled and pushed manifest versions and the last successful trust-validation time persisted for the local workspace.
+- Team setup now uses native invitation-file import/export instead of identity-bundle copy and paste.
 
 ### Fixed
 
 - Canvas nodes can no longer be dragged when workspace trust or sync-conflict state forbids mutation.
 - Clean test builds now reference the command toolkit explicitly instead of relying on a transitive compile asset.
 - Conflict recovery rejects paths that escape the expected workspace root.
+- Project invitations targeting another local identity are rejected before a workspace is created.
+- Tampered identity invitation fields are rejected when their proof no longer verifies.
 
 ## 0.2.0-alpha.2 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+No changes yet.
+
+## 0.3.0 — 2026-07-30
+
+Understandable collaboration milestone. This release lets distinct local identities join a signed project, exchange changes through an untrusted shared directory, understand conflicts, and recover from blocked or mistaken operations.
+
 ### Added
 
 - Session-scoped undo and redo for node drags and auto-arrangement, with toolbar controls and `Ctrl+Z`, `Ctrl+Shift+Z`, and `Ctrl+Y` shortcuts.
@@ -42,6 +48,30 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Workspace exchange paths are contained beneath their expected roots.
 - Pull stages and revalidates a complete inbox before local mutation, records rollback pairs, and restores them if application or sync-state persistence fails.
 - Viewer and inactive-member keys are excluded from current workspace and incoming-change authority while remaining available for historical audit verification.
+
+### Security
+
+- Multi-member signatures resolve by key ID against machine-local project trust anchors established by project creation or a targeted signed invitation.
+- Identity invitations prove possession of the included private key; project invitations bind the target identity, inviter administrator, project, membership revision, exchange location hint, and trusted member keys.
+- Shared manifests reject invalid signatures, rollback, unknown same-version batches, content/hash discontinuity, missing required documents, and malformed document/signature pairs.
+- Pull validates shared content, stages it locally, revalidates the staged bytes, and retains rollback copies before changing trusted local state.
+- Deactivated and Viewer identities cannot mutate or publish current project content.
+
+### Workspace compatibility
+
+- Signed project schema remains version 1.
+- `ProjectMember.keyId` is an optional schema-1 field. Existing workspaces derive the legacy key ID from the member user ID.
+- Project trust anchors, archives, conflict recovery, canvas viewport state, and sync staging remain machine-local and are excluded from signed exchange snapshots.
+- Existing single-identity projects remain readable and gain a local trust-anchor file after successful validation.
+
+### Known limitations
+
+- This release contains no installers or application binaries.
+- Conflict resolution compares known fields but still applies a whole-document choice rather than a field merge.
+- Same-user automated key rotation, hardware-backed keys, and revocation timestamps are not implemented.
+- Shared-folder confidentiality and availability remain responsibilities of the underlying storage.
+- Advanced canvas multi-selection, alignment tools, minimap navigation, and user-defined relationship types are deferred.
+- GitHub Project discovery does not include standalone draft items, and provider integrations remain read-only.
 
 ## 0.2.0-alpha.2 — 2026-07-30
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>alpha.3-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.3-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Release notes often live in scattered issues, commit messages, and private docum
 | Persistent signed canvas layout | Working |
 | Signed persistence and trust validation | Working |
 | Markdown changelog export | Working |
-| Shared-folder push/pull | Working foundation |
-| Conflict and audit diagnostics | Functional, needs UX polish |
+| Shared-folder push/pull | Working with distinct signed identities and staged validation |
+| Conflict and audit diagnostics | Document-aware, recoverable, and actionable |
 | Local Git awareness | Read-only integration available |
 | Changelog, roadmap, and GitHub issue discovery | Working, explicit approval required |
 | Full GitHub, GitLab, and VaultSync adapters | Planned |

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -47,13 +47,13 @@ Exit criteria:
 Goal: two people can exchange signed changes through a shared directory and understand every blocked action.
 
 - [x] Add a two-workspace end-to-end collaboration test harness.
-- [ ] Replace raw JSON conflict previews with document-aware field comparisons.
+- [x] Replace raw-first conflict previews with bounded document-aware field comparisons and retained raw evidence.
 - [x] Add guided whole-document conflict resolution and machine-local recovery copies.
-- [ ] Show manifest version, last push/pull, audit status, and actionable recovery steps.
+- [x] Show shared/last push/last pull manifest evidence, audit status, and actionable recovery steps.
 - [x] Replace identity-bundle copy/paste with signed identity and project invitation files.
-- [ ] Define behavior for member key rotation and lost keys.
-- [ ] Test network-share interruption, partial copies, deleted files, and stale manifests.
-- [ ] Document backup and disaster-recovery procedures.
+- [x] Define behavior for member key rotation, compromise, and lost keys.
+- [x] Test interrupted/partial shared copies, deleted files, required-file deletion, and stale or replayed manifests.
+- [x] Document backup and disaster-recovery procedures.
 
 Exit criteria:
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -28,11 +28,11 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
 - [x] Add native folder pickers instead of requiring raw paths.
-- [ ] Add first-run identity setup instead of silently creating a default identity.
-- [ ] Add delete/archive flows for draft versions and items.
-- [ ] Group items by changelog category and improve empty states.
-- [ ] Preview changelogs before writing a file; expose current changelog options.
-- [ ] Add view-model workflow tests for create, edit, freeze, release, and export.
+- [x] Add explicit first-run identity setup and pre-project identity-invitation export.
+- [x] Add two-step recoverable archive flows for draft versions and items.
+- [x] Group release items by changelog category and improve version/item empty states.
+- [x] Preview changelogs before writing a file and expose incomplete, key, description, and compact options.
+- [x] Add view-model workflow tests for identity setup, create, edit, freeze, release, preview, and export.
 - [x] Establish lightweight milestone tags and accomplishment records without binary packaging.
 
 Exit criteria:

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -50,7 +50,7 @@ Goal: two people can exchange signed changes through a shared directory and unde
 - [ ] Replace raw JSON conflict previews with document-aware field comparisons.
 - [x] Add guided whole-document conflict resolution and machine-local recovery copies.
 - [ ] Show manifest version, last push/pull, audit status, and actionable recovery steps.
-- [ ] Replace identity-bundle copy/paste with invitation files or QR/text import.
+- [x] Replace identity-bundle copy/paste with signed identity and project invitation files.
 - [ ] Define behavior for member key rotation and lost keys.
 - [ ] Test network-share interruption, partial copies, deleted files, and stale manifests.
 - [ ] Document backup and disaster-recovery procedures.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -13,7 +13,7 @@ Blueprints should become the smallest trustworthy path from “we plan to ship t
 3. safe and explicit when a small team exchanges work;
 4. extensible toward GitHub, GitLab, and VaultSync without making a provider the source of truth.
 
-## Now — v0.2: coherent solo workflow
+## Completed — v0.2: coherent solo workflow
 
 Goal: a new contributor can build the app, and a developer can plan and export a release without implementation knowledge.
 
@@ -24,8 +24,6 @@ Goal: a new contributor can build the app, and a developer can plan and export a
 - [x] Persist, sign, audit, sync, validate, and restore shared node positions while keeping viewport preferences machine-local.
 - [x] Add approval-first Source Lens discovery for changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
 - [x] Replace icon-only navigation with a clear workflow rail and adaptive next-action guidance.
-- [ ] Expand canvas editing beyond the completed session undo/redo foundation with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
-- [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Keep release, team, sync, trust, and integration operations in focused secondary tools.
 - [x] Add native folder pickers instead of requiring raw paths.
 - [x] Add explicit first-run identity setup and pre-project identity-invitation export.
@@ -42,7 +40,7 @@ Exit criteria:
 - all destructive or immutable actions explain their consequences;
 - the v0.2 milestone is recorded by a tag, changelog section, release-history entry, and lightweight GitHub prerelease.
 
-## Next — v0.3: understandable collaboration
+## Completed — v0.3: understandable collaboration
 
 Goal: two people can exchange signed changes through a shared directory and understand every blocked action.
 
@@ -68,6 +66,8 @@ Goal: connect release intent to source history without weakening local ownership
 
 - [x] Read local Git root, branch, remote, dirty state, tag, and recent commits.
 - [x] Match item keys in commit subjects for changelog context.
+- [ ] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
+- [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [ ] Link a Blueprints project to one or more repositories.
 - [ ] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [ ] Define provider-neutral issue, pull-request, and release references.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -46,9 +46,9 @@ Exit criteria:
 
 Goal: two people can exchange signed changes through a shared directory and understand every blocked action.
 
-- [ ] Add a two-workspace end-to-end collaboration test harness.
+- [x] Add a two-workspace end-to-end collaboration test harness.
 - [ ] Replace raw JSON conflict previews with document-aware field comparisons.
-- [ ] Add guided conflict resolution and safe recovery copies.
+- [x] Add guided whole-document conflict resolution and machine-local recovery copies.
 - [ ] Show manifest version, last push/pull, audit status, and actionable recovery steps.
 - [ ] Replace identity-bundle copy/paste with invitation files or QR/text import.
 - [ ] Define behavior for member key rotation and lost keys.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Use this directory as the canonical technical and user documentation.
 | Understanding the code | [Architecture](architecture.md) |
 | Inspecting project files | [Workspace format](workspace-format.md) |
 | Reviewing trust boundaries | [Security model](security-model.md) |
+| Rotating or recovering member keys | [Member key lifecycle](key-lifecycle.md) |
+| Backing up or restoring a project | [Backup and disaster recovery](backup-recovery.md) |
 | Activating SonarQube Cloud | [SonarQube Cloud](sonarqube.md) |
 | Reviewing milestone accomplishments | [Release history](releases.md) |
 | Publishing a build | [Release process](releasing.md) |

--- a/docs/backup-recovery.md
+++ b/docs/backup-recovery.md
@@ -1,0 +1,74 @@
+# Backup and disaster recovery
+
+Blueprints separates editable project state, signing identities, and the shared exchange layer. A usable recovery plan must account for each one explicitly.
+
+## What to back up
+
+Back up:
+
+1. every chosen local project workspace;
+2. the complete Blueprints local application-data directory, especially `Identities/` and `Security/`;
+3. the shared project directory if it is not already protected by versioned storage;
+4. signed identity and project invitation files while onboarding is in progress.
+
+The application-data root is the operating system's local application-data directory plus `Blueprints`. The local project path and shared exchange path are shown in the application.
+
+Private signing keys exist only in the identity directory. On macOS and Linux, restoring an encrypted private key without the matching `Security/local-private-key-protector.key` does not restore the identity.
+
+## Create a consistent backup
+
+1. Finish or cancel the current edit.
+2. Refresh the exchange view and record its manifest and audit status.
+3. Close Blueprints so no workspace save is in progress.
+4. Copy the local workspace and the complete Blueprints application-data directory to versioned backup storage.
+5. Back up the shared exchange directory separately.
+6. Verify that the backup contains document/signature pairs and protected identity files.
+7. Record the backup time and the last pulled/pushed/shared manifest versions.
+
+Do not place private identity data inside the project workspace or shared exchange folder.
+
+## Restore a local workspace
+
+1. Keep the damaged copy; do not overwrite it in place.
+2. Restore the Blueprints application-data directory, including identities and key-protection material.
+3. Restore the project workspace to a new local path.
+4. Start Blueprints and open the restored local path with the intended shared exchange path.
+5. Confirm the identity, project ID, trust state, audit chain, membership revision, and manifest evidence before editing.
+6. If the shared location is newer, pull only after its manifest and audit checks are green.
+
+If the protected identity cannot be restored, follow [member key lifecycle](key-lifecycle.md). Blueprints has no last-administrator bypass.
+
+## Restore the shared exchange
+
+1. Stop all team members from pushing or pulling.
+2. Preserve the damaged shared directory.
+3. Restore one complete known-good shared snapshot, including `project/`, `versions/`, `log/`, `manifest/`, and signatures.
+4. Have an administrator compare its manifest version with each member's last locally recorded version.
+5. Reject a restored snapshot that rolls the manifest backward unless every member deliberately resets from the same reviewed backup.
+6. Reopen and refresh from one trusted local workspace before allowing the team to resume.
+
+The `packs/` directories help diagnose individual publications, but they are not guaranteed to be complete project backups.
+
+## Recover from a conflict choice
+
+Before applying a conflict choice, Blueprints stores both available sides under:
+
+```text
+.blueprints/recovery/conflicts/<recovery-id>/
+```
+
+`resolution.json` identifies the path, selected side, presence of each document/signature, and outcome. To reverse a choice, close Blueprints, back up the current workspace, restore the desired JSON and `.sig` pair to its recorded relative path, then reopen and validate. If the restored side differs from the shared baseline, expect a new explicit conflict.
+
+Incoming deletions retain the previous local pair in the batch inbox recovery directory and add a `.deleted` marker.
+
+## Recovery drill
+
+Before relying on a backup policy, perform a drill on a disposable copy:
+
+- restore the identity and protection material;
+- open a restored workspace;
+- validate audit and trust status;
+- export a changelog;
+- join a second disposable workspace through an invitation;
+- push and pull one signed change;
+- confirm a tampered copy is rejected.

--- a/docs/key-lifecycle.md
+++ b/docs/key-lifecycle.md
@@ -1,0 +1,31 @@
+# Member key lifecycle
+
+Blueprints 0.3 treats a member identity as the pair of a user ID and one Ed25519 key ID. Membership revisions are signed project truth. Accepted public keys are also retained as machine-local trust anchors so historical audit entries remain verifiable.
+
+## Planned rotation
+
+Before replacing a working key:
+
+1. ensure the project has another active administrator;
+2. create and back up the replacement local identity;
+3. export its signed identity invitation;
+4. have another administrator add the replacement identity with the required role;
+5. exchange and validate at least one change from the replacement identity;
+6. deactivate the old member record;
+7. retain the old public trust anchor for historical verification and destroy old private-key copies only after recovery backups are confirmed.
+
+Blueprints does not silently rewrite historical signatures. Deactivation prevents future membership-authorized use but does not make old signatures invalid retroactively.
+
+## Lost or suspected-compromised keys
+
+- Another active administrator should deactivate the affected member and invite a new identity.
+- A replacement identity receives a new user ID and key ID. Blueprints does not claim continuity of private-key possession.
+- If the only administrator key is lost, there is no in-app bypass. Restore the protected identity from backup or restore a project copy that still has an available active administrator.
+- If a key may be compromised, stop exchanging changes until an administrator has reviewed the audit log, deactivated the member, and published a new membership revision.
+- Shared-folder access control is not revocation. A deactivated user who can still write to the folder may cause denial of service, but their key does not regain membership authority.
+
+## Recovery records
+
+Keep identity backups separate from project backups. Project workspaces contain public keys, not private signing keys. Conflict recovery copies preserve documents, not identities.
+
+Automated same-user key rotation, platform-keystore migration, revocation timestamps, and hardware-backed keys remain future security work.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,7 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.3.0` | 2026-07-30 | Understandable collaboration | Distinct signing identities, signed invitation onboarding, member-key-aware trust, staged and recoverable sync, semantic conflict comparison, manifest/audit evidence, recoverable archives, explicit identity setup, and disaster-recovery guidance |
 | `v0.2.0-alpha.2` | 2026-07-30 | Interactive workspace | Diagram-first canvas, signed shared layouts, machine-local viewport state, approval-first Source Lens, adaptive workflow navigation, .NET 10, Avalonia 12, and expanded security/user documentation |
 | [`v0.1.0-alpha.1`](https://github.com/ATAC-Helicopter/Blueprints/releases/tag/v0.1.0-alpha.1) | 2026-02-28 | Foundation | Domain contracts, canonical signed persistence, protected identities, shared-folder sync foundation, audit chaining, and the initial Avalonia application scaffold |
 
@@ -14,7 +15,6 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 | Version | Milestone outcome |
 | --- | --- |
 | `v0.2.0` | Complete the coherent solo workflow with identity onboarding, editing history, archive/delete flows, and release polish |
-| `v0.3.0` | Collaboration that two users can understand and recover |
 | `v0.4.0` | Provider-neutral source-control awareness |
 | `v0.5.0` | Explicit VaultSync transport and backup-health integration |
 | `v1.0.0` | A dependable, supported small-team release planner |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -39,6 +39,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Invalid incoming signatures block pull.
 - Invalid or missing signed local content produces untrusted or corrupt read-only state.
 - Conflicting concurrent changes block further mutation.
+- Whole-document conflict choices preserve both available sides in machine-local recovery storage before mutation.
 - Only an active Admin may change membership.
 - At least one active Admin must remain.
 - Released versions reject further version and item edits.
@@ -60,7 +61,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Shared-folder availability, confidentiality, and rollback resistance depend on the underlying storage.
 - Current workspace saves are not a single atomic transaction across all changed files.
 - Canvas layout is a whole signed document; concurrent arrangements conflict as a unit and are not field-merged.
-- Conflict resolution currently exposes low-level previews and supports whole-document choices.
+- Conflict resolution provides semantic summaries for known document types but still operates on whole documents rather than merging individual fields.
+- Conflict recovery copies are local, unsigned operational records; protect and back them up according to the sensitivity of project content.
 - Blueprints does not encrypt project content.
 - Duplicate detection is an exact normalized-title warning, not semantic identity proof.
 - GitHub Project discovery currently sees project-linked repository issues, not standalone Project draft items.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -19,6 +19,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 | Local workspace | Editable only while required content validates |
 | Shared sync root | Untrusted exchange input until manifest and signatures validate |
 | Local identity directory | Sensitive local state protected by OS permissions and key protection |
+| Project invitation | Out-of-band signed trust bootstrap targeted to one local identity |
+| Local project trust anchors | Machine-local accepted member keys; never sourced from unverified shared data |
 | Git/provider integration | Informational; not authoritative project truth |
 | Source Lens proposals | Untrusted transient suggestions; no persistence before explicit approval |
 | UI input | Validated by application workflows before persistence |
@@ -36,6 +38,10 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 ## Security invariants
 
 - Private keys are never written into a workspace or shared root.
+- Identity invitations prove possession of their included private key.
+- Project invitations bind the target identity, inviter administrator, project, membership revision, and initial member-key set.
+- A join is staged and fully validated before the final local workspace is created.
+- Documents, manifests, and audit entries are verified against their signer key ID in the locally trusted project-key set.
 - Invalid incoming signatures block pull.
 - Invalid or missing signed local content produces untrusted or corrupt read-only state.
 - Conflicting concurrent changes block further mutation.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -42,7 +42,9 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Project invitations bind the target identity, inviter administrator, project, membership revision, and initial member-key set.
 - A join is staged and fully validated before the final local workspace is created.
 - Documents, manifests, and audit entries are verified against their signer key ID in the locally trusted project-key set.
+- Current workspace and incoming project content require an active Editor or Admin key; inactive and Viewer keys remain usable only for historical audit verification.
 - Invalid incoming signatures block pull.
+- Pull copies incoming data to a local inbox, rechecks signatures and manifest hashes there, snapshots rollback pairs, and only then mutates the local workspace.
 - Invalid or missing signed local content produces untrusted or corrupt read-only state.
 - Conflicting concurrent changes block further mutation.
 - Whole-document conflict choices preserve both available sides in machine-local recovery storage before mutation.
@@ -84,3 +86,5 @@ Security-sensitive pull requests should include:
 - any workspace compatibility impact.
 
 Report vulnerabilities using [SECURITY.md](../SECURITY.md).
+
+Operational behavior for planned rotation, compromise, and lost keys is defined in [member key lifecycle](key-lifecycle.md). Automated same-user rotation and revocation remain unimplemented.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -115,4 +115,4 @@ Back up both:
 
 A workspace without the signing identity may remain readable but cannot be safely continued as the same member. Formal key recovery is not implemented yet.
 
-See [workspace format](workspace-format.md) and [security model](security-model.md) for details.
+See [workspace format](workspace-format.md), [security model](security-model.md), [member key lifecycle](key-lifecycle.md), and [backup and disaster recovery](backup-recovery.md) for details.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -19,7 +19,7 @@ Blueprints is a desktop application for planning releases in signed local files.
 4. Use **Browse** to choose different local and shared roots. Neither may contain the other.
 5. Select **Create signed project**.
 
-Blueprints creates the first local identity automatically in the current preview. Identity onboarding is planned.
+Blueprints creates the first local identity automatically in the current preview. Explicit first-run identity naming is still planned.
 
 ## Plan a release
 
@@ -74,6 +74,17 @@ GitHub discovery requires the authenticated GitHub CLI. Local changelog and road
 ## Exchange changes
 
 The shared root is an exchange layer, not the editable workspace.
+
+To add a second person:
+
+1. The new person opens **Team** in any local project and exports a signed identity invitation.
+2. An existing project administrator imports that file, reviews the requested display name and role, and adds the member.
+3. The administrator pushes the membership revision.
+4. With the new member selected, the administrator exports a signed project invitation.
+5. The new member chooses **Join a team project** on the setup screen and selects an empty local workspace.
+6. Blueprints stages and validates the shared project before promoting it to the chosen local location.
+
+Project invitations are targeted to one local identity. Treat them as sensitive team coordination records and transfer them through an authenticated channel.
 
 - **Refresh comparison** compares local, shared, and last-synced baselines.
 - **Push** copies valid outgoing signed documents and updates the signed manifest.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -19,7 +19,9 @@ Blueprints is a desktop application for planning releases in signed local files.
 4. Use **Browse** to choose different local and shared roots. Neither may contain the other.
 5. Select **Create signed project**.
 
-Blueprints creates the first local identity automatically in the current preview. Explicit first-run identity naming is still planned.
+Before creating or joining a project, enter the display name teammates should see and select **Create identity**. Blueprints creates protected local Ed25519 key material. Back up the complete Blueprints application-data directory before relying on that identity.
+
+A new teammate can export a signed identity invitation directly from the setup screen before they belong to any project.
 
 ## Plan a release
 
@@ -52,10 +54,15 @@ See [canvas engine](canvas-engine.md) for the exact model and [troubleshooting](
 
 1. Select a version node.
 2. Open the **Versions and releases** tool from the rail.
-3. Select **Export notes**.
-4. Review the changelog preview and saved path.
+3. Choose whether to include incomplete items, item keys, descriptions, or compact output.
+4. Select **Preview notes** to review the exact Markdown without writing a file.
+5. Select **Export notes** and review the saved path.
 
 Incomplete items are excluded by the current default rules. When a local Git repository is linked, recent commit subjects and matching item keys are added as source context.
+
+## Archive draft work
+
+Draft versions and items in Planned or In Progress state can be archived. Select the archive action twice to confirm. The entity leaves the active signed plan, its removal participates in sync, and its signed files remain under `.blueprints/archive/` for recovery. Frozen and released versions are immutable and cannot be archived.
 
 ## Discover work with Source Lens
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,9 +78,12 @@ The shared root is an exchange layer, not the editable workspace.
 - **Refresh comparison** compares local, shared, and last-synced baselines.
 - **Push** copies valid outgoing signed documents and updates the signed manifest.
 - **Pull** validates incoming signatures and manifest continuity before applying changes.
+- The exchange header reports the last locally recorded pulled/pushed manifest versions and successful trust check; these are local evidence, not a guarantee that an offline shared folder has not changed.
 - If both copies changed, Blueprints blocks mutation until you choose **Keep Local** or **Accept Shared**.
 
-The current conflict preview is low-level. Make a backup before resolving important conflicts.
+The conflict view summarizes important fields for known project document types and keeps bounded raw previews available for diagnosis. Before applying **Keep Local** or **Accept Shared**, Blueprints preserves both available document/signature pairs under `.blueprints/recovery/conflicts/` in the local workspace. The completion message includes the exact recovery directory.
+
+Conflict recovery copies reduce the risk of an accidental choice, but they are not a substitute for backing up the complete workspace before important collaboration or membership changes.
 
 ## Trust and read-only mode
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -25,10 +25,18 @@ This document describes the current schema-1 layout. The format is pre-release a
 │   └── <change-id>.sig
 └── .blueprints/
     ├── sync-state.json
-    └── canvas-view.json
+    ├── canvas-view.json
+    └── recovery/
+        └── conflicts/
+            └── <recovery-id>/
+                ├── resolution.json
+                ├── local/       # preserved document/signature pair, when present
+                └── shared/      # preserved document/signature pair, when present
 ```
 
 The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` are local bookkeeping and are not signed project truth or exchange input.
+
+Before applying a whole-document conflict choice, Blueprints creates a conflict recovery directory. Its metadata records the selected path, choice, presence of each source file, and whether the operation was prepared, applied, or failed. Recovery data stays local and is excluded from exchange manifests.
 
 ## Serialization
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -30,6 +30,7 @@ This document describes the current schema-1 layout. The format is pre-release a
 └── .blueprints/
     ├── canvas-view.json
     ├── trusted-project-keys.json
+    ├── archive/                 # recoverable draft version/item archives
     └── recovery/
         └── conflicts/
             └── <recovery-id>/
@@ -43,6 +44,8 @@ The collaboration layer also writes a signed manifest in the shared project root
 `trusted-project-keys.json` is the machine-local trust-anchor set established when a project is created or a signed project invitation is accepted. It lets documents and audit entries signed by different project members validate without placing trust in the shared folder itself. A verified membership revision may extend this set, but unverified shared membership data cannot.
 
 Before applying a whole-document conflict choice, Blueprints creates a conflict recovery directory. Its metadata records the selected path, choice, presence of each source file, and whether the operation was prepared, applied, or failed. Recovery data stays local and is excluded from exchange manifests.
+
+Archiving a draft version or item first copies its signed data beneath `.blueprints/archive/<archive-id>/`, writes `archive.json`, removes it from active signed project state, and records an audit entry. The UI requires the archive action twice for confirmation. Frozen and released content cannot be archived.
 
 ## Serialization
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -26,6 +26,7 @@ This document describes the current schema-1 layout. The format is pre-release a
 └── .blueprints/
     ├── sync-state.json
     ├── canvas-view.json
+    ├── trusted-project-keys.json
     └── recovery/
         └── conflicts/
             └── <recovery-id>/
@@ -35,6 +36,8 @@ This document describes the current schema-1 layout. The format is pre-release a
 ```
 
 The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` are local bookkeeping and are not signed project truth or exchange input.
+
+`trusted-project-keys.json` is the machine-local trust-anchor set established when a project is created or a signed project invitation is accepted. It lets documents and audit entries signed by different project members validate without placing trust in the shared folder itself. A verified membership revision may extend this set, but unverified shared membership data cannot.
 
 Before applying a whole-document conflict choice, Blueprints creates a conflict recovery directory. Its metadata records the selected path, choice, presence of each source file, and whether the operation was prepared, applied, or failed. Recovery data stays local and is excluded from exchange manifests.
 
@@ -125,3 +128,5 @@ There is no general migration engine yet. Optional schema-1 documents, including
 - provider access tokens;
 - machine-specific integration settings;
 - arbitrary repository content.
+
+Signed `*.blueprints-identity.json` and `*.blueprints-project.json` invitation files are deliberate out-of-band handoff artifacts, not workspace documents. Identity invitations prove possession of the included private key. Project invitations bind a target identity, project identity, membership revision, exchange hint, inviter administrator, and trusted member-key set under the inviter's signature.

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -23,8 +23,11 @@ This document describes the current schema-1 layout. The format is pre-release a
 ├── log/
 │   ├── <change-id>.json
 │   └── <change-id>.sig
+├── sync/
+│   ├── state.json
+│   ├── inbox/                   # staged pull batches and rollback pairs
+│   └── staging/                 # prepared push batches
 └── .blueprints/
-    ├── sync-state.json
     ├── canvas-view.json
     ├── trusted-project-keys.json
     └── recovery/
@@ -35,7 +38,7 @@ This document describes the current schema-1 layout. The format is pre-release a
                 └── shared/      # preserved document/signature pair, when present
 ```
 
-The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` are local bookkeeping and are not signed project truth or exchange input.
+The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` and `sync/` are local bookkeeping and are not signed project truth or exchange input.
 
 `trusted-project-keys.json` is the machine-local trust-anchor set established when a project is created or a signed project invitation is accepted. It lets documents and audit entries signed by different project members validate without placing trust in the shared folder itself. A verified membership revision may extend this set, but unverified shared membership data cannot.
 


### PR DESCRIPTION
## Outcome

Completes the Blueprints 0.3.0 understandable-collaboration milestone and closes inherited solo-workflow gaps required for a coherent release.

## What changed

- adds distinct member-key validation with machine-local project trust anchors
- replaces identity bundle copy/paste with signed identity and targeted project invitation files
- stages and validates project joins before creating the final local workspace
- hardens shared-folder sync against partial copies, missing required files, path traversal, rollback, replay, and deleted documents
- stages pulls locally, revalidates manifest hashes/signatures, and preserves rollback pairs
- adds document-aware conflict comparisons and automatic recovery copies
- exposes shared/push/pull manifest evidence, audit status, and recovery guidance
- adds explicit first-run identity setup
- adds recoverable draft version/item archives with two-step UI confirmation
- adds changelog preview-before-write and export options
- groups release items by category and improves empty states
- documents backup, disaster recovery, and member-key lifecycle behavior
- promotes the repository version and release records to 0.3.0

## Security and compatibility

Signed project schema remains version 1. `ProjectMember.keyId` is optional for compatibility with existing schema-1 workspaces. Trust anchors, staging, rollback, conflict recovery, and archive data remain machine-local and excluded from exchange snapshots. Viewer and inactive-member keys remain valid for historical audit verification but cannot authorize current project mutations.

## Verification

- `./scripts/verify.sh` — 90 tests passed, 0 warnings, 0 errors
- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` — no vulnerable packages reported
- resolved application version: `0.3.0`
