### PR TITLE
Advance Blueprints 0.4 source awareness and canvas tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ obj/
 .vs/
 .vscode/
 .idea/
+.sonarlint/
 *.user
 *.suo
 *.userprefs

--- a/Blueprints.App/Models/CanvasAlignmentGuides.cs
+++ b/Blueprints.App/Models/CanvasAlignmentGuides.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasAlignmentGuides(
+    IReadOnlyList<double> Vertical,
+    IReadOnlyList<double> Horizontal)
+{
+    public static CanvasAlignmentGuides Empty { get; } = new([], []);
+}

--- a/Blueprints.App/Models/CanvasNodeBounds.cs
+++ b/Blueprints.App/Models/CanvasNodeBounds.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasNodeBounds(
+    Guid EntityId,
+    double X,
+    double Y,
+    double Width,
+    double Height);

--- a/Blueprints.App/Models/CanvasSelectionBounds.cs
+++ b/Blueprints.App/Models/CanvasSelectionBounds.cs
@@ -1,0 +1,16 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasSelectionBounds(
+    double StartX,
+    double StartY,
+    double EndX,
+    double EndY)
+{
+    public double Left => Math.Min(StartX, EndX);
+
+    public double Top => Math.Min(StartY, EndY);
+
+    public double Right => Math.Max(StartX, EndX);
+
+    public double Bottom => Math.Max(StartY, EndY);
+}

--- a/Blueprints.App/Models/HostedSourceDiscoveryResult.cs
+++ b/Blueprints.App/Models/HostedSourceDiscoveryResult.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.App.Models;
+
+public sealed record HostedSourceDiscoveryResult(
+    IReadOnlyList<SourceDiscoveryCandidate> Candidates,
+    IReadOnlyList<string> Warnings,
+    int IssueCount,
+    int ProjectCount,
+    int PullRequestCount,
+    int ReleaseCount);

--- a/Blueprints.App/Models/IntegrationSettings.cs
+++ b/Blueprints.App/Models/IntegrationSettings.cs
@@ -4,5 +4,16 @@ public sealed record IntegrationSettings(
     string LocalGitRepositoryPath,
     string VaultSyncMetadataRoot)
 {
+    public IReadOnlyList<string> LocalGitRepositoryPaths { get; init; } = [];
+
+    public IReadOnlyList<string> EffectiveLocalGitRepositoryPaths =>
+        LocalGitRepositoryPaths
+            .Append(LocalGitRepositoryPath)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Select(static path => Path.GetFullPath(path.Trim()))
+            .Distinct(StringComparer.Ordinal)
+            .Take(8)
+            .ToArray();
+
     public static IntegrationSettings Empty { get; } = new(string.Empty, string.Empty);
 }

--- a/Blueprints.App/Models/ProviderReference.cs
+++ b/Blueprints.App/Models/ProviderReference.cs
@@ -1,0 +1,14 @@
+namespace Blueprints.App.Models;
+
+public sealed record ProviderReference(
+    SourceProviderKind Provider,
+    ProviderReferenceKind Kind,
+    string Repository,
+    string Identifier,
+    string? WebUrl)
+{
+    public string DisplaySummary =>
+        string.IsNullOrWhiteSpace(Repository)
+            ? $"{Provider} {Kind} {Identifier}"
+            : $"{Provider} {Repository} · {Kind} {Identifier}";
+}

--- a/Blueprints.App/Models/ProviderReferenceKind.cs
+++ b/Blueprints.App/Models/ProviderReferenceKind.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.App.Models;
+
+public enum ProviderReferenceKind
+{
+    PlanningDocument,
+    Commit,
+    Issue,
+    PullRequest,
+    Release,
+    Project,
+}

--- a/Blueprints.App/Models/ReleaseReadinessDiagnostic.cs
+++ b/Blueprints.App/Models/ReleaseReadinessDiagnostic.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record ReleaseReadinessDiagnostic(
+    ReleaseReadinessLevel Level,
+    string Title,
+    string Detail,
+    string Guidance);

--- a/Blueprints.App/Models/ReleaseReadinessLevel.cs
+++ b/Blueprints.App/Models/ReleaseReadinessLevel.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public enum ReleaseReadinessLevel
+{
+    Ready,
+    Attention,
+    Blocking,
+}

--- a/Blueprints.App/Models/SourceArtifactKind.cs
+++ b/Blueprints.App/Models/SourceArtifactKind.cs
@@ -6,4 +6,6 @@ public enum SourceArtifactKind
     Roadmap,
     GitHubIssue,
     GitHubProject,
+    PullRequest,
+    Release,
 }

--- a/Blueprints.App/Models/SourceDiscoveryCandidate.cs
+++ b/Blueprints.App/Models/SourceDiscoveryCandidate.cs
@@ -9,4 +9,5 @@ public sealed record SourceDiscoveryCandidate(
     bool IsDone,
     string SourceReference,
     string SourceContext,
-    double Confidence);
+    double Confidence,
+    ProviderReference? ProviderReference = null);

--- a/Blueprints.App/Models/SourceDiscoveryResult.cs
+++ b/Blueprints.App/Models/SourceDiscoveryResult.cs
@@ -6,9 +6,12 @@ public sealed record SourceDiscoveryResult(
     int ChangelogCount,
     int RoadmapCount,
     int GitHubIssueCount,
-    int GitHubProjectCount)
+    int GitHubProjectCount,
+    int PullRequestCount = 0,
+    int ReleaseCount = 0)
 {
     public string Summary =>
         $"Found {Candidates.Count} proposals · {ChangelogCount} changelog · {RoadmapCount} roadmap · " +
-        $"{GitHubIssueCount} issues · {GitHubProjectCount} project-linked";
+        $"{GitHubIssueCount} issues · {PullRequestCount} pull requests · {ReleaseCount} releases · " +
+        $"{GitHubProjectCount} project-linked";
 }

--- a/Blueprints.App/Models/SourceImportProposal.cs
+++ b/Blueprints.App/Models/SourceImportProposal.cs
@@ -36,6 +36,9 @@ public sealed class SourceImportProposal : ObservableObject
 
     public string SourceContext => Candidate.SourceContext;
 
+    public string ProviderReferenceSummary =>
+        Candidate.ProviderReference?.DisplaySummary ?? "Unclassified source reference";
+
     public string ConfidenceSummary => $"{Candidate.Confidence:P0} confidence";
 
     public bool IsDuplicate { get; }

--- a/Blueprints.App/Models/SourceProviderKind.cs
+++ b/Blueprints.App/Models/SourceProviderKind.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public enum SourceProviderKind
+{
+    Local,
+    GitHub,
+    GitLab,
+}

--- a/Blueprints.App/Services/CanvasSelectionService.cs
+++ b/Blueprints.App/Services/CanvasSelectionService.cs
@@ -1,0 +1,105 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public static class CanvasSelectionService
+{
+    public static IReadOnlySet<Guid> SelectIntersecting(
+        IReadOnlyList<CanvasNodeBounds> nodes,
+        CanvasSelectionBounds selection)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentNullException.ThrowIfNull(selection);
+
+        return nodes
+            .Where(node =>
+                node.X <= selection.Right &&
+                node.X + node.Width >= selection.Left &&
+                node.Y <= selection.Bottom &&
+                node.Y + node.Height >= selection.Top)
+            .Select(static node => node.EntityId)
+            .ToHashSet();
+    }
+
+    public static (double DeltaX, double DeltaY) ConstrainMove(
+        IReadOnlyList<CanvasNodeBounds> selectedNodes,
+        double requestedDeltaX,
+        double requestedDeltaY,
+        double surfaceWidth,
+        double surfaceHeight)
+    {
+        ArgumentNullException.ThrowIfNull(selectedNodes);
+        if (selectedNodes.Count == 0)
+        {
+            return (0, 0);
+        }
+
+        var minimumDeltaX = selectedNodes.Max(static node => -node.X);
+        var maximumDeltaX = selectedNodes.Min(node => surfaceWidth - node.X - node.Width);
+        var minimumDeltaY = selectedNodes.Max(static node => -node.Y);
+        var maximumDeltaY = selectedNodes.Min(node => surfaceHeight - node.Y - node.Height);
+
+        return (
+            Math.Clamp(requestedDeltaX, minimumDeltaX, maximumDeltaX),
+            Math.Clamp(requestedDeltaY, minimumDeltaY, maximumDeltaY));
+    }
+
+    public static CanvasAlignmentGuides FindAlignmentGuides(
+        IReadOnlyList<CanvasNodeBounds> movingNodes,
+        IReadOnlyList<CanvasNodeBounds> stationaryNodes,
+        double tolerance = 5)
+    {
+        ArgumentNullException.ThrowIfNull(movingNodes);
+        ArgumentNullException.ThrowIfNull(stationaryNodes);
+        if (tolerance < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tolerance));
+        }
+
+        if (movingNodes.Count == 0 || stationaryNodes.Count == 0)
+        {
+            return CanvasAlignmentGuides.Empty;
+        }
+
+        var vertical = new HashSet<double>();
+        var horizontal = new HashSet<double>();
+        foreach (var moving in movingNodes)
+        {
+            foreach (var stationary in stationaryNodes)
+            {
+                AddMatches(
+                    [moving.X, moving.X + moving.Width / 2, moving.X + moving.Width],
+                    [stationary.X, stationary.X + stationary.Width / 2, stationary.X + stationary.Width],
+                    tolerance,
+                    vertical);
+                AddMatches(
+                    [moving.Y, moving.Y + moving.Height / 2, moving.Y + moving.Height],
+                    [stationary.Y, stationary.Y + stationary.Height / 2, stationary.Y + stationary.Height],
+                    tolerance,
+                    horizontal);
+            }
+        }
+
+        return new CanvasAlignmentGuides(
+            vertical.Order().ToArray(),
+            horizontal.Order().ToArray());
+    }
+
+    private static void AddMatches(
+        IReadOnlyList<double> movingCoordinates,
+        IReadOnlyList<double> stationaryCoordinates,
+        double tolerance,
+        ISet<double> matches)
+    {
+        foreach (var moving in movingCoordinates)
+        {
+            foreach (var stationary in stationaryCoordinates)
+            {
+                if (Math.Abs(moving - stationary) <= tolerance)
+                {
+                    matches.Add(stationary);
+                }
+            }
+        }
+    }
+}

--- a/Blueprints.App/Services/GitHubSourceJsonParser.cs
+++ b/Blueprints.App/Services/GitHubSourceJsonParser.cs
@@ -5,6 +5,30 @@ namespace Blueprints.App.Services;
 
 public static class GitHubSourceJsonParser
 {
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseProjectDrafts(
+        string json,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        using var document = JsonDocument.Parse(json);
+        if (!document.RootElement.TryGetProperty("data", out var data)
+            || !data.TryGetProperty("repository", out var repository)
+            || repository.ValueKind != JsonValueKind.Object
+            || !repository.TryGetProperty("projectsV2", out var projects)
+            || !projects.TryGetProperty("nodes", out var projectNodes)
+            || projectNodes.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return projectNodes
+            .EnumerateArray()
+            .Take(10)
+            .SelectMany(project => ParseProjectDrafts(project, repositoryName))
+            .Take(100)
+            .ToArray();
+    }
+
     public static IReadOnlyList<SourceDiscoveryCandidate> ParsePullRequests(
         string json,
         string repositoryName)
@@ -63,6 +87,53 @@ public static class GitHubSourceJsonParser
                 repositoryName,
                 $"#{number}",
                 url));
+    }
+
+    private static IReadOnlyList<SourceDiscoveryCandidate> ParseProjectDrafts(
+        JsonElement project,
+        string repositoryName)
+    {
+        var projectNumber = project.GetProperty("number").GetInt32();
+        var projectTitle = ReadString(project, "title") ?? $"Project {projectNumber}";
+        var projectUrl = ReadString(project, "url");
+        if (!project.TryGetProperty("items", out var items)
+            || !items.TryGetProperty("nodes", out var itemNodes)
+            || itemNodes.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return itemNodes
+            .EnumerateArray()
+            .Take(100)
+            .Where(static item =>
+                item.TryGetProperty("content", out var content)
+                && content.ValueKind == JsonValueKind.Object
+                && ReadString(content, "__typename") == "DraftIssue")
+            .Select(item =>
+            {
+                var itemId = ReadString(item, "id") ?? "(unknown)";
+                var content = item.GetProperty("content");
+                var title = ReadString(content, "title") ?? "Untitled project draft";
+                var body = ReadString(content, "body");
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.GitHubProject,
+                    title,
+                    Truncate(body, 2_000),
+                    SuggestItemType([], title),
+                    "added",
+                    false,
+                    $"github:project:{projectNumber}:draft:{itemId}",
+                    $"{projectTitle} · standalone draft item",
+                    0.9,
+                    new ProviderReference(
+                        SourceProviderKind.GitHub,
+                        ProviderReferenceKind.Project,
+                        repositoryName,
+                        $"{projectNumber}/draft/{itemId}",
+                        projectUrl));
+            })
+            .ToArray();
     }
 
     private static SourceDiscoveryCandidate ParseRelease(

--- a/Blueprints.App/Services/GitHubSourceJsonParser.cs
+++ b/Blueprints.App/Services/GitHubSourceJsonParser.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public static class GitHubSourceJsonParser
+{
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParsePullRequests(
+        string json,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(100)
+            .Select(pullRequest => ParsePullRequest(pullRequest, repositoryName))
+            .ToArray();
+    }
+
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseReleases(
+        string json,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(50)
+            .Select(release => ParseRelease(release, repositoryName))
+            .ToArray();
+    }
+
+    private static SourceDiscoveryCandidate ParsePullRequest(
+        JsonElement pullRequest,
+        string repositoryName)
+    {
+        var number = pullRequest.GetProperty("number").GetInt32();
+        var title = pullRequest.GetProperty("title").GetString()?.Trim() ?? $"Pull request #{number}";
+        var body = ReadString(pullRequest, "body");
+        var state = ReadString(pullRequest, "state");
+        var mergedAt = ReadString(pullRequest, "mergedAt");
+        var url = ReadString(pullRequest, "url");
+        var labels = ReadLabels(pullRequest);
+        var completed = !string.Equals(state, "OPEN", StringComparison.OrdinalIgnoreCase);
+        var context = string.IsNullOrWhiteSpace(mergedAt)
+            ? $"GitHub pull request #{number} · {state ?? "unknown state"}"
+            : $"GitHub pull request #{number} · merged {mergedAt}";
+
+        return new SourceDiscoveryCandidate(
+            SourceArtifactKind.PullRequest,
+            title,
+            Truncate(body, 2_000),
+            SuggestItemType(labels, title),
+            SuggestCategory(labels, completed),
+            completed,
+            $"github:pr:#{number}",
+            context,
+            0.96,
+            new ProviderReference(
+                SourceProviderKind.GitHub,
+                ProviderReferenceKind.PullRequest,
+                repositoryName,
+                $"#{number}",
+                url));
+    }
+
+    private static SourceDiscoveryCandidate ParseRelease(
+        JsonElement release,
+        string repositoryName)
+    {
+        var tag = ReadString(release, "tagName") ?? "(untagged)";
+        var name = ReadString(release, "name");
+        var isDraft = ReadBoolean(release, "isDraft");
+        var isPrerelease = ReadBoolean(release, "isPrerelease");
+        var publishedAt = ReadString(release, "publishedAt");
+        var url = ReadString(release, "url")
+            ?? $"https://github.com/{repositoryName}/releases/tag/{Uri.EscapeDataString(tag)}";
+        var title = string.IsNullOrWhiteSpace(name) ? tag : name;
+        var states = new[]
+            {
+                isDraft ? "draft" : null,
+                isPrerelease ? "prerelease" : "release",
+                publishedAt is null ? null : $"published {publishedAt}",
+            }
+            .Where(static value => value is not null);
+
+        return new SourceDiscoveryCandidate(
+            SourceArtifactKind.Release,
+            title,
+            null,
+            "feature",
+            "changed",
+            !isDraft && publishedAt is not null,
+            $"github:release:{tag}",
+            string.Join(" · ", states),
+            0.98,
+            new ProviderReference(
+                SourceProviderKind.GitHub,
+                ProviderReferenceKind.Release,
+                repositoryName,
+                tag,
+                url));
+    }
+
+    private static IReadOnlyList<string> ReadLabels(JsonElement element) =>
+        element.TryGetProperty("labels", out var labels) && labels.ValueKind == JsonValueKind.Array
+            ? labels
+                .EnumerateArray()
+                .Select(static label => label.TryGetProperty("name", out var name) ? name.GetString() : null)
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Cast<string>()
+                .ToArray()
+            : [];
+
+    private static string SuggestItemType(IReadOnlyList<string> labels, string title)
+    {
+        var text = $"{string.Join(' ', labels)} {title}";
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "bug";
+        }
+
+        return "feature";
+    }
+
+    private static string SuggestCategory(IReadOnlyList<string> labels, bool completed)
+    {
+        var text = string.Join(' ', labels);
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "fixed";
+        }
+
+        return completed ? "changed" : "added";
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()?.Trim()
+            : null;
+
+    private static bool ReadBoolean(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value)
+        && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+        && value.GetBoolean();
+
+    private static string? Truncate(string? value, int maximumLength) =>
+        string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Length <= maximumLength
+                ? value
+                : $"{value[..maximumLength]}…";
+}

--- a/Blueprints.App/Services/IHostedSourceProviderReader.cs
+++ b/Blueprints.App/Services/IHostedSourceProviderReader.cs
@@ -1,0 +1,10 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public interface IHostedSourceProviderReader
+{
+    HostedSourceDiscoveryResult Read(
+        string repositoryRoot,
+        string repositoryName);
+}

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -29,7 +29,7 @@ public sealed class IntegrationStatusService
 
         return
         [
-            GetLocalGitStatus(settings, checkedAtUtc),
+            .. GetLocalGitStatuses(settings, checkedAtUtc),
             new IntegrationStatusCard(
                 IntegrationProviderType.GitHub,
                 "GitHub",
@@ -67,13 +67,16 @@ public sealed class IntegrationStatusService
 
     public void SaveSettings(IntegrationSettings settings) => _settingsStore.Save(settings);
 
-    private IntegrationStatusCard GetLocalGitStatus(
+    private IReadOnlyList<IntegrationStatusCard> GetLocalGitStatuses(
         IntegrationSettings settings,
         DateTimeOffset checkedAtUtc)
     {
-        if (string.IsNullOrWhiteSpace(settings.LocalGitRepositoryPath))
+        var repositoryPaths = settings.EffectiveLocalGitRepositoryPaths;
+        if (repositoryPaths.Count == 0)
         {
-            return new IntegrationStatusCard(
+            return
+            [
+                new IntegrationStatusCard(
                 IntegrationProviderType.LocalGit,
                 "Local Git",
                 IntegrationConnectionState.NotConfigured,
@@ -82,10 +85,20 @@ public sealed class IntegrationStatusService
                 "Link a repository path to detect branch, origin remote, dirty state, and latest tag.",
                 BlueprintsTrustBoundary(),
                 checkedAtUtc,
-                []);
+                []),
+            ];
         }
 
-        var gitStatus = _localGitRepositoryInspector.Inspect(settings.LocalGitRepositoryPath);
+        return repositoryPaths
+            .Select(path => GetLocalGitStatus(path, checkedAtUtc))
+            .ToArray();
+    }
+
+    private IntegrationStatusCard GetLocalGitStatus(
+        string repositoryPath,
+        DateTimeOffset checkedAtUtc)
+    {
+        var gitStatus = _localGitRepositoryInspector.Inspect(repositoryPath);
         if (!gitStatus.IsRepository)
         {
             return new IntegrationStatusCard(

--- a/Blueprints.App/Services/MarkdownSourceDiscoveryParser.cs
+++ b/Blueprints.App/Services/MarkdownSourceDiscoveryParser.cs
@@ -61,7 +61,13 @@ public sealed partial class MarkdownSourceDiscoveryParser
                     isDone || kind == SourceArtifactKind.Changelog,
                     $"{kind.ToString().ToLowerInvariant()}:{relativeName}:{lineNumber}",
                     context,
-                    kind == SourceArtifactKind.Roadmap && checkbox.Length > 0 ? 0.94 : 0.82));
+                    kind == SourceArtifactKind.Roadmap && checkbox.Length > 0 ? 0.94 : 0.82,
+                    new ProviderReference(
+                        SourceProviderKind.Local,
+                        ProviderReferenceKind.PlanningDocument,
+                        Path.GetDirectoryName(Path.GetFullPath(filePath)) ?? string.Empty,
+                        $"{relativeName}:{lineNumber}",
+                        null)));
 
             if (candidates.Count >= MaximumCandidatesPerFile)
             {

--- a/Blueprints.App/Services/ReleaseReadinessDiagnosticBuilder.cs
+++ b/Blueprints.App/Services/ReleaseReadinessDiagnosticBuilder.cs
@@ -1,0 +1,127 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public static class ReleaseReadinessDiagnosticBuilder
+{
+    public static IReadOnlyList<ReleaseReadinessDiagnostic> Build(
+        WorkspaceVersionCard? version,
+        IntegrationStatusCard? localGit,
+        IReadOnlyList<VersionSourceChangeDiagnostic> sourceChanges)
+    {
+        ArgumentNullException.ThrowIfNull(sourceChanges);
+        var diagnostics = new List<ReleaseReadinessDiagnostic>();
+
+        if (version is null)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Blocking,
+                    "No release version selected",
+                    "Source history cannot be evaluated without a target version.",
+                    "Select or create a version before reviewing release readiness."));
+            return diagnostics;
+        }
+
+        AddRepositoryDiagnostic(diagnostics, localGit);
+
+        var incompleteItemCount = version.Items.Count(static item => !item.IsDone);
+        if (incompleteItemCount > 0)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Incomplete release items",
+                    $"{incompleteItemCount} selected-version items are not marked complete.",
+                    "Finish them, move them to another version, or deliberately export them as incomplete."));
+        }
+
+        if (localGit is { State: IntegrationConnectionState.Connected or IntegrationConnectionState.Warning })
+        {
+            AddSourceChangeDiagnostics(diagnostics, sourceChanges);
+        }
+
+        if (diagnostics.Count == 0)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Ready,
+                    "Source history is ready",
+                    "The linked repository is clean and every recent change maps to a completed item in this version.",
+                    "Review the changelog preview, then freeze or release when the human review is complete."));
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddRepositoryDiagnostic(
+        ICollection<ReleaseReadinessDiagnostic> diagnostics,
+        IntegrationStatusCard? localGit)
+    {
+        if (localGit is null || localGit.State == IntegrationConnectionState.NotConfigured)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "No source repository linked",
+                    "Blueprints cannot compare this release plan with source history.",
+                    "Link a local Git repository in Source Lens. Core release planning remains available offline."));
+            return;
+        }
+
+        if (localGit.State == IntegrationConnectionState.Error)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Blocking,
+                    "Linked repository is unavailable",
+                    localGit.Summary,
+                    localGit.Guidance));
+            return;
+        }
+
+        if (localGit.State == IntegrationConnectionState.Warning)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Blocking,
+                    "Repository has uncommitted changes",
+                    $"{localGit.Target} is not clean, so its source history is not a stable release baseline.",
+                    "Review, commit, stash, or deliberately discard the working-tree changes outside Blueprints, then refresh health."));
+        }
+    }
+
+    private static void AddSourceChangeDiagnostics(
+        ICollection<ReleaseReadinessDiagnostic> diagnostics,
+        IReadOnlyList<VersionSourceChangeDiagnostic> sourceChanges)
+    {
+        if (sourceChanges.Count == 0)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "No recent source changes found",
+                    "There are no commits after the repository's latest tag to compare with this version.",
+                    "Confirm the tag boundary and repository link are correct."));
+            return;
+        }
+
+        var unmatched = sourceChanges
+            .Where(static change => !change.MatchesSelectedVersion)
+            .ToArray();
+        if (unmatched.Length > 0)
+        {
+            var examples = string.Join(
+                ", ",
+                unmatched
+                    .Take(3)
+                    .Select(static change => $"{change.Change.ShortHash} {change.Change.Subject}"));
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Recent commits are unmatched",
+                    $"{unmatched.Length} recent commits do not reference a completed item in this version. {examples}",
+                    "Connect the commits to completed item keys, move the relevant item into this version, or confirm the commits are intentionally out of scope."));
+        }
+    }
+}

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -8,6 +8,8 @@ namespace Blueprints.App.Services;
 public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryService
 {
     private const int MaximumGitHubIssues = 100;
+    private const int MaximumGitHubPullRequests = 100;
+    private const int MaximumGitHubReleases = 50;
     private readonly MarkdownSourceDiscoveryParser _markdownParser;
 
     public RepositorySourceDiscoveryService()
@@ -38,17 +40,29 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         var repositoryName = ReadGitHubRepositoryName(root);
         var githubIssueCount = 0;
         var githubProjectCount = 0;
+        var pullRequestCount = 0;
+        var releaseCount = 0;
         if (string.IsNullOrWhiteSpace(repositoryName))
         {
-            warnings.Add("GitHub issues were skipped because the origin remote is not a recognizable GitHub repository.");
+            warnings.Add("GitHub sources were skipped because the origin remote is not a recognizable GitHub repository.");
         }
         else
         {
-            var github = ReadGitHubIssues(root, repositoryName);
-            candidates.AddRange(github.Candidates);
-            warnings.AddRange(github.Warnings);
-            githubIssueCount = github.Candidates.Count;
-            githubProjectCount = github.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject);
+            var issues = ReadGitHubIssues(root, repositoryName);
+            candidates.AddRange(issues.Candidates);
+            warnings.AddRange(issues.Warnings);
+            githubIssueCount = issues.Candidates.Count;
+            githubProjectCount = issues.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject);
+
+            var pullRequests = ReadGitHubPullRequests(root, repositoryName);
+            candidates.AddRange(pullRequests.Candidates);
+            warnings.AddRange(pullRequests.Warnings);
+            pullRequestCount = pullRequests.Candidates.Count;
+
+            var releases = ReadGitHubReleases(root, repositoryName);
+            candidates.AddRange(releases.Candidates);
+            warnings.AddRange(releases.Warnings);
+            releaseCount = releases.Candidates.Count;
         }
 
         var deduplicated = candidates
@@ -65,7 +79,9 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             changelogCount,
             roadmapCount,
             githubIssueCount,
-            githubProjectCount);
+            githubProjectCount,
+            pullRequestCount,
+            releaseCount);
     }
 
     private int AddMarkdownCandidates(
@@ -133,6 +149,80 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         catch (JsonException exception)
         {
             return new GitHubDiscovery([], [$"GitHub returned unreadable issue data: {exception.Message}"]);
+        }
+    }
+
+    private static GitHubDiscovery ReadGitHubPullRequests(string root, string repositoryName)
+    {
+        var command = RunProcess(
+            root,
+            "gh",
+            [
+                "pr",
+                "list",
+                "--repo",
+                repositoryName,
+                "--state",
+                "all",
+                "--limit",
+                MaximumGitHubPullRequests.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                "--json",
+                "number,title,body,state,labels,url,mergedAt",
+            ]);
+        if (!command.Success)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub pull requests were skipped: {command.Error}"]);
+        }
+
+        try
+        {
+            return new GitHubDiscovery(
+                GitHubSourceJsonParser.ParsePullRequests(command.Output, repositoryName),
+                []);
+        }
+        catch (JsonException exception)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub returned unreadable pull-request data: {exception.Message}"]);
+        }
+    }
+
+    private static GitHubDiscovery ReadGitHubReleases(string root, string repositoryName)
+    {
+        var command = RunProcess(
+            root,
+            "gh",
+            [
+                "release",
+                "list",
+                "--repo",
+                repositoryName,
+                "--limit",
+                MaximumGitHubReleases.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                "--json",
+                "tagName,name,isDraft,isPrerelease,publishedAt",
+            ]);
+        if (!command.Success)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub releases were skipped: {command.Error}"]);
+        }
+
+        try
+        {
+            return new GitHubDiscovery(
+                GitHubSourceJsonParser.ParseReleases(command.Output, repositoryName),
+                []);
+        }
+        catch (JsonException exception)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub returned unreadable release data: {exception.Message}"]);
         }
     }
 

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -126,7 +126,7 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             using var document = JsonDocument.Parse(command.Output);
             var candidates = document.RootElement
                 .EnumerateArray()
-                .Select(ParseGitHubIssue)
+                .Select(issue => ParseGitHubIssue(issue, repositoryName))
                 .ToArray();
             return new GitHubDiscovery(candidates, []);
         }
@@ -136,7 +136,9 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         }
     }
 
-    private static SourceDiscoveryCandidate ParseGitHubIssue(JsonElement issue)
+    private static SourceDiscoveryCandidate ParseGitHubIssue(
+        JsonElement issue,
+        string repositoryName)
     {
         var number = issue.GetProperty("number").GetInt32();
         var title = issue.GetProperty("title").GetString()?.Trim() ?? $"Issue #{number}";
@@ -180,7 +182,13 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase),
             $"github:#{number}",
             string.Join(" · ", contextParts.DefaultIfEmpty($"GitHub issue #{number}")),
-            isProjectLinked ? 0.97 : 0.93);
+            isProjectLinked ? 0.97 : 0.93,
+            new ProviderReference(
+                SourceProviderKind.GitHub,
+                ProviderReferenceKind.Issue,
+                repositoryName,
+                $"#{number}",
+                url));
     }
 
     private static IReadOnlyList<string> ReadProjectNames(JsonElement issue)

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -10,6 +10,11 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
     private const int MaximumGitHubIssues = 100;
     private const int MaximumGitHubPullRequests = 100;
     private const int MaximumGitHubReleases = 50;
+    private const string GitHubProjectDraftQuery =
+        "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){" +
+        "projectsV2(first:10){nodes{number title url items(first:100){nodes{id type content{" +
+        "__typename ... on DraftIssue{title body} ... on Issue{number} ... on PullRequest{number}" +
+        "}}}}}}}";
     private readonly MarkdownSourceDiscoveryParser _markdownParser;
 
     public RepositorySourceDiscoveryService()
@@ -63,6 +68,11 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             candidates.AddRange(releases.Candidates);
             warnings.AddRange(releases.Warnings);
             releaseCount = releases.Candidates.Count;
+
+            var projectDrafts = ReadGitHubProjectDrafts(root, repositoryName);
+            candidates.AddRange(projectDrafts.Candidates);
+            warnings.AddRange(projectDrafts.Warnings);
+            githubProjectCount += projectDrafts.Candidates.Count;
         }
 
         var deduplicated = candidates
@@ -223,6 +233,52 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             return new GitHubDiscovery(
                 [],
                 [$"GitHub returned unreadable release data: {exception.Message}"]);
+        }
+    }
+
+    private static GitHubDiscovery ReadGitHubProjectDrafts(
+        string root,
+        string repositoryName)
+    {
+        var separator = repositoryName.IndexOf('/');
+        if (separator <= 0 || separator == repositoryName.Length - 1)
+        {
+            return new GitHubDiscovery(
+                [],
+                ["GitHub Project drafts were skipped because the repository identity is malformed."]);
+        }
+
+        var command = RunProcess(
+            root,
+            "gh",
+            [
+                "api",
+                "graphql",
+                "-f",
+                $"owner={repositoryName[..separator]}",
+                "-f",
+                $"name={repositoryName[(separator + 1)..]}",
+                "-f",
+                $"query={GitHubProjectDraftQuery}",
+            ]);
+        if (!command.Success)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub Project drafts were skipped: {command.Error}"]);
+        }
+
+        try
+        {
+            return new GitHubDiscovery(
+                GitHubSourceJsonParser.ParseProjectDrafts(command.Output, repositoryName),
+                []);
+        }
+        catch (JsonException exception)
+        {
+            return new GitHubDiscovery(
+                [],
+                [$"GitHub returned unreadable Project draft data: {exception.Message}"]);
         }
     }
 

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -16,15 +16,28 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         "__typename ... on DraftIssue{title body} ... on Issue{number} ... on PullRequest{number}" +
         "}}}}}}}";
     private readonly MarkdownSourceDiscoveryParser _markdownParser;
+    private readonly IHostedSourceProviderReader _hostedSourceProviderReader;
 
     public RepositorySourceDiscoveryService()
-        : this(new MarkdownSourceDiscoveryParser())
+        : this(
+            new MarkdownSourceDiscoveryParser(),
+            new GitHubCliSourceProviderReader())
     {
     }
 
     public RepositorySourceDiscoveryService(MarkdownSourceDiscoveryParser markdownParser)
+        : this(markdownParser, new GitHubCliSourceProviderReader())
     {
+    }
+
+    public RepositorySourceDiscoveryService(
+        MarkdownSourceDiscoveryParser markdownParser,
+        IHostedSourceProviderReader hostedSourceProviderReader)
+    {
+        ArgumentNullException.ThrowIfNull(markdownParser);
+        ArgumentNullException.ThrowIfNull(hostedSourceProviderReader);
         _markdownParser = markdownParser;
+        _hostedSourceProviderReader = hostedSourceProviderReader;
     }
 
     public SourceDiscoveryResult Discover(string repositoryPath)
@@ -53,26 +66,13 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         }
         else
         {
-            var issues = ReadGitHubIssues(root, repositoryName);
-            candidates.AddRange(issues.Candidates);
-            warnings.AddRange(issues.Warnings);
-            githubIssueCount = issues.Candidates.Count;
-            githubProjectCount = issues.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject);
-
-            var pullRequests = ReadGitHubPullRequests(root, repositoryName);
-            candidates.AddRange(pullRequests.Candidates);
-            warnings.AddRange(pullRequests.Warnings);
-            pullRequestCount = pullRequests.Candidates.Count;
-
-            var releases = ReadGitHubReleases(root, repositoryName);
-            candidates.AddRange(releases.Candidates);
-            warnings.AddRange(releases.Warnings);
-            releaseCount = releases.Candidates.Count;
-
-            var projectDrafts = ReadGitHubProjectDrafts(root, repositoryName);
-            candidates.AddRange(projectDrafts.Candidates);
-            warnings.AddRange(projectDrafts.Warnings);
-            githubProjectCount += projectDrafts.Candidates.Count;
+            var hosted = _hostedSourceProviderReader.Read(root, repositoryName);
+            candidates.AddRange(hosted.Candidates);
+            warnings.AddRange(hosted.Warnings);
+            githubIssueCount = hosted.IssueCount;
+            githubProjectCount = hosted.ProjectCount;
+            pullRequestCount = hosted.PullRequestCount;
+            releaseCount = hosted.ReleaseCount;
         }
 
         var deduplicated = candidates
@@ -492,4 +492,35 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
     private sealed record GitHubDiscovery(
         IReadOnlyList<SourceDiscoveryCandidate> Candidates,
         IReadOnlyList<string> Warnings);
+
+    private sealed class GitHubCliSourceProviderReader : IHostedSourceProviderReader
+    {
+        public HostedSourceDiscoveryResult Read(
+            string repositoryRoot,
+            string repositoryName)
+        {
+            var issues = ReadGitHubIssues(repositoryRoot, repositoryName);
+            var pullRequests = ReadGitHubPullRequests(repositoryRoot, repositoryName);
+            var releases = ReadGitHubReleases(repositoryRoot, repositoryName);
+            var projectDrafts = ReadGitHubProjectDrafts(repositoryRoot, repositoryName);
+            return new HostedSourceDiscoveryResult(
+                [
+                    .. issues.Candidates,
+                    .. pullRequests.Candidates,
+                    .. releases.Candidates,
+                    .. projectDrafts.Candidates,
+                ],
+                [
+                    .. issues.Warnings,
+                    .. pullRequests.Warnings,
+                    .. releases.Warnings,
+                    .. projectDrafts.Warnings,
+                ],
+                issues.Candidates.Count,
+                issues.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject)
+                + projectDrafts.Candidates.Count,
+                pullRequests.Candidates.Count,
+                releases.Candidates.Count);
+        }
+    }
 }

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,8 @@ namespace Blueprints.App.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
+    private const int MaximumLinkedRepositories = 8;
+    private const int MaximumCombinedSourceCandidates = 500;
     private readonly ProjectWorkspaceCoordinatorService? _coordinatorService;
     private readonly IntegrationStatusService _integrationStatusService;
     private readonly ISourceDiscoveryService _sourceDiscoveryService;
@@ -1551,15 +1553,20 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         try
         {
+            var repositoryPaths = ParseLocalGitRepositoryPaths(LocalGitRepositoryPath);
             var settings = _integrationStatusService.GetSettings();
             _integrationStatusService.SaveSettings(settings with
             {
-                LocalGitRepositoryPath = LocalGitRepositoryPath.Trim(),
+                LocalGitRepositoryPath = repositoryPaths.FirstOrDefault() ?? string.Empty,
+                LocalGitRepositoryPaths = repositoryPaths,
             });
             RefreshIntegrations();
-            IntegrationMessage = string.IsNullOrWhiteSpace(LocalGitRepositoryPath)
-                ? "Local Git repository link cleared."
-                : "Local Git repository link saved.";
+            IntegrationMessage = repositoryPaths.Count switch
+            {
+                0 => "Local Git repository links cleared.",
+                1 => "Local Git repository link saved.",
+                _ => $"{repositoryPaths.Count} Local Git repository links saved.",
+            };
         }
         catch (Exception exception)
         {
@@ -1594,7 +1601,8 @@ public partial class MainWindowViewModel : ViewModelBase
         IntegrationMessage = "Reading changelogs, roadmaps, GitHub issues, and project links…";
         try
         {
-            var result = await Task.Run(() => _sourceDiscoveryService.Discover(LocalGitRepositoryPath));
+            var repositoryPaths = ParseLocalGitRepositoryPaths(LocalGitRepositoryPath);
+            var result = await Task.Run(() => DiscoverSources(repositoryPaths));
             PopulateSourceProposals(result);
             IntegrationMessage = result.Candidates.Count == 0
                 ? "The scan completed, but no importable planning entries were found."
@@ -2211,7 +2219,9 @@ public partial class MainWindowViewModel : ViewModelBase
     private void RefreshIntegrations()
     {
         var settings = _integrationStatusService.GetSettings();
-        LocalGitRepositoryPath = settings.LocalGitRepositoryPath;
+        LocalGitRepositoryPath = string.Join(
+            Environment.NewLine,
+            settings.EffectiveLocalGitRepositoryPaths);
 
         Integrations.Clear();
         foreach (var integration in _integrationStatusService.GetIntegrationStatuses())
@@ -2325,9 +2335,10 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     private IReadOnlyList<SourceChangeSummary> GetLocalGitRecentChanges() =>
-        Integrations.FirstOrDefault(static integration => integration.Provider == IntegrationProviderType.LocalGit)
-            ?.RecentChanges
-        ?? [];
+        Integrations
+            .Where(static integration => integration.Provider == IntegrationProviderType.LocalGit)
+            .SelectMany(static integration => integration.RecentChanges)
+            .ToArray();
 
     private void RefreshVersionSourceChangeDiagnostics()
     {
@@ -2339,8 +2350,7 @@ public partial class MainWindowViewModel : ViewModelBase
         }
 
         ReleaseReadinessDiagnostics.Clear();
-        var localGit = Integrations.FirstOrDefault(
-            static integration => integration.Provider == IntegrationProviderType.LocalGit);
+        var localGit = GetLocalGitReadinessStatus();
         foreach (var diagnostic in ReleaseReadinessDiagnosticBuilder.Build(
                      SelectedVersion,
                      localGit,
@@ -2351,6 +2361,84 @@ public partial class MainWindowViewModel : ViewModelBase
 
         OnPropertyChanged(nameof(VersionSourceChangeSummary));
         OnPropertyChanged(nameof(ReleaseReadinessSummary));
+    }
+
+    private IntegrationStatusCard? GetLocalGitReadinessStatus()
+    {
+        var repositories = Integrations
+            .Where(static integration => integration.Provider == IntegrationProviderType.LocalGit)
+            .ToArray();
+        if (repositories.Length <= 1)
+        {
+            return repositories.FirstOrDefault();
+        }
+
+        var state = repositories.Any(
+            static repository => repository.State == IntegrationConnectionState.Error)
+            ? IntegrationConnectionState.Error
+            : repositories.Any(
+                static repository => repository.State == IntegrationConnectionState.Warning)
+                ? IntegrationConnectionState.Warning
+                : IntegrationConnectionState.Connected;
+        return new IntegrationStatusCard(
+            IntegrationProviderType.LocalGit,
+            "Local Git repositories",
+            state,
+            string.Join(", ", repositories.Select(static repository => repository.Target)),
+            $"{repositories.Length} linked repositories; " +
+            $"{repositories.Count(static repository => repository.State == IntegrationConnectionState.Connected)} clean, " +
+            $"{repositories.Count(static repository => repository.State == IntegrationConnectionState.Warning)} dirty, " +
+            $"{repositories.Count(static repository => repository.State == IntegrationConnectionState.Error)} unavailable.",
+            "Resolve every dirty or unavailable repository before treating source history as a stable release baseline.",
+            repositories[0].TrustBoundary,
+            repositories.Max(static repository => repository.CheckedAtUtc),
+            GetLocalGitRecentChanges());
+    }
+
+    private SourceDiscoveryResult DiscoverSources(IReadOnlyList<string> repositoryPaths)
+    {
+        var results = repositoryPaths
+            .Select(path => (Path: path, Result: _sourceDiscoveryService.Discover(path)))
+            .ToArray();
+        var candidates = results
+            .SelectMany(pair => pair.Result.Candidates.Select(candidate => candidate with
+            {
+                SourceReference = $"{pair.Path}::{candidate.SourceReference}",
+                SourceContext = $"{Path.GetFileName(pair.Path)} · {candidate.SourceContext}",
+            }))
+            .ToArray();
+        var warnings = results
+            .SelectMany(pair => pair.Result.Warnings.Select(warning => $"{Path.GetFileName(pair.Path)}: {warning}"))
+            .ToList();
+        if (candidates.Length > MaximumCombinedSourceCandidates)
+        {
+            warnings.Add(
+                $"Combined discovery was limited to {MaximumCombinedSourceCandidates} proposals across all linked repositories.");
+        }
+
+        return new SourceDiscoveryResult(
+            candidates.Take(MaximumCombinedSourceCandidates).ToArray(),
+            warnings,
+            results.Sum(static pair => pair.Result.ChangelogCount),
+            results.Sum(static pair => pair.Result.RoadmapCount),
+            results.Sum(static pair => pair.Result.GitHubIssueCount),
+            results.Sum(static pair => pair.Result.GitHubProjectCount));
+    }
+
+    private static IReadOnlyList<string> ParseLocalGitRepositoryPaths(string value)
+    {
+        var paths = value
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (paths.Length > MaximumLinkedRepositories)
+        {
+            throw new InvalidOperationException(
+                $"Link no more than {MaximumLinkedRepositories} local repositories to one Blueprints installation.");
+        }
+
+        return paths;
     }
 
     private void RefreshSuggestedPaths()

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -2422,7 +2422,9 @@ public partial class MainWindowViewModel : ViewModelBase
             results.Sum(static pair => pair.Result.ChangelogCount),
             results.Sum(static pair => pair.Result.RoadmapCount),
             results.Sum(static pair => pair.Result.GitHubIssueCount),
-            results.Sum(static pair => pair.Result.GitHubProjectCount));
+            results.Sum(static pair => pair.Result.GitHubProjectCount),
+            results.Sum(static pair => pair.Result.PullRequestCount),
+            results.Sum(static pair => pair.Result.ReleaseCount));
     }
 
     private static IReadOnlyList<string> ParseLocalGitRepositoryPaths(string value)

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -107,6 +107,7 @@ public partial class MainWindowViewModel : ViewModelBase
         TrustDiagnostics = new ObservableCollection<TrustDiagnosticCard>();
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
+        ReleaseReadinessDiagnostics = new ObservableCollection<ReleaseReadinessDiagnostic>();
         _integrationStatusService = new IntegrationStatusService();
         _sourceDiscoveryService = new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
@@ -136,6 +137,7 @@ public partial class MainWindowViewModel : ViewModelBase
         TrustDiagnostics = new ObservableCollection<TrustDiagnosticCard>();
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
+        ReleaseReadinessDiagnostics = new ObservableCollection<ReleaseReadinessDiagnostic>();
         SourceImportProposals = new ObservableCollection<SourceImportProposal>();
 
         RefreshRecentProjects();
@@ -166,6 +168,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<IntegrationStatusCard> Integrations { get; }
 
     public ObservableCollection<VersionSourceChangeDiagnostic> VersionSourceChangeDiagnostics { get; }
+
+    public ObservableCollection<ReleaseReadinessDiagnostic> ReleaseReadinessDiagnostics { get; }
 
     public ObservableCollection<SourceImportProposal> SourceImportProposals { get; }
 
@@ -922,6 +926,22 @@ public partial class MainWindowViewModel : ViewModelBase
             var unmatchedCount = VersionSourceChangeDiagnostics.Count - matchedCount;
 
             return $"{matchedCount} matched source changes, {unmatchedCount} unmatched recent changes.";
+        }
+    }
+
+    public string ReleaseReadinessSummary
+    {
+        get
+        {
+            var blocking = ReleaseReadinessDiagnostics.Count(
+                static diagnostic => diagnostic.Level == ReleaseReadinessLevel.Blocking);
+            var attention = ReleaseReadinessDiagnostics.Count(
+                static diagnostic => diagnostic.Level == ReleaseReadinessLevel.Attention);
+            return blocking > 0
+                ? $"{blocking} blocking source-control checks · {attention} need attention"
+                : attention > 0
+                    ? $"No source-control blockers · {attention} checks need attention"
+                    : "Source-control checks are ready for human release review";
         }
     }
 
@@ -2021,6 +2041,7 @@ public partial class MainWindowViewModel : ViewModelBase
         }
 
         VersionSourceChangeDiagnostics.Clear();
+        ReleaseReadinessDiagnostics.Clear();
 
         Title = $"{project.Name} ({project.ProjectCode})";
         TrustSummary = session.LoadResult.TrustReport.Summary;
@@ -2117,6 +2138,7 @@ public partial class MainWindowViewModel : ViewModelBase
         SyncDiagnostics.Clear();
         TrustDiagnostics.Clear();
         VersionSourceChangeDiagnostics.Clear();
+        ReleaseReadinessDiagnostics.Clear();
         SourceImportProposals.Clear();
         SelectedSourceProposal = null;
         SourceDiscoverySummary = "Connect a repository, then scan its planning sources.";
@@ -2316,7 +2338,19 @@ public partial class MainWindowViewModel : ViewModelBase
             VersionSourceChangeDiagnostics.Add(diagnostic);
         }
 
+        ReleaseReadinessDiagnostics.Clear();
+        var localGit = Integrations.FirstOrDefault(
+            static integration => integration.Provider == IntegrationProviderType.LocalGit);
+        foreach (var diagnostic in ReleaseReadinessDiagnosticBuilder.Build(
+                     SelectedVersion,
+                     localGit,
+                     VersionSourceChangeDiagnostics))
+        {
+            ReleaseReadinessDiagnostics.Add(diagnostic);
+        }
+
         OnPropertyChanged(nameof(VersionSourceChangeSummary));
+        OnPropertyChanged(nameof(ReleaseReadinessSummary));
     }
 
     private void RefreshSuggestedPaths()

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
@@ -7,19 +7,42 @@
           BorderThickness="1"
           CornerRadius="4"
           ClipToBounds="True">
-    <ScrollViewer x:Name="Viewport"
-                  HorizontalScrollBarVisibility="Auto"
-                  VerticalScrollBarVisibility="Auto">
-      <Viewbox x:Name="ZoomHost"
-               Stretch="None"
-               StretchDirection="Both"
-               HorizontalAlignment="Left"
-               VerticalAlignment="Top">
-        <Canvas x:Name="Surface"
-                Width="1500"
-                Height="960"
-                Background="#082F50" />
-      </Viewbox>
-    </ScrollViewer>
+    <Grid>
+      <ScrollViewer x:Name="Viewport"
+                    HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Auto">
+        <Viewbox x:Name="ZoomHost"
+                 Stretch="None"
+                 StretchDirection="Both"
+                 HorizontalAlignment="Left"
+                 VerticalAlignment="Top">
+          <Canvas x:Name="Surface"
+                  Width="1500"
+                  Height="960"
+                  Background="#082F50" />
+        </Viewbox>
+      </ScrollViewer>
+
+      <Border HorizontalAlignment="Right"
+              VerticalAlignment="Bottom"
+              Width="190"
+              Height="132"
+              Margin="0,0,18,18"
+              Padding="7"
+              Background="#E6071F34"
+              BorderBrush="#659FC0"
+              BorderThickness="1"
+              CornerRadius="5"
+              IsHitTestVisible="False">
+        <Grid RowDefinitions="Auto,*" RowSpacing="4">
+          <TextBlock Text="MINIMAP" Foreground="#8BDCF0" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
+          <Canvas x:Name="MiniMapSurface"
+                  Grid.Row="1"
+                  Width="174"
+                  Height="106"
+                  Background="#B9082F50" />
+        </Grid>
+      </Border>
+    </Grid>
   </Border>
 </UserControl>

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -20,12 +20,16 @@ public partial class BlueprintCanvasSurface : UserControl
     private const double VersionNodeHeight = 104;
     private const double ItemNodeHeight = 82;
     private readonly Dictionary<Guid, Point> _positions = [];
+    private readonly Dictionary<Guid, Control> _nodes = [];
+    private readonly HashSet<Guid> _selectedNodeIds = [];
     private readonly List<ConnectionVisual> _connections = [];
+    private readonly List<Line> _alignmentGuideVisuals = [];
     private readonly CanvasLayoutHistory _layoutHistory = new();
     private MainWindowViewModel? _viewModel;
     private Control? _draggedNode;
     private IReadOnlyList<CanvasNodeLayoutEdit>? _dragStartLayout;
-    private Point _dragOffset;
+    private IReadOnlyDictionary<Guid, Point> _dragStartPositions = new Dictionary<Guid, Point>();
+    private Point _dragStartPointer;
     private double _zoom = 1;
     private bool _isRestoringLayout;
     private bool _isPersistingLayout;
@@ -33,12 +37,26 @@ public partial class BlueprintCanvasSurface : UserControl
     private bool _isPanning;
     private Point _panStart;
     private Vector _panOrigin;
+    private bool _isBoxSelecting;
+    private Point _boxSelectionStart;
+    private Rectangle? _boxSelectionVisual;
+    private IReadOnlySet<Guid> _selectionBeforeBox = new HashSet<Guid>();
 
     public event EventHandler? HistoryStateChanged;
+
+    public event EventHandler? SelectionStateChanged;
 
     public bool CanUndo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanUndo;
 
     public bool CanRedo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanRedo;
+
+    public string SelectionSummary =>
+        _selectedNodeIds.Count switch
+        {
+            0 => "No canvas nodes selected",
+            1 => "1 canvas node selected",
+            _ => $"{_selectedNodeIds.Count} canvas nodes selected",
+        };
 
     public BlueprintCanvasSurface()
     {
@@ -126,12 +144,16 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             PersistViewState();
         }
+
+        RenderMiniMap();
     }
 
     private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
     {
         DetachViewModel();
         ClearLayoutHistory();
+        _selectedNodeIds.Clear();
+        NotifySelectionStateChanged();
         _viewModel = DataContext as MainWindowViewModel;
         if (_viewModel is not null)
         {
@@ -217,31 +239,40 @@ public partial class BlueprintCanvasSurface : UserControl
                 continue;
             }
 
-            var selected = tag.Type switch
-            {
-                "version" => _viewModel.SelectedVersion?.VersionId == id,
-                "item" => _viewModel.SelectedItem?.ItemId == id,
-                _ => false,
-            };
+            var selected = _selectedNodeIds.Contains(id)
+                || tag.Type switch
+                {
+                    "version" => _viewModel.SelectedVersion?.VersionId == id,
+                    "item" => _viewModel.SelectedItem?.ItemId == id,
+                    _ => false,
+                };
             border.Background = Brush.Parse(
                 selected
                     ? "#12669A"
-                    : tag.Type == "version"
-                        ? "#0B3D62"
-                        : "#0A3656");
+                    : tag.Type switch
+                    {
+                        "project" => "#0A2035",
+                        "version" => "#0B3D62",
+                        _ => "#0A3656",
+                    });
             border.BorderBrush = Brush.Parse(
                 selected
                     ? "#FFFFFF"
-                    : tag.Type == "version"
-                        ? "#4EA9CC"
-                        : "#397F9F");
+                    : tag.Type switch
+                    {
+                        "project" => "#65D2EF",
+                        "version" => "#4EA9CC",
+                        _ => "#397F9F",
+                    });
         }
     }
 
     private void RenderGraph()
     {
         Surface.Children.Clear();
+        _nodes.Clear();
         _connections.Clear();
+        _alignmentGuideVisuals.Clear();
         DrawGrid();
 
         if (_viewModel is null)
@@ -260,6 +291,7 @@ public partial class BlueprintCanvasSurface : UserControl
             new Point(48, Math.Max(310, Surface.Height / 2 - 70)));
         Place(projectNode, projectPoint);
         Surface.Children.Add(projectNode);
+        RegisterNode(projectNode);
 
         var globalItemIndex = 0;
         for (var versionIndex = 0; versionIndex < _viewModel.Versions.Count; versionIndex++)
@@ -271,6 +303,7 @@ public partial class BlueprintCanvasSurface : UserControl
             var versionNode = CreateVersionNode(version);
             Place(versionNode, versionPoint);
             Surface.Children.Add(versionNode);
+            RegisterNode(versionNode);
             AddConnection(projectNode, versionNode, "#52C7E8", 2);
 
             foreach (var item in version.Items)
@@ -281,6 +314,7 @@ public partial class BlueprintCanvasSurface : UserControl
                 var itemNode = CreateItemNode(version, item);
                 Place(itemNode, itemPoint);
                 Surface.Children.Add(itemNode);
+                RegisterNode(itemNode);
                 AddConnection(versionNode, itemNode, item.IsDone ? "#5DD6B2" : "#73AFCF", item.IsDone ? 2 : 1.25);
                 globalItemIndex++;
             }
@@ -290,6 +324,14 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             Surface.Children.Insert(FindGridVisualCount(), connection.Line);
             UpdateConnection(connection);
+        }
+
+        var selectionChanged = _selectedNodeIds.RemoveWhere(id => !_nodes.ContainsKey(id)) > 0;
+        UpdateSelectionVisuals();
+        RenderMiniMap();
+        if (selectionChanged)
+        {
+            NotifySelectionStateChanged();
         }
 
         if (_viewModel.Versions.Count == 0)
@@ -304,6 +346,14 @@ public partial class BlueprintCanvasSurface : UserControl
             };
             Place(empty, new Point(360, 330));
             Surface.Children.Add(empty);
+        }
+    }
+
+    private void RegisterNode(Control node)
+    {
+        if (node.Tag is NodeTag { Id: Guid nodeId })
+        {
+            _nodes[nodeId] = node;
         }
     }
 
@@ -487,15 +537,25 @@ public partial class BlueprintCanvasSurface : UserControl
             PointerPressedEvent,
             (_, eventArgs) =>
             {
-                if (_viewModel?.CanMutateWorkspace != true)
+                if (!eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
+                {
+                    return;
+                }
+
+                UpdateNodeSelection(nodeId, eventArgs.KeyModifiers);
+                Focus();
+                eventArgs.Handled = true;
+                if (_viewModel?.CanMutateWorkspace != true || !_selectedNodeIds.Contains(nodeId))
                 {
                     return;
                 }
 
                 _draggedNode = node;
                 _dragStartLayout = CaptureLayout();
-                var pointer = eventArgs.GetPosition(Surface);
-                _dragOffset = new Point(pointer.X - Canvas.GetLeft(node), pointer.Y - Canvas.GetTop(node));
+                _dragStartPointer = eventArgs.GetPosition(Surface);
+                _dragStartPositions = _selectedNodeIds
+                    .Where(_positions.ContainsKey)
+                    .ToDictionary(id => id, id => _positions[id]);
                 eventArgs.Pointer.Capture(node);
             },
             RoutingStrategies.Tunnel);
@@ -509,12 +569,16 @@ public partial class BlueprintCanvasSurface : UserControl
             }
 
             var pointer = eventArgs.GetPosition(Surface);
-            var point = new Point(
-                Math.Clamp(pointer.X - _dragOffset.X, 0, Surface.Width - node.Bounds.Width),
-                Math.Clamp(pointer.Y - _dragOffset.Y, 0, Surface.Height - node.Bounds.Height));
-            Place(node, point);
-            _positions[nodeId] = point;
-            UpdateConnections(node);
+            var requestedDelta = pointer - _dragStartPointer;
+            var selectedBounds = GetNodeBounds(_dragStartPositions);
+            var constrained = CanvasSelectionService.ConstrainMove(
+                selectedBounds,
+                requestedDelta.X,
+                requestedDelta.Y,
+                Surface.Width,
+                Surface.Height);
+            MoveNodesFromOrigins(_dragStartPositions, constrained.DeltaX, constrained.DeltaY);
+            RenderAlignmentGuides();
         };
         node.PointerReleased += (_, eventArgs) =>
         {
@@ -530,8 +594,68 @@ public partial class BlueprintCanvasSurface : UserControl
                 }
 
                 _dragStartLayout = null;
+                _dragStartPositions = new Dictionary<Guid, Point>();
+                ClearAlignmentGuides();
             }
         };
+    }
+
+    private void UpdateNodeSelection(Guid nodeId, KeyModifiers modifiers)
+    {
+        var additive = modifiers.HasFlag(KeyModifiers.Control)
+            || modifiers.HasFlag(KeyModifiers.Shift);
+        if (additive)
+        {
+            if (!_selectedNodeIds.Add(nodeId))
+            {
+                _selectedNodeIds.Remove(nodeId);
+            }
+        }
+        else if (!_selectedNodeIds.Contains(nodeId))
+        {
+            _selectedNodeIds.Clear();
+            _selectedNodeIds.Add(nodeId);
+        }
+
+        UpdateSelectionVisuals();
+        NotifySelectionStateChanged();
+    }
+
+    private IReadOnlyList<CanvasNodeBounds> GetNodeBounds(
+        IReadOnlyDictionary<Guid, Point>? positions = null) =>
+        _nodes
+            .Where(pair => positions is null || positions.ContainsKey(pair.Key))
+            .Select(pair =>
+            {
+                var point = positions is null ? _positions[pair.Key] : positions[pair.Key];
+                return new CanvasNodeBounds(
+                    pair.Key,
+                    point.X,
+                    point.Y,
+                    pair.Value.Width,
+                    pair.Value.Height);
+            })
+            .ToArray();
+
+    private void MoveNodesFromOrigins(
+        IReadOnlyDictionary<Guid, Point> origins,
+        double deltaX,
+        double deltaY)
+    {
+        foreach (var (id, origin) in origins)
+        {
+            if (!_nodes.TryGetValue(id, out var selectedNode))
+            {
+                continue;
+            }
+
+            var point = new Point(origin.X + deltaX, origin.Y + deltaY);
+            Place(selectedNode, point);
+            _positions[id] = point;
+            UpdateConnections(selectedNode);
+        }
+
+        RenderMiniMap();
     }
 
     private void RestoreLayout()
@@ -581,6 +705,7 @@ public partial class BlueprintCanvasSurface : UserControl
 
     private void HandleViewportScrollChanged(object? sender, ScrollChangedEventArgs eventArgs)
     {
+        RenderMiniMap();
         if (_isRestoringLayout || _viewModel is null)
         {
             return;
@@ -598,46 +723,115 @@ public partial class BlueprintCanvasSurface : UserControl
 
     private void HandleSurfacePointerPressed(object? sender, PointerPressedEventArgs eventArgs)
     {
-        if (!eventArgs.GetCurrentPoint(Surface).Properties.IsMiddleButtonPressed)
+        var properties = eventArgs.GetCurrentPoint(Surface).Properties;
+        Focus();
+        if (properties.IsMiddleButtonPressed)
         {
-            Focus();
+            _isPanning = true;
+            _panStart = eventArgs.GetPosition(Viewport);
+            _panOrigin = Viewport.Offset;
+            Surface.Cursor = new Cursor(StandardCursorType.SizeAll);
+            eventArgs.Pointer.Capture(Surface);
+            eventArgs.Handled = true;
             return;
         }
 
-        _isPanning = true;
-        _panStart = eventArgs.GetPosition(Viewport);
-        _panOrigin = Viewport.Offset;
-        Surface.Cursor = new Cursor(StandardCursorType.SizeAll);
+        if (!properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var additive = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        _selectionBeforeBox = additive
+            ? _selectedNodeIds.ToHashSet()
+            : new HashSet<Guid>();
+        if (!additive)
+        {
+            _selectedNodeIds.Clear();
+        }
+
+        _isBoxSelecting = true;
+        _boxSelectionStart = eventArgs.GetPosition(Surface);
+        _boxSelectionVisual = new Rectangle
+        {
+            Fill = Brush.Parse("#3365D2EF"),
+            Stroke = Brush.Parse("#8BE6F7"),
+            StrokeThickness = 1.5,
+            IsHitTestVisible = false,
+        };
+        Place(_boxSelectionVisual, _boxSelectionStart);
+        Surface.Children.Add(_boxSelectionVisual);
         eventArgs.Pointer.Capture(Surface);
+        UpdateSelectionVisuals();
+        NotifySelectionStateChanged();
         eventArgs.Handled = true;
     }
 
     private void HandleSurfacePointerMoved(object? sender, PointerEventArgs eventArgs)
     {
-        if (!_isPanning)
+        if (_isPanning)
+        {
+            var current = eventArgs.GetPosition(Viewport);
+            var delta = current - _panStart;
+            Viewport.Offset = new Vector(
+                Math.Max(0, _panOrigin.X - delta.X),
+                Math.Max(0, _panOrigin.Y - delta.Y));
+            eventArgs.Handled = true;
+            return;
+        }
+
+        if (!_isBoxSelecting || _boxSelectionVisual is null)
         {
             return;
         }
 
-        var current = eventArgs.GetPosition(Viewport);
-        var delta = current - _panStart;
-        Viewport.Offset = new Vector(
-            Math.Max(0, _panOrigin.X - delta.X),
-            Math.Max(0, _panOrigin.Y - delta.Y));
+        var currentSelectionPoint = eventArgs.GetPosition(Surface);
+        var selection = new CanvasSelectionBounds(
+            _boxSelectionStart.X,
+            _boxSelectionStart.Y,
+            currentSelectionPoint.X,
+            currentSelectionPoint.Y);
+        Canvas.SetLeft(_boxSelectionVisual, selection.Left);
+        Canvas.SetTop(_boxSelectionVisual, selection.Top);
+        _boxSelectionVisual.Width = selection.Right - selection.Left;
+        _boxSelectionVisual.Height = selection.Bottom - selection.Top;
+
+        _selectedNodeIds.Clear();
+        _selectedNodeIds.UnionWith(_selectionBeforeBox);
+        _selectedNodeIds.UnionWith(
+            CanvasSelectionService.SelectIntersecting(GetNodeBounds(), selection));
+        UpdateSelectionVisuals();
+        NotifySelectionStateChanged();
         eventArgs.Handled = true;
     }
 
     private void HandleSurfacePointerReleased(object? sender, PointerReleasedEventArgs eventArgs)
     {
-        if (!_isPanning)
+        if (_isPanning)
+        {
+            _isPanning = false;
+            Surface.Cursor = Cursor.Default;
+            eventArgs.Pointer.Capture(null);
+            PersistViewState();
+            eventArgs.Handled = true;
+            return;
+        }
+
+        if (!_isBoxSelecting)
         {
             return;
         }
 
-        _isPanning = false;
-        Surface.Cursor = Cursor.Default;
+        _isBoxSelecting = false;
+        if (_boxSelectionVisual is not null)
+        {
+            Surface.Children.Remove(_boxSelectionVisual);
+            _boxSelectionVisual = null;
+        }
+
         eventArgs.Pointer.Capture(null);
-        PersistViewState();
+        _selectionBeforeBox = new HashSet<Guid>();
         eventArgs.Handled = true;
     }
 
@@ -685,12 +879,168 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             ZoomOut();
         }
+        else if (control && eventArgs.Key == Key.A)
+        {
+            _selectedNodeIds.Clear();
+            _selectedNodeIds.UnionWith(_nodes.Keys);
+            UpdateSelectionVisuals();
+            NotifySelectionStateChanged();
+        }
+        else if (!control && eventArgs.Key is Key.Left or Key.Right or Key.Up or Key.Down)
+        {
+            var distance = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift) ? 10 : 1;
+            var delta = eventArgs.Key switch
+            {
+                Key.Left => new Vector(-distance, 0),
+                Key.Right => new Vector(distance, 0),
+                Key.Up => new Vector(0, -distance),
+                _ => new Vector(0, distance),
+            };
+            MoveSelectedNodes(delta);
+        }
+        else if (eventArgs.Key == Key.Escape)
+        {
+            _selectedNodeIds.Clear();
+            UpdateSelectionVisuals();
+            NotifySelectionStateChanged();
+        }
         else
         {
             return;
         }
 
         eventArgs.Handled = true;
+    }
+
+    private void MoveSelectedNodes(Vector requestedDelta)
+    {
+        if (_viewModel?.CanMutateWorkspace != true || _selectedNodeIds.Count == 0)
+        {
+            return;
+        }
+
+        var previous = CaptureLayout();
+        var origins = _selectedNodeIds
+            .Where(id => _nodes.ContainsKey(id) && _positions.ContainsKey(id))
+            .ToDictionary(id => id, id => _positions[id]);
+        var selectedBounds = GetNodeBounds(origins);
+        var constrained = CanvasSelectionService.ConstrainMove(
+            selectedBounds,
+            requestedDelta.X,
+            requestedDelta.Y,
+            Surface.Width,
+            Surface.Height);
+        MoveNodesFromOrigins(origins, constrained.DeltaX, constrained.DeltaY);
+        if (_layoutHistory.Record(previous, CaptureLayout()))
+        {
+            NotifyHistoryStateChanged();
+            PersistLayout();
+        }
+    }
+
+    private void RenderAlignmentGuides()
+    {
+        ClearAlignmentGuides();
+        var allBounds = GetNodeBounds();
+        var moving = allBounds
+            .Where(node => _selectedNodeIds.Contains(node.EntityId))
+            .ToArray();
+        var stationary = allBounds
+            .Where(node => !_selectedNodeIds.Contains(node.EntityId))
+            .ToArray();
+        var guides = CanvasSelectionService.FindAlignmentGuides(moving, stationary);
+        foreach (var x in guides.Vertical)
+        {
+            AddAlignmentGuide(new Point(x, 0), new Point(x, Surface.Height));
+        }
+
+        foreach (var y in guides.Horizontal)
+        {
+            AddAlignmentGuide(new Point(0, y), new Point(Surface.Width, y));
+        }
+    }
+
+    private void AddAlignmentGuide(Point start, Point end)
+    {
+        var line = new Line
+        {
+            StartPoint = start,
+            EndPoint = end,
+            Stroke = Brush.Parse("#F2C66D"),
+            StrokeThickness = 1,
+            StrokeDashArray = [5, 4],
+            IsHitTestVisible = false,
+        };
+        _alignmentGuideVisuals.Add(line);
+        Surface.Children.Add(line);
+    }
+
+    private void ClearAlignmentGuides()
+    {
+        foreach (var line in _alignmentGuideVisuals)
+        {
+            Surface.Children.Remove(line);
+        }
+
+        _alignmentGuideVisuals.Clear();
+    }
+
+    private void RenderMiniMap()
+    {
+        if (MiniMapSurface is null || Surface is null)
+        {
+            return;
+        }
+
+        MiniMapSurface.Children.Clear();
+        if (Surface.Width <= 0 || Surface.Height <= 0)
+        {
+            return;
+        }
+
+        var scale = Math.Min(MiniMapSurface.Width / Surface.Width, MiniMapSurface.Height / Surface.Height);
+        foreach (var (id, node) in _nodes)
+        {
+            if (!_positions.TryGetValue(id, out var point))
+            {
+                continue;
+            }
+
+            var tag = node.Tag as NodeTag;
+            var preview = new Rectangle
+            {
+                Width = Math.Max(3, node.Width * scale),
+                Height = Math.Max(2, node.Height * scale),
+                Fill = Brush.Parse(
+                    _selectedNodeIds.Contains(id)
+                        ? "#F2C66D"
+                        : tag?.Type switch
+                        {
+                            "project" => "#65D2EF",
+                            "version" => "#4EA9CC",
+                            _ => "#5DD6B2",
+                        }),
+                IsHitTestVisible = false,
+            };
+            Place(preview, new Point(point.X * scale, point.Y * scale));
+            MiniMapSurface.Children.Add(preview);
+        }
+
+        var viewport = new Rectangle
+        {
+            Width = Math.Clamp(Viewport.Viewport.Width / _zoom * scale, 2, MiniMapSurface.Width),
+            Height = Math.Clamp(Viewport.Viewport.Height / _zoom * scale, 2, MiniMapSurface.Height),
+            Stroke = Brushes.White,
+            StrokeThickness = 1,
+            Fill = Brush.Parse("#16FFFFFF"),
+            IsHitTestVisible = false,
+        };
+        Place(
+            viewport,
+            new Point(
+                Math.Clamp(Viewport.Offset.X / _zoom * scale, 0, MiniMapSurface.Width - viewport.Width),
+                Math.Clamp(Viewport.Offset.Y / _zoom * scale, 0, MiniMapSurface.Height - viewport.Height)));
+        MiniMapSurface.Children.Add(viewport);
     }
 
     private void PersistLayout()
@@ -763,6 +1113,9 @@ public partial class BlueprintCanvasSurface : UserControl
 
     private void NotifyHistoryStateChanged() =>
         HistoryStateChanged?.Invoke(this, EventArgs.Empty);
+
+    private void NotifySelectionStateChanged() =>
+        SelectionStateChanged?.Invoke(this, EventArgs.Empty);
 
     private void PersistViewState()
     {

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -137,6 +137,7 @@
                 <StackPanel Spacing="3">
                   <TextBlock Text="{Binding SelectedSourceProposal.Kind}" Classes="eyebrow" />
                   <TextBlock Text="{Binding SelectedSourceProposal.SourceReference}" Classes="mono muted" FontSize="10" />
+                  <TextBlock Text="{Binding SelectedSourceProposal.ProviderReferenceSummary}" Classes="muted" FontSize="10" TextWrapping="Wrap" />
                 </StackPanel>
                 <CheckBox Grid.Column="1"
                           Content="Approved"

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -30,16 +30,19 @@
     <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
       <Border Classes="card" Padding="12,8">
         <StackPanel Orientation="Horizontal" Spacing="8">
-          <TextBlock Text="REPOSITORY" Classes="eyebrow" VerticalAlignment="Center" />
+          <TextBlock Text="REPOSITORIES" Classes="eyebrow" VerticalAlignment="Center" />
           <TextBlock Text="read-only" Foreground="#277A67" FontSize="11" FontWeight="Bold" VerticalAlignment="Center" />
         </StackPanel>
       </Border>
       <TextBox Grid.Column="1"
                Text="{Binding LocalGitRepositoryPath}"
-               PlaceholderText="/path/to/repository" />
+               AcceptsReturn="True"
+               MinHeight="58"
+               VerticalContentAlignment="Top"
+               PlaceholderText="One local Git worktree path per line" />
       <Button Grid.Column="2"
               Classes="secondary"
-              Content="Save link"
+              Content="Save links"
               Command="{Binding SaveLocalGitRepositoryPathCommand}" />
     </Grid>
 

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -143,7 +143,11 @@
             <StackPanel Spacing="4">
               <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
               <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#6DD6EF" FontSize="10" />
-              <TextBlock Text="Drag nodes · Ctrl+Z / Ctrl+Shift+Z undo/redo · Middle-drag to pan · Ctrl+wheel to zoom"
+              <TextBlock x:Name="CanvasSelectionSummary"
+                         Foreground="#D7EEF7"
+                         FontSize="10"
+                         FontWeight="Bold" />
+              <TextBlock Text="Drag empty space to box-select · Ctrl/Shift-click adds nodes · arrows move · Shift+arrows move 10px · Ctrl+A selects all · Esc clears"
                          Foreground="#8FBAD0"
                          FontSize="10"
                          TextWrapping="Wrap" />

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -9,7 +9,9 @@ public partial class OverviewView : UserControl
     {
         InitializeComponent();
         BlueprintSurface.HistoryStateChanged += (_, _) => UpdateHistoryButtons();
+        BlueprintSurface.SelectionStateChanged += (_, _) => UpdateSelectionSummary();
         UpdateHistoryButtons();
+        UpdateSelectionSummary();
     }
 
     private void UndoClick(object? sender, RoutedEventArgs eventArgs) =>
@@ -38,4 +40,7 @@ public partial class OverviewView : UserControl
         UndoButton.IsEnabled = BlueprintSurface.CanUndo;
         RedoButton.IsEnabled = BlueprintSurface.CanRedo;
     }
+
+    private void UpdateSelectionSummary() =>
+        CanvasSelectionSummary.Text = BlueprintSurface.SelectionSummary;
 }

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml
@@ -132,6 +132,40 @@
           </Grid>
         </Border>
 
+        <Border Classes="card">
+          <StackPanel Spacing="10">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+              <StackPanel Spacing="3">
+                <TextBlock Classes="eyebrow" Text="RELEASE READINESS" />
+                <TextBlock Text="{Binding ReleaseReadinessSummary}" FontSize="17" FontWeight="Bold" TextWrapping="Wrap" />
+              </StackPanel>
+              <Button Grid.Column="1"
+                      Classes="secondary"
+                      Content="Open Source Lens"
+                      Command="{Binding NavigateToIntegrationsCommand}" />
+            </Grid>
+            <ItemsControl ItemsSource="{Binding ReleaseReadinessDiagnostics}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="models:ReleaseReadinessDiagnostic">
+                  <Border Background="#F3F9FC"
+                          BorderBrush="#BED8E8"
+                          BorderThickness="1"
+                          CornerRadius="4"
+                          Padding="11"
+                          Margin="0,0,0,6">
+                    <Grid ColumnDefinitions="90,220,*,*" ColumnSpacing="10">
+                      <TextBlock Text="{Binding Level}" Classes="eyebrow" VerticalAlignment="Top" />
+                      <TextBlock Grid.Column="1" Text="{Binding Title}" FontWeight="Bold" TextWrapping="Wrap" />
+                      <TextBlock Grid.Column="2" Text="{Binding Detail}" Classes="muted" TextWrapping="Wrap" />
+                      <TextBlock Grid.Column="3" Text="{Binding Guidance}" Foreground="#0B5D8B" TextWrapping="Wrap" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </StackPanel>
+        </Border>
+
         <Grid ColumnDefinitions="340,*" ColumnSpacing="16">
           <Border Classes="card">
             <StackPanel Spacing="10">

--- a/Blueprints.Tests/CanvasSelectionServiceTests.cs
+++ b/Blueprints.Tests/CanvasSelectionServiceTests.cs
@@ -1,0 +1,65 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class CanvasSelectionServiceTests
+{
+    [Fact]
+    public void SelectIntersecting_NormalizesDragDirectionAndIncludesPartialIntersections()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var outside = Guid.NewGuid();
+        CanvasNodeBounds[] nodes =
+        [
+            new(first, 20, 20, 100, 80),
+            new(second, 180, 100, 100, 80),
+            new(outside, 400, 400, 100, 80),
+        ];
+
+        var selected = CanvasSelectionService.SelectIntersecting(
+            nodes,
+            new CanvasSelectionBounds(250, 150, 80, 60));
+
+        Assert.Equal(2, selected.Count);
+        Assert.Contains(first, selected);
+        Assert.Contains(second, selected);
+        Assert.DoesNotContain(outside, selected);
+    }
+
+    [Fact]
+    public void ConstrainMove_KeepsTheWholeSelectionInsideTheSurface()
+    {
+        CanvasNodeBounds[] nodes =
+        [
+            new(Guid.NewGuid(), 10, 20, 100, 80),
+            new(Guid.NewGuid(), 250, 220, 120, 90),
+        ];
+
+        var towardTopLeft = CanvasSelectionService.ConstrainMove(nodes, -50, -50, 400, 340);
+        var towardBottomRight = CanvasSelectionService.ConstrainMove(nodes, 100, 100, 400, 340);
+
+        Assert.Equal((-10d, -20d), towardTopLeft);
+        Assert.Equal((30d, 30d), towardBottomRight);
+    }
+
+    [Fact]
+    public void FindAlignmentGuides_MatchesEdgesAndCentersWithinTolerance()
+    {
+        CanvasNodeBounds[] moving =
+        [
+            new(Guid.NewGuid(), 98, 48, 100, 80),
+        ];
+        CanvasNodeBounds[] stationary =
+        [
+            new(Guid.NewGuid(), 100, 50, 100, 80),
+            new(Guid.NewGuid(), 500, 500, 100, 80),
+        ];
+
+        var guides = CanvasSelectionService.FindAlignmentGuides(moving, stationary);
+
+        Assert.Equal([100d, 150d, 200d], guides.Vertical);
+        Assert.Equal([50d, 90d, 130d], guides.Horizontal);
+    }
+}

--- a/Blueprints.Tests/GitHubSourceJsonParserTests.cs
+++ b/Blueprints.Tests/GitHubSourceJsonParserTests.cs
@@ -1,0 +1,84 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class GitHubSourceJsonParserTests
+{
+    [Fact]
+    public void ParsePullRequests_ProducesProviderNeutralReferencesAndCompletion()
+    {
+        var candidates = GitHubSourceJsonParser.ParsePullRequests(
+            """
+            [
+              {
+                "number": 42,
+                "title": "Fix release check",
+                "body": "Make readiness explicit.",
+                "state": "MERGED",
+                "labels": [{ "name": "bug" }],
+                "url": "https://github.com/example/project/pull/42",
+                "mergedAt": "2026-07-30T10:00:00Z"
+              }
+            ]
+            """,
+            "example/project");
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal(SourceArtifactKind.PullRequest, candidate.Kind);
+        Assert.True(candidate.IsDone);
+        Assert.Equal("bug", candidate.SuggestedItemTypeId);
+        Assert.Equal("fixed", candidate.SuggestedCategoryId);
+        var reference = Assert.IsType<ProviderReference>(candidate.ProviderReference);
+        Assert.Equal(SourceProviderKind.GitHub, reference.Provider);
+        Assert.Equal(ProviderReferenceKind.PullRequest, reference.Kind);
+        Assert.Equal("example/project", reference.Repository);
+        Assert.Equal("#42", reference.Identifier);
+    }
+
+    [Fact]
+    public void ParseReleases_DistinguishesDraftAndPublishedRecords()
+    {
+        var candidates = GitHubSourceJsonParser.ParseReleases(
+            """
+            [
+              {
+                "tagName": "v0.4.0-alpha.4",
+                "name": "Alpha 4",
+                "isDraft": true,
+                "isPrerelease": true,
+                "publishedAt": null,
+                "url": "https://github.com/example/project/releases/tag/v0.4.0-alpha.4"
+              },
+              {
+                "tagName": "v0.3.0",
+                "name": "",
+                "isDraft": false,
+                "isPrerelease": true,
+                "publishedAt": "2026-07-30T10:00:00Z"
+              }
+            ]
+            """,
+            "example/project");
+
+        Assert.Collection(
+            candidates,
+            draft =>
+            {
+                Assert.Equal(SourceArtifactKind.Release, draft.Kind);
+                Assert.False(draft.IsDone);
+                Assert.Equal("Alpha 4", draft.Title);
+            },
+            published =>
+            {
+                Assert.True(published.IsDone);
+                Assert.Equal("v0.3.0", published.Title);
+                var reference = Assert.IsType<ProviderReference>(published.ProviderReference);
+                Assert.Equal(ProviderReferenceKind.Release, reference.Kind);
+                Assert.Equal("v0.3.0", reference.Identifier);
+                Assert.Equal(
+                    "https://github.com/example/project/releases/tag/v0.3.0",
+                    reference.WebUrl);
+            });
+    }
+}

--- a/Blueprints.Tests/GitHubSourceJsonParserTests.cs
+++ b/Blueprints.Tests/GitHubSourceJsonParserTests.cs
@@ -6,6 +6,59 @@ namespace Blueprints.Tests;
 public sealed class GitHubSourceJsonParserTests
 {
     [Fact]
+    public void ParseProjectDrafts_ReturnsOnlyStandaloneDraftItems()
+    {
+        var candidates = GitHubSourceJsonParser.ParseProjectDrafts(
+            """
+            {
+              "data": {
+                "repository": {
+                  "projectsV2": {
+                    "nodes": [
+                      {
+                        "number": 8,
+                        "title": "Blueprints Roadmap",
+                        "url": "https://github.com/users/example/projects/8",
+                        "items": {
+                          "nodes": [
+                            {
+                              "id": "draft-1",
+                              "type": "DRAFT_ISSUE",
+                              "content": {
+                                "__typename": "DraftIssue",
+                                "title": "Design offline provider cache",
+                                "body": "Keep the source boundary explicit."
+                              }
+                            },
+                            {
+                              "id": "issue-1",
+                              "type": "ISSUE",
+                              "content": {
+                                "__typename": "Issue",
+                                "number": 42
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """,
+            "example/project");
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal(SourceArtifactKind.GitHubProject, candidate.Kind);
+        Assert.Equal("Design offline provider cache", candidate.Title);
+        Assert.False(candidate.IsDone);
+        var reference = Assert.IsType<ProviderReference>(candidate.ProviderReference);
+        Assert.Equal(ProviderReferenceKind.Project, reference.Kind);
+        Assert.Equal("8/draft/draft-1", reference.Identifier);
+    }
+
+    [Fact]
     public void ParsePullRequests_ProducesProviderNeutralReferencesAndCompletion()
     {
         var candidates = GitHubSourceJsonParser.ParsePullRequests(

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -77,7 +77,7 @@ public sealed class IntegrationStatusServiceTests
             .Single(status => status.Provider == IntegrationProviderType.LocalGit);
 
         Assert.Equal(IntegrationConnectionState.Connected, localGit.State);
-        Assert.Equal("/repo", localGit.Target);
+        Assert.Equal(Path.GetFullPath("/repo"), localGit.Target);
         Assert.Contains("main", localGit.Summary, StringComparison.Ordinal);
         Assert.Contains("v1.0.0", localGit.Summary, StringComparison.Ordinal);
         Assert.Single(localGit.RecentChanges);
@@ -130,7 +130,9 @@ public sealed class IntegrationStatusServiceTests
             .ToArray();
 
         Assert.Equal(2, localGit.Length);
-        Assert.Equal(["/repo-a", "/repo-b"], localGit.Select(static status => status.Target));
+        Assert.Equal(
+            [Path.GetFullPath("/repo-a"), Path.GetFullPath("/repo-b")],
+            localGit.Select(static status => status.Target));
         Assert.All(localGit, status => Assert.Equal(IntegrationConnectionState.Connected, status.State));
     }
 

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -106,6 +106,34 @@ public sealed class IntegrationStatusServiceTests
         Assert.Contains("uncommitted", localGit.Guidance, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void GetIntegrationStatuses_InspectsEveryDistinctLinkedRepository()
+    {
+        var settings = new IntegrationSettings("/repo-a", string.Empty)
+        {
+            LocalGitRepositoryPaths = ["/repo-a", "/repo-b"],
+        };
+        var service = CreateService(
+            settings,
+            new LocalGitRepositoryStatus(
+                true,
+                string.Empty,
+                "main",
+                "(no origin remote)",
+                false,
+                "(no tags)",
+                [],
+                "Repository working tree is clean."));
+
+        var localGit = service.GetIntegrationStatuses()
+            .Where(status => status.Provider == IntegrationProviderType.LocalGit)
+            .ToArray();
+
+        Assert.Equal(2, localGit.Length);
+        Assert.Equal(["/repo-a", "/repo-b"], localGit.Select(static status => status.Target));
+        Assert.All(localGit, status => Assert.Equal(IntegrationConnectionState.Connected, status.State));
+    }
+
     private static IntegrationStatusService CreateService(
         IntegrationSettings settings,
         LocalGitRepositoryStatus? gitStatus = null) =>
@@ -137,14 +165,16 @@ public sealed class IntegrationStatusServiceTests
         }
 
         public LocalGitRepositoryStatus Inspect(string repositoryPath) =>
-            _status ?? new LocalGitRepositoryStatus(
-                false,
-                repositoryPath,
-                string.Empty,
-                string.Empty,
-                false,
-                string.Empty,
-                [],
-                "Configured path is not a Git repository.");
+            _status is null
+                ? new LocalGitRepositoryStatus(
+                    false,
+                    repositoryPath,
+                    string.Empty,
+                    string.Empty,
+                    false,
+                    string.Empty,
+                    [],
+                    "Configured path is not a Git repository.")
+                : _status with { RepositoryRoot = repositoryPath };
     }
 }

--- a/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
+++ b/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
@@ -33,6 +33,10 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
                 Assert.False(first.IsDone);
                 Assert.Equal("feature", first.SuggestedItemTypeId);
                 Assert.Equal("Canvas interaction", first.SourceContext);
+                var reference = Assert.IsType<ProviderReference>(first.ProviderReference);
+                Assert.Equal(SourceProviderKind.Local, reference.Provider);
+                Assert.Equal(ProviderReferenceKind.PlanningDocument, reference.Kind);
+                Assert.Equal("Roadmap.md:3", reference.Identifier);
             },
             second =>
             {

--- a/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
+++ b/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Blueprints.App.Models;
 using Blueprints.App.Services;
 
@@ -109,6 +110,27 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
             static warning => warning.Contains("GitHub", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Discover_UsesTheProviderNeutralHostedReaderBoundary()
+    {
+        Directory.CreateDirectory(_root);
+        RunGit("init", _root);
+        RunGit("-C", _root, "remote", "add", "origin", "https://github.com/example/project.git");
+        var hostedReader = new TestHostedSourceProviderReader();
+        var service = new RepositorySourceDiscoveryService(
+            new MarkdownSourceDiscoveryParser(),
+            hostedReader);
+
+        var result = service.Discover(_root);
+
+        Assert.Equal("example/project", hostedReader.RepositoryName);
+        Assert.Equal(_root, hostedReader.RepositoryRoot);
+        Assert.Equal(1, result.PullRequestCount);
+        Assert.Contains(
+            result.Candidates,
+            static candidate => candidate.Kind == SourceArtifactKind.PullRequest);
+    }
+
     private string Write(string name, string content)
     {
         Directory.CreateDirectory(_root);
@@ -117,11 +139,69 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
         return path;
     }
 
+    private static void RunGit(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start Git for the test.");
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, error);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root))
         {
             Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private sealed class TestHostedSourceProviderReader : IHostedSourceProviderReader
+    {
+        public string RepositoryRoot { get; private set; } = string.Empty;
+
+        public string RepositoryName { get; private set; } = string.Empty;
+
+        public HostedSourceDiscoveryResult Read(
+            string repositoryRoot,
+            string repositoryName)
+        {
+            RepositoryRoot = repositoryRoot;
+            RepositoryName = repositoryName;
+            return new HostedSourceDiscoveryResult(
+                [
+                    new SourceDiscoveryCandidate(
+                        SourceArtifactKind.PullRequest,
+                        "Provider-neutral reader",
+                        null,
+                        "feature",
+                        "added",
+                        false,
+                        "test:pr:1",
+                        "Test pull request",
+                        1,
+                        new ProviderReference(
+                            SourceProviderKind.GitHub,
+                            ProviderReferenceKind.PullRequest,
+                            repositoryName,
+                            "#1",
+                            null)),
+                ],
+                [],
+                0,
+                0,
+                1,
+                0);
         }
     }
 }

--- a/Blueprints.Tests/ReleaseReadinessDiagnosticBuilderTests.cs
+++ b/Blueprints.Tests/ReleaseReadinessDiagnosticBuilderTests.cs
@@ -1,0 +1,96 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+using Blueprints.Core.Enums;
+
+namespace Blueprints.Tests;
+
+public sealed class ReleaseReadinessDiagnosticBuilderTests
+{
+    [Fact]
+    public void Build_BlocksDirtyRepositoryAndCallsOutUnmatchedChanges()
+    {
+        var version = CreateVersion(
+            new WorkspaceItemCard(Guid.NewGuid(), "BP-10", "Done", string.Empty, "feature", "added", true),
+            new WorkspaceItemCard(Guid.NewGuid(), "BP-11", "Open", string.Empty, "feature", "added", false));
+        var change = new SourceChangeSummary(
+            "abcdef123",
+            "abcdef1",
+            "Refactor internal pipeline",
+            "Flavio",
+            DateTimeOffset.UtcNow,
+            []);
+        var sourceDiagnostic = new VersionSourceChangeDiagnostic(change, [], false);
+
+        var diagnostics = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Warning, [change]),
+            [sourceDiagnostic]);
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Level == ReleaseReadinessLevel.Blocking
+                && diagnostic.Title.Contains("uncommitted", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Title.Contains("unmatched", StringComparison.OrdinalIgnoreCase)
+                && diagnostic.Detail.Contains("abcdef1", StringComparison.Ordinal));
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Title.Contains("Incomplete", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ReturnsReadyWhenRepositoryIsCleanAndEveryChangeMatches()
+    {
+        var item = new WorkspaceItemCard(
+            Guid.NewGuid(),
+            "BP-10",
+            "Done",
+            string.Empty,
+            "feature",
+            "added",
+            true);
+        var version = CreateVersion(item);
+        var change = new SourceChangeSummary(
+            "abcdef123",
+            "abcdef1",
+            "BP-10 Finish readiness",
+            "Flavio",
+            DateTimeOffset.UtcNow,
+            ["BP-10"]);
+
+        var diagnostics = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, [change]),
+            [new VersionSourceChangeDiagnostic(change, ["BP-10"], true)]);
+
+        var ready = Assert.Single(diagnostics);
+        Assert.Equal(ReleaseReadinessLevel.Ready, ready.Level);
+    }
+
+    private static WorkspaceVersionCard CreateVersion(params WorkspaceItemCard[] items) =>
+        new(
+            Guid.NewGuid(),
+            "0.4.0",
+            ReleaseStatus.InProgress,
+            string.Empty,
+            items.Length,
+            items.Count(static item => item.IsDone),
+            items);
+
+    private static IntegrationStatusCard CreateLocalGit(
+        IntegrationConnectionState state,
+        IReadOnlyList<SourceChangeSummary> changes) =>
+        new(
+            IntegrationProviderType.LocalGit,
+            "Local Git",
+            state,
+            "/repo",
+            state == IntegrationConnectionState.Warning
+                ? "Repository has uncommitted changes."
+                : "Repository working tree is clean.",
+            "Review repository state.",
+            "Blueprints remains authoritative.",
+            DateTimeOffset.UtcNow,
+            changes);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Release-readiness diagnostics that surface unavailable or dirty repositories, incomplete items, missing post-tag history, and recent commits that do not map to completed items in the selected version.
 - Machine-local links for up to eight Git worktrees, with combined read-only health, source discovery, source trace, and release-readiness analysis.
 - A provider-neutral reference contract for planning documents, commits, issues, pull requests, releases, and project records across local Git, GitHub, and GitLab.
+- Bounded read-only discovery for up to 100 GitHub pull requests and 50 GitHub release records per linked repository, including merge/publication state and provider-neutral provenance.
 
 ### Changed
 
@@ -18,6 +19,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - The release planner now presents source-control blockers and follow-up guidance next to source trace and changelog review.
 - Source Lens accepts one repository path per line and preserves the full repository-qualified provenance of combined proposals.
 - Source Lens proposals now expose structured provider, repository, artifact kind, identifier, and optional web location instead of relying only on GitHub-specific display strings.
+- Combined Source Lens summaries now separate issue, pull-request, release, and project-linked proposal counts.
 
 ## 0.3.0 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Machine-local links for up to eight Git worktrees, with combined read-only health, source discovery, source trace, and release-readiness analysis.
 - A provider-neutral reference contract for planning documents, commits, issues, pull requests, releases, and project records across local Git, GitHub, and GitLab.
 - Bounded read-only discovery for up to 100 GitHub pull requests and 50 GitHub release records per linked repository, including merge/publication state and provider-neutral provenance.
+- Repository-linked GitHub Project discovery for standalone draft items through a bounded read-only GraphQL query covering at most 10 projects, 100 items per project, and 100 returned drafts.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 ### Added
 
 - Canvas box selection, additive multi-selection, grouped node dragging, `Ctrl+A`, `Escape`, precise arrow-key movement, live alignment guides, and a viewport minimap.
+- Release-readiness diagnostics that surface unavailable or dirty repositories, incomplete items, missing post-tag history, and recent commits that do not map to completed items in the selected version.
 
 ### Changed
 
 - Alpha 4 development builds now identify themselves as `0.4.0-alpha.4-dev`.
 - Canvas guidance now exposes the active selection and the available multi-node keyboard controls; resulting layout changes keep using signed, audited persistence.
+- The release planner now presents source-control blockers and follow-up guidance next to source trace and changelog review.
 
 ## 0.3.0 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - A provider-neutral reference contract for planning documents, commits, issues, pull requests, releases, and project records across local Git, GitHub, and GitLab.
 - Bounded read-only discovery for up to 100 GitHub pull requests and 50 GitHub release records per linked repository, including merge/publication state and provider-neutral provenance.
 - Repository-linked GitHub Project discovery for standalone draft items through a bounded read-only GraphQL query covering at most 10 projects, 100 items per project, and 100 returned drafts.
+- An injectable provider-neutral hosted-source reader boundary, keeping repository discovery and approval workflows independent from the current authenticated GitHub CLI implementation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Canvas box selection, additive multi-selection, grouped node dragging, `Ctrl+A`, `Escape`, precise arrow-key movement, live alignment guides, and a viewport minimap.
 - Release-readiness diagnostics that surface unavailable or dirty repositories, incomplete items, missing post-tag history, and recent commits that do not map to completed items in the selected version.
 - Machine-local links for up to eight Git worktrees, with combined read-only health, source discovery, source trace, and release-readiness analysis.
+- A provider-neutral reference contract for planning documents, commits, issues, pull requests, releases, and project records across local Git, GitHub, and GitLab.
 
 ### Changed
 
@@ -16,6 +17,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Canvas guidance now exposes the active selection and the available multi-node keyboard controls; resulting layout changes keep using signed, audited persistence.
 - The release planner now presents source-control blockers and follow-up guidance next to source trace and changelog review.
 - Source Lens accepts one repository path per line and preserves the full repository-qualified provenance of combined proposals.
+- Source Lens proposals now expose structured provider, repository, artifact kind, identifier, and optional web location instead of relying only on GitHub-specific display strings.
 
 ## 0.3.0 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 - Canvas box selection, additive multi-selection, grouped node dragging, `Ctrl+A`, `Escape`, precise arrow-key movement, live alignment guides, and a viewport minimap.
 - Release-readiness diagnostics that surface unavailable or dirty repositories, incomplete items, missing post-tag history, and recent commits that do not map to completed items in the selected version.
+- Machine-local links for up to eight Git worktrees, with combined read-only health, source discovery, source trace, and release-readiness analysis.
 
 ### Changed
 
 - Alpha 4 development builds now identify themselves as `0.4.0-alpha.4-dev`.
 - Canvas guidance now exposes the active selection and the available multi-node keyboard controls; resulting layout changes keep using signed, audited persistence.
 - The release planner now presents source-control blockers and follow-up guidance next to source trace and changelog review.
+- Source Lens accepts one repository path per line and preserves the full repository-qualified provenance of combined proposals.
 
 ## 0.3.0 — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- Canvas box selection, additive multi-selection, grouped node dragging, `Ctrl+A`, `Escape`, precise arrow-key movement, live alignment guides, and a viewport minimap.
+
+### Changed
+
+- Alpha 4 development builds now identify themselves as `0.4.0-alpha.4-dev`.
+- Canvas guidance now exposes the active selection and the available multi-node keyboard controls; resulting layout changes keep using signed, audited persistence.
 
 ## 0.3.0 — 2026-07-30
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionSuffix>alpha.4-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -60,13 +60,13 @@ Exit criteria:
 - conflicts explain what changed and produce a recoverable result;
 - membership changes cannot remove the last active administrator.
 
-## Later — v0.4: source-control awareness
+## In progress — v0.4: source-control awareness
 
 Goal: connect release intent to source history without weakening local ownership.
 
 - [x] Read local Git root, branch, remote, dirty state, tag, and recent commits.
 - [x] Match item keys in commit subjects for changelog context.
-- [ ] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
+- [x] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [ ] Link a Blueprints project to one or more repositories.
 - [ ] Add release-readiness diagnostics for uncommitted and unmatched changes.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -73,7 +73,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
 - [ ] Replace the CLI-backed reader with a provider-neutral authenticated adapter and add pull-request/release references.
-- [ ] Add standalone GitHub Project draft-item discovery.
+- [x] Add standalone GitHub Project draft-item discovery.
 - [ ] Define and separately approve any future provider write operations.
 - [ ] Add GitLab parity after the provider contract stabilizes.
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -69,7 +69,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [ ] Link a Blueprints project to one or more repositories.
-- [ ] Add release-readiness diagnostics for uncommitted and unmatched changes.
+- [x] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [ ] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
 - [ ] Replace the CLI-backed reader with a provider-neutral authenticated adapter and add pull-request/release references.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -70,7 +70,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Link a Blueprints project to one or more repositories.
 - [x] Add release-readiness diagnostics for uncommitted and unmatched changes.
-- [ ] Define provider-neutral issue, pull-request, and release references.
+- [x] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
 - [ ] Replace the CLI-backed reader with a provider-neutral authenticated adapter and add pull-request/release references.
 - [ ] Add standalone GitHub Project draft-item discovery.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -68,7 +68,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Match item keys in commit subjects for changelog context.
 - [x] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
 - [ ] Add user-created typed relationships after defining their domain and conflict semantics.
-- [ ] Link a Blueprints project to one or more repositories.
+- [x] Link a Blueprints project to one or more repositories.
 - [x] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [ ] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -72,7 +72,8 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [x] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
-- [ ] Replace the CLI-backed reader with a provider-neutral authenticated adapter and add pull-request/release references.
+- [x] Route hosted discovery through a provider-neutral reader contract and add pull-request/release references.
+- [ ] Replace the authenticated GitHub CLI implementation with a direct provider adapter.
 - [x] Add standalone GitHub Project draft-item discovery.
 - [ ] Define and separately approve any future provider write operations.
 - [ ] Add GitLab parity after the provider contract stabilizes.

--- a/docs/canvas-engine.md
+++ b/docs/canvas-engine.md
@@ -25,7 +25,12 @@ Changing a node title, state, category, or completion value uses the existing ve
 | --- | --- |
 | Click a version | Select it and open version fields in the inspector |
 | Click a work item | Select it, its owning version, and its item fields |
-| Drag a node | Move it and save a new signed layout revision on release |
+| Drag empty canvas | Draw a box that selects every intersecting node |
+| Ctrl/Shift-click a node | Add or remove it from the canvas selection |
+| Drag a selected node | Move the complete selection and save a new signed layout revision on release |
+| Arrow keys | Move selected nodes by one pixel and save the layout |
+| Shift+arrow keys | Move selected nodes by ten pixels and save the layout |
+| Ctrl+A / Escape | Select every node / clear the canvas selection |
 | Middle-drag empty canvas | Pan without changing shared node positions |
 | Scroll the canvas | Save machine-local viewport offsets after a short debounce |
 | Ctrl+mouse wheel or zoom buttons | Change and save machine-local zoom |
@@ -38,6 +43,8 @@ Changing a node title, state, category, or completion value uses the existing ve
 | Ctrl+Shift+Z or Ctrl+Y | Redo the latest undone layout change |
 | Ctrl+0 | Fit the local view |
 | Ctrl+plus/minus | Zoom the local view |
+
+Live guides appear when the edge or center of a moving node approaches another node's edge or center. The minimap shows the full graph, selected nodes, and the current viewport. Selection, guides, and minimap visuals are session-local UI state; only resulting node coordinates are persisted.
 
 Editing and layout controls are disabled when the workspace is untrusted or has unresolved sync conflicts.
 
@@ -110,7 +117,7 @@ Version and work-item content remain separate documents. A layout conflict does 
 - There is one shared release-planning canvas per project.
 - Node positions are shared project state, not per-user preferences.
 - Connectors represent ownership and cannot yet be created as arbitrary edge types.
-- There is no minimap, box selection, grouping, or keyboard-driven node movement yet.
+- Multi-selection groups nodes for movement only; it does not create a persistent group entity.
 - Auto arrangement is deterministic but not a graph-optimization engine.
 - Layout conflict resolution is whole-document.
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -9,9 +9,11 @@ Source Lens converts existing project signals into editable Blueprints work-item
 | `CHANGELOG.md` | Local read-only Markdown parsing | Bullet entries, completed by default |
 | `Roadmap.md` | Local read-only Markdown parsing | Bullet and task-list entries with checkbox state |
 | GitHub issues | Authenticated `gh issue list` request | Open and closed issue metadata |
+| GitHub pull requests | Authenticated `gh pr list` request | Open, closed, and merged pull-request metadata |
+| GitHub releases | Authenticated `gh release list` request | Draft and published release records |
 | GitHub Projects | `projectItems` attached to returned issues | Project-linked issues with project context |
 
-The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
+The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues, 100 pull requests, and 50 releases per repository. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
 
 Standalone GitHub Project draft items are not imported yet. Only issues visible through the repository issue query and linked to a Project are recognized.
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -11,13 +11,13 @@ Source Lens converts existing project signals into editable Blueprints work-item
 | GitHub issues | Authenticated `gh issue list` request | Open and closed issue metadata |
 | GitHub Projects | `projectItems` attached to returned issues | Project-linked issues with project context |
 
-The scanner checks the repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues. A scan returns at most 250 deduplicated proposals.
+The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
 
 Standalone GitHub Project draft items are not imported yet. Only issues visible through the repository issue query and linked to a Project are recognized.
 
 ## Requirements
 
-- Link a local Git worktree in **Source Lens**.
+- Link one or more local Git worktrees in **Source Lens**, one path per line.
 - Install Git.
 - For GitHub discovery, install and authenticate the GitHub CLI with `gh auth login`.
 - The Git worktree must have a recognizable `github.com` origin remote.
@@ -27,7 +27,7 @@ Local Markdown discovery still works if GitHub is unavailable. Source Lens repor
 ## Approval workflow
 
 1. Open **Source Lens**.
-2. Link the local repository and select **Scan sources**.
+2. Link up to eight local repositories, one path per line, and select **Scan sources**.
 3. Select a proposal from the inbox.
 4. Review and edit its title, description, target version, work type, changelog category, and completion state.
 5. Include or exclude the proposal with **Approved**.
@@ -58,7 +58,7 @@ Applied items retain tags that identify:
 - the source kind;
 - a compact source reference such as `github:#42` or `roadmap:Roadmap.md:18`.
 
-Source content remains informational. It does not inherit authority from GitHub, a roadmap, or a changelog.
+When several repositories are scanned, the source reference is qualified with the full local worktree path before it enters the proposal inbox. Source content remains informational. It does not inherit authority from GitHub, a roadmap, or a changelog.
 
 ## Security and privacy
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -60,6 +60,16 @@ Applied items retain tags that identify:
 
 When several repositories are scanned, the source reference is qualified with the full local worktree path before it enters the proposal inbox. Source content remains informational. It does not inherit authority from GitHub, a roadmap, or a changelog.
 
+Internally, Source Lens classifies references without making one hosted provider the domain model. A reference records:
+
+- provider (`Local`, `GitHub`, or `GitLab`);
+- artifact kind (planning document, commit, issue, pull request, release, or project);
+- repository identity;
+- provider identifier;
+- an optional web location.
+
+Local Markdown and GitHub issue discovery already emit this structure. Pull-request, release, standalone project, and GitLab readers can use the same contract without changing signed Blueprints project truth.
+
 ## Security and privacy
 
 - Discovery is read-only for the repository and GitHub.

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -11,11 +11,11 @@ Source Lens converts existing project signals into editable Blueprints work-item
 | GitHub issues | Authenticated `gh issue list` request | Open and closed issue metadata |
 | GitHub pull requests | Authenticated `gh pr list` request | Open, closed, and merged pull-request metadata |
 | GitHub releases | Authenticated `gh release list` request | Draft and published release records |
-| GitHub Projects | `projectItems` attached to returned issues | Project-linked issues with project context |
+| GitHub Projects | Repository-linked Projects query plus `projectItems` attached to issues | Standalone draft items and project-linked issues |
 
 The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues, 100 pull requests, and 50 releases per repository. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
 
-Standalone GitHub Project draft items are not imported yet. Only issues visible through the repository issue query and linked to a Project are recognized.
+Standalone draft discovery reads only Projects linked to the repository, checks at most 10 Projects and 100 items per Project, and returns at most 100 drafts. Issues and pull requests found in those Projects remain owned by their dedicated discovery feeds, preventing duplicate Project proposals.
 
 ## Requirements
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -26,6 +26,8 @@ Standalone draft discovery reads only Projects linked to the repository, checks 
 
 Local Markdown discovery still works if GitHub is unavailable. Source Lens reports the skipped provider as a warning instead of failing the entire scan.
 
+Repository discovery talks to hosted services through a provider-neutral reader contract. The current GitHub implementation uses the authenticated GitHub CLI behind that boundary; replacing its transport does not require changing proposal approval, provenance, or signed workspace behavior.
+
 ## Approval workflow
 
 1. Open **Source Lens**.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -60,6 +60,16 @@ See [canvas engine](canvas-engine.md) for the exact model and [troubleshooting](
 
 Incomplete items are excluded by the current default rules. When a local Git repository is linked, recent commit subjects and matching item keys are added as source context.
 
+Before freezing or releasing, review **Release readiness** in the release planner. It reports:
+
+- an unavailable or unconfigured repository;
+- uncommitted working-tree changes that make the source baseline unstable;
+- incomplete items in the selected version;
+- missing post-tag history;
+- recent commits that do not reference a completed item key in the selected version.
+
+Repository errors and dirty state are blockers. Unmatched commits and incomplete items require attention because they may be intentionally out of scope; Blueprints explains them but does not silently change source history or the release plan.
+
 ## Archive draft work
 
 Draft versions and items in Planned or In Progress state can be archived. Select the archive action twice to confirm. The entity leaves the active signed plan, its removal participates in sync, and its signed files remain under `.blueprints/archive/` for recovery. Frozen and released versions are immutable and cannot be archived.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,8 +77,8 @@ Draft versions and items in Planned or In Progress state can be archived. Select
 ## Discover work with Source Lens
 
 1. Open **Source Lens** from the navigation.
-2. Enter the path to a Git worktree.
-3. Select **Save link**, then **Scan sources**.
+2. Enter up to eight Git worktree paths, one per line.
+3. Select **Save links**, then **Scan sources**.
 4. Review the proposal inbox produced from changelogs, roadmaps, GitHub issues, and issue-linked GitHub Projects.
 5. Edit the selected proposal’s title, context, target version, type, changelog group, and completion state.
 6. Exclude anything that should not enter Blueprints.


### PR DESCRIPTION
## Summary
- begin alpha 4 development at `0.4.0-alpha.4-dev`
- add box selection, multi-node movement, keyboard positioning, live guides, minimap navigation, and signed layout persistence
- add release-readiness diagnostics for dirty, unavailable, incomplete, missing-history, and unmatched-source states
- link and scan up to eight repositories with bounded combined discovery and repository-qualified provenance
- define provider-neutral source references and a swappable hosted-reader boundary
- discover GitHub pull requests, releases, linked Project items, and standalone Project drafts read-only
- update the changelog, roadmap, canvas guide, Source Lens guide, and user guide

## Trust and compatibility
- selection, guides, minimap, credentials, and repository links remain machine-local
- only final node coordinates use the existing signed and audited layout document
- hosted discovery remains read-only and all imported proposals still require explicit approval
- existing single-repository settings migrate through the legacy path field
- signed workspace schema remains version 1

## Verification
- `./scripts/verify.sh`
- 100 tests pass in Release
- formatting is clean
- no vulnerable direct or transitive NuGet packages
- live GitHub CLI fields and bounded Projects GraphQL query verified
- macOS application launch and XAML render smoke test passed