### PR TITLE
Add signed typed relationships to the canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ obj/
 .vscode/
 .idea/
 .sonarlint/
+.DS_Store
 *.user
 *.suo
 *.userprefs

--- a/Blueprints.App/Models/RelationshipEditRequest.cs
+++ b/Blueprints.App/Models/RelationshipEditRequest.cs
@@ -1,0 +1,10 @@
+using Blueprints.Core.Models;
+
+namespace Blueprints.App.Models;
+
+public sealed record RelationshipEditRequest(
+    Guid? RelationshipId,
+    string TypeId,
+    RelationshipEndpoint Source,
+    RelationshipEndpoint Target,
+    string? Label);

--- a/Blueprints.App/Models/RelationshipEndpointOption.cs
+++ b/Blueprints.App/Models/RelationshipEndpointOption.cs
@@ -1,0 +1,7 @@
+using Blueprints.Core.Models;
+
+namespace Blueprints.App.Models;
+
+public sealed record RelationshipEndpointOption(
+    RelationshipEndpoint Endpoint,
+    string DisplayName);

--- a/Blueprints.App/Models/RelationshipTypeEditRequest.cs
+++ b/Blueprints.App/Models/RelationshipTypeEditRequest.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Models;
+
+public sealed record RelationshipTypeEditRequest(
+    string TypeId,
+    string Name,
+    string? Description,
+    string ColorHex,
+    bool IsDirectional);

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -493,6 +493,142 @@ public sealed class ProjectWorkspaceCoordinatorService
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
     }
 
+    public LocalWorkspaceSession SaveRelationshipType(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        RelationshipTypeEditRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var typeId = request.TypeId.Trim().ToLowerInvariant();
+        var existing = workspace.Relationships?.Types.FirstOrDefault(type =>
+            string.Equals(type.TypeId, typeId, StringComparison.Ordinal));
+        if (existing is not null &&
+            existing.IsDirectional != request.IsDirectional &&
+            workspace.Relationships!.Relationships.Any(edge =>
+                string.Equals(edge.TypeId, typeId, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException(
+                "A relationship type's direction cannot change while relationships use it.");
+        }
+
+        var types = (workspace.Relationships?.Types ?? [])
+            .Where(type => !string.Equals(type.TypeId, typeId, StringComparison.Ordinal))
+            .Append(new RelationshipTypeDefinition(
+                typeId,
+                request.Name.Trim(),
+                string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim(),
+                request.ColorHex.Trim().ToUpperInvariant(),
+                request.IsDirectional))
+            .OrderBy(static type => type.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static type => type.TypeId, StringComparer.Ordinal)
+            .ToArray();
+        var document = CreateRelationshipDocument(
+            workspace,
+            identity,
+            types,
+            workspace.Relationships?.Relationships ?? []);
+        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
+        AppendAuditEntry(
+            localWorkspaceRoot,
+            identity,
+            workspace with { Relationships = document },
+            existing is null ? "relationship.type.create" : "relationship.type.update",
+            $"{(existing is null ? "Created" : "Updated")} relationship type {document.Types.First(type => type.TypeId == typeId).Name}.");
+        return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+    }
+
+    public LocalWorkspaceSession SaveRelationship(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        RelationshipEditRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var relationships = workspace.Relationships
+            ?? throw new InvalidOperationException(
+                "Create a relationship type before adding relationships.");
+        var relationshipId = request.RelationshipId ?? Guid.NewGuid();
+        if (request.RelationshipId is not null &&
+            relationships.Relationships.All(edge => edge.RelationshipId != relationshipId))
+        {
+            throw new InvalidOperationException("The selected relationship was not found.");
+        }
+
+        var edges = relationships.Relationships
+            .Where(edge => edge.RelationshipId != relationshipId)
+            .Append(new RelationshipEdge(
+                relationshipId,
+                request.TypeId.Trim().ToLowerInvariant(),
+                request.Source,
+                request.Target,
+                string.IsNullOrWhiteSpace(request.Label) ? null : request.Label.Trim()))
+            .OrderBy(static edge => edge.TypeId, StringComparer.Ordinal)
+            .ThenBy(static edge => edge.RelationshipId)
+            .ToArray();
+        var document = CreateRelationshipDocument(
+            workspace,
+            identity,
+            relationships.Types,
+            edges);
+        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
+        AppendAuditEntry(
+            localWorkspaceRoot,
+            identity,
+            workspace with { Relationships = document },
+            request.RelationshipId is null ? "relationship.create" : "relationship.update",
+            $"{(request.RelationshipId is null ? "Created" : "Updated")} relationship {relationshipId:N}.");
+        return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+    }
+
+    public LocalWorkspaceSession RemoveRelationship(
+        string localWorkspaceRoot,
+        string sharedWorkspaceRoot,
+        Guid relationshipId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
+
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var session = OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+        EnsureWorkspaceMutable(session);
+        var workspace = session.LoadResult.Workspace;
+        var relationships = workspace.Relationships
+            ?? throw new InvalidOperationException("The selected relationship was not found.");
+        if (relationships.Relationships.All(edge => edge.RelationshipId != relationshipId))
+        {
+            throw new InvalidOperationException("The selected relationship was not found.");
+        }
+
+        var document = CreateRelationshipDocument(
+            workspace,
+            identity,
+            relationships.Types,
+            relationships.Relationships
+                .Where(edge => edge.RelationshipId != relationshipId)
+                .ToArray());
+        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
+        AppendAuditEntry(
+            localWorkspaceRoot,
+            identity,
+            workspace with { Relationships = document },
+            "relationship.remove",
+            $"Removed relationship {relationshipId:N}.");
+        return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
+    }
+
     public LocalWorkspaceSession ReleaseVersion(
         string localWorkspaceRoot,
         string sharedWorkspaceRoot,
@@ -590,6 +726,10 @@ public sealed class ProjectWorkspaceCoordinatorService
                     .ToArray(),
                 CanvasLayout = RemoveArchivedLayoutNodes(
                     workspace.CanvasLayout,
+                    removedEntityIds,
+                    identity),
+                Relationships = RemoveArchivedRelationships(
+                    workspace.Relationships,
                     removedEntityIds,
                     identity),
             };
@@ -694,6 +834,10 @@ public sealed class ProjectWorkspaceCoordinatorService
                     Versions = versions,
                     CanvasLayout = RemoveArchivedLayoutNodes(
                         workspace.CanvasLayout,
+                        new HashSet<Guid> { itemId },
+                        identity),
+                    Relationships = RemoveArchivedRelationships(
+                        workspace.Relationships,
                         new HashSet<Guid> { itemId },
                         identity),
                 },
@@ -1400,6 +1544,69 @@ public sealed class ProjectWorkspaceCoordinatorService
             Nodes = layout.Nodes
                 .Where(node => !removedEntityIds.Contains(node.EntityId))
                 .ToArray(),
+            UpdatedUtc = DateTimeOffset.UtcNow,
+            LastModifiedByUserId = identity.Profile.UserId,
+            LastModifiedByName = identity.Profile.DisplayName,
+        };
+    }
+
+    private void SaveRelationshipDocument(
+        string localWorkspaceRoot,
+        Security.Models.StoredIdentity identity,
+        ProjectWorkspaceSnapshot workspace,
+        RelationshipDocument document)
+    {
+        RelationshipDocumentValidator.Validate(document, workspace.Project.ProjectId);
+        RelationshipDocumentValidator.ValidateEntityReferences(
+            document,
+            workspace.Project.ProjectId,
+            workspace.Versions.Select(static version => version.Version.VersionId).ToHashSet(),
+            workspace.Versions
+                .SelectMany(static version => version.Items)
+                .Select(static item => item.ItemId)
+                .ToHashSet());
+        _workspaceStore.SaveRelationships(localWorkspaceRoot, document, identity.SigningKey);
+    }
+
+    private static RelationshipDocument CreateRelationshipDocument(
+        ProjectWorkspaceSnapshot workspace,
+        Security.Models.StoredIdentity identity,
+        IReadOnlyList<RelationshipTypeDefinition> types,
+        IReadOnlyList<RelationshipEdge> relationships) =>
+        new(
+            CurrentSchemaVersion,
+            workspace.Project.ProjectId,
+            (workspace.Relationships?.Revision ?? 0) + 1,
+            types,
+            relationships,
+            DateTimeOffset.UtcNow,
+            identity.Profile.UserId,
+            identity.Profile.DisplayName);
+
+    private static RelationshipDocument? RemoveArchivedRelationships(
+        RelationshipDocument? document,
+        IReadOnlySet<Guid> removedEntityIds,
+        Security.Models.StoredIdentity identity)
+    {
+        if (document is null)
+        {
+            return null;
+        }
+
+        var relationships = document.Relationships
+            .Where(edge =>
+                !removedEntityIds.Contains(edge.Source.EntityId) &&
+                !removedEntityIds.Contains(edge.Target.EntityId))
+            .ToArray();
+        if (relationships.Length == document.Relationships.Count)
+        {
+            return document;
+        }
+
+        return document with
+        {
+            Revision = document.Revision + 1,
+            Relationships = relationships,
             UpdatedUtc = DateTimeOffset.UtcNow,
             LastModifiedByUserId = identity.Profile.UserId,
             LastModifiedByName = identity.Profile.DisplayName,

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -90,6 +90,17 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _integrationMessage = string.Empty;
     private WorkspaceSection _selectedWorkspaceSection = WorkspaceSection.Overview;
     private CanvasLayoutDocument? _canvasLayout;
+    private RelationshipDocument? _relationshipDocument;
+    private RelationshipTypeDefinition? _selectedRelationshipType;
+    private RelationshipEdge? _selectedRelationship;
+    private RelationshipEndpointOption? _selectedRelationshipSource;
+    private RelationshipEndpointOption? _selectedRelationshipTarget;
+    private string _relationshipTypeId = string.Empty;
+    private string _relationshipTypeName = string.Empty;
+    private string _relationshipTypeDescription = string.Empty;
+    private string _relationshipTypeColor = "#52C7E8";
+    private bool _relationshipTypeIsDirectional;
+    private string _relationshipLabel = string.Empty;
     private CanvasViewState _canvasViewState = CanvasViewState.Default;
     private SourceImportProposal? _selectedSourceProposal;
     private string _sourceDiscoverySummary = "Connect a repository, then scan its planning sources.";
@@ -110,6 +121,9 @@ public partial class MainWindowViewModel : ViewModelBase
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
         ReleaseReadinessDiagnostics = new ObservableCollection<ReleaseReadinessDiagnostic>();
+        RelationshipTypes = new ObservableCollection<RelationshipTypeDefinition>();
+        Relationships = new ObservableCollection<RelationshipEdge>();
+        RelationshipEndpoints = new ObservableCollection<RelationshipEndpointOption>();
         _integrationStatusService = new IntegrationStatusService();
         _sourceDiscoveryService = new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
@@ -140,6 +154,9 @@ public partial class MainWindowViewModel : ViewModelBase
         Integrations = new ObservableCollection<IntegrationStatusCard>();
         VersionSourceChangeDiagnostics = new ObservableCollection<VersionSourceChangeDiagnostic>();
         ReleaseReadinessDiagnostics = new ObservableCollection<ReleaseReadinessDiagnostic>();
+        RelationshipTypes = new ObservableCollection<RelationshipTypeDefinition>();
+        Relationships = new ObservableCollection<RelationshipEdge>();
+        RelationshipEndpoints = new ObservableCollection<RelationshipEndpointOption>();
         SourceImportProposals = new ObservableCollection<SourceImportProposal>();
 
         RefreshRecentProjects();
@@ -174,6 +191,12 @@ public partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<ReleaseReadinessDiagnostic> ReleaseReadinessDiagnostics { get; }
 
     public ObservableCollection<SourceImportProposal> SourceImportProposals { get; }
+
+    public ObservableCollection<RelationshipTypeDefinition> RelationshipTypes { get; }
+
+    public ObservableCollection<RelationshipEdge> Relationships { get; }
+
+    public ObservableCollection<RelationshipEndpointOption> RelationshipEndpoints { get; }
 
     public SourceImportProposal? SelectedSourceProposal
     {
@@ -277,6 +300,132 @@ public partial class MainWindowViewModel : ViewModelBase
         CanvasLayout is null
             ? "Layout has not been saved yet"
             : $"Shared layout revision {CanvasLayout.Revision}";
+
+    public RelationshipDocument? RelationshipDocument
+    {
+        get => _relationshipDocument;
+        private set
+        {
+            if (SetProperty(ref _relationshipDocument, value))
+            {
+                OnPropertyChanged(nameof(RelationshipRevisionSummary));
+            }
+        }
+    }
+
+    public string RelationshipRevisionSummary =>
+        RelationshipDocument is null
+            ? "No custom relationship graph yet"
+            : $"Relationship revision {RelationshipDocument.Revision} · {Relationships.Count} links";
+
+    public RelationshipTypeDefinition? SelectedRelationshipType
+    {
+        get => _selectedRelationshipType;
+        set
+        {
+            if (SetProperty(ref _selectedRelationshipType, value) && value is not null)
+            {
+                RelationshipTypeId = value.TypeId;
+                RelationshipTypeName = value.Name;
+                RelationshipTypeDescription = value.Description ?? string.Empty;
+                RelationshipTypeColor = value.ColorHex;
+                RelationshipTypeIsDirectional = value.IsDirectional;
+                OnPropertyChanged(nameof(CanSaveRelationship));
+            }
+        }
+    }
+
+    public RelationshipEdge? SelectedRelationship
+    {
+        get => _selectedRelationship;
+        set
+        {
+            if (SetProperty(ref _selectedRelationship, value))
+            {
+                if (value is not null)
+                {
+                    SelectedRelationshipType = RelationshipTypes.FirstOrDefault(type =>
+                        type.TypeId == value.TypeId);
+                    SelectedRelationshipSource = RelationshipEndpoints.FirstOrDefault(option =>
+                        option.Endpoint == value.Source);
+                    SelectedRelationshipTarget = RelationshipEndpoints.FirstOrDefault(option =>
+                        option.Endpoint == value.Target);
+                    RelationshipLabel = value.Label ?? string.Empty;
+                }
+                OnPropertyChanged(nameof(CanRemoveRelationship));
+            }
+        }
+    }
+
+    public RelationshipEndpointOption? SelectedRelationshipSource
+    {
+        get => _selectedRelationshipSource;
+        set
+        {
+            if (SetProperty(ref _selectedRelationshipSource, value))
+            {
+                OnPropertyChanged(nameof(CanSaveRelationship));
+            }
+        }
+    }
+
+    public RelationshipEndpointOption? SelectedRelationshipTarget
+    {
+        get => _selectedRelationshipTarget;
+        set
+        {
+            if (SetProperty(ref _selectedRelationshipTarget, value))
+            {
+                OnPropertyChanged(nameof(CanSaveRelationship));
+            }
+        }
+    }
+
+    public string RelationshipTypeId
+    {
+        get => _relationshipTypeId;
+        set => SetProperty(ref _relationshipTypeId, value);
+    }
+
+    public string RelationshipTypeName
+    {
+        get => _relationshipTypeName;
+        set => SetProperty(ref _relationshipTypeName, value);
+    }
+
+    public string RelationshipTypeDescription
+    {
+        get => _relationshipTypeDescription;
+        set => SetProperty(ref _relationshipTypeDescription, value);
+    }
+
+    public string RelationshipTypeColor
+    {
+        get => _relationshipTypeColor;
+        set => SetProperty(ref _relationshipTypeColor, value);
+    }
+
+    public bool RelationshipTypeIsDirectional
+    {
+        get => _relationshipTypeIsDirectional;
+        set => SetProperty(ref _relationshipTypeIsDirectional, value);
+    }
+
+    public string RelationshipLabel
+    {
+        get => _relationshipLabel;
+        set => SetProperty(ref _relationshipLabel, value);
+    }
+
+    public bool CanSaveRelationship =>
+        CanMutateWorkspace &&
+        SelectedRelationshipType is not null &&
+        SelectedRelationshipSource is not null &&
+        SelectedRelationshipTarget is not null &&
+        SelectedRelationshipSource.Endpoint != SelectedRelationshipTarget.Endpoint;
+
+    public bool CanRemoveRelationship =>
+        CanMutateWorkspace && SelectedRelationship is not null;
 
     public CanvasViewState CanvasViewState
     {
@@ -1962,6 +2111,128 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
+    [RelayCommand]
+    private void BeginNewRelationshipType()
+    {
+        SelectedRelationshipType = null;
+        RelationshipTypeId = string.Empty;
+        RelationshipTypeName = string.Empty;
+        RelationshipTypeDescription = string.Empty;
+        RelationshipTypeColor = "#52C7E8";
+        RelationshipTypeIsDirectional = false;
+    }
+
+    [RelayCommand]
+    private void SaveRelationshipType()
+    {
+        if (_coordinatorService is null || _currentSession is null)
+        {
+            WorkspaceMessage = "Open a workspace before creating relationship types.";
+            return;
+        }
+
+        try
+        {
+            var typeId = RelationshipTypeId.Trim().ToLowerInvariant();
+            ApplySession(
+                _coordinatorService.SaveRelationshipType(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    new RelationshipTypeEditRequest(
+                        typeId,
+                        RelationshipTypeName,
+                        RelationshipTypeDescription,
+                        RelationshipTypeColor,
+                        RelationshipTypeIsDirectional)));
+            SelectedRelationshipType = RelationshipTypes.FirstOrDefault(type =>
+                type.TypeId == typeId);
+            WorkspaceMessage = $"Saved relationship type {RelationshipTypeName.Trim()}.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void BeginNewRelationship()
+    {
+        SelectedRelationship = null;
+        RelationshipLabel = string.Empty;
+        SelectedRelationshipSource ??= RelationshipEndpoints.FirstOrDefault();
+        SelectedRelationshipTarget ??= RelationshipEndpoints.Skip(1).FirstOrDefault();
+    }
+
+    [RelayCommand]
+    private void SaveRelationship()
+    {
+        if (_coordinatorService is null ||
+            _currentSession is null ||
+            SelectedRelationshipType is null ||
+            SelectedRelationshipSource is null ||
+            SelectedRelationshipTarget is null)
+        {
+            WorkspaceMessage = "Choose a type and two different endpoints.";
+            return;
+        }
+
+        try
+        {
+            var relationshipId = SelectedRelationship?.RelationshipId;
+            var typeId = SelectedRelationshipType.TypeId;
+            var source = SelectedRelationshipSource.Endpoint;
+            var target = SelectedRelationshipTarget.Endpoint;
+            ApplySession(
+                _coordinatorService.SaveRelationship(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    new RelationshipEditRequest(
+                        relationshipId,
+                        typeId,
+                        source,
+                        target,
+                        RelationshipLabel)));
+            SelectedRelationship = relationshipId is Guid id
+                ? Relationships.FirstOrDefault(edge => edge.RelationshipId == id)
+                : Relationships.FirstOrDefault(edge =>
+                    edge.TypeId == typeId &&
+                    edge.Source == source &&
+                    edge.Target == target);
+            WorkspaceMessage = relationshipId is null
+                ? "Created a signed relationship."
+                : "Updated the signed relationship.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void RemoveSelectedRelationship()
+    {
+        if (_coordinatorService is null || _currentSession is null || SelectedRelationship is null)
+        {
+            WorkspaceMessage = "Select a relationship first.";
+            return;
+        }
+
+        try
+        {
+            ApplySession(
+                _coordinatorService.RemoveRelationship(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    SelectedRelationship.RelationshipId));
+            SelectedRelationship = Relationships.FirstOrDefault();
+            WorkspaceMessage = "Removed the signed relationship.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
     private void ApplySession(LocalWorkspaceSession session)
     {
         var wasActiveSession = HasActiveSession;
@@ -2011,6 +2282,51 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             AvailableCategories.Add(categoryId);
         }
+
+        RelationshipDocument = workspace.Relationships;
+        SelectedRelationship = null;
+        SelectedRelationshipType = null;
+        SelectedRelationshipSource = null;
+        SelectedRelationshipTarget = null;
+        RelationshipTypes.Clear();
+        foreach (var type in workspace.Relationships?.Types ?? [])
+        {
+            RelationshipTypes.Add(type);
+        }
+
+        Relationships.Clear();
+        foreach (var relationship in workspace.Relationships?.Relationships ?? [])
+        {
+            Relationships.Add(relationship);
+        }
+
+        RelationshipEndpoints.Clear();
+        RelationshipEndpoints.Add(
+            new RelationshipEndpointOption(
+                new RelationshipEndpoint("project", project.ProjectId),
+                $"Project · {project.Name}"));
+        foreach (var version in workspace.Versions.OrderBy(static value => value.Version.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            RelationshipEndpoints.Add(
+                new RelationshipEndpointOption(
+                    new RelationshipEndpoint("version", version.Version.VersionId),
+                    $"Version · {version.Version.Name}"));
+            foreach (var item in version.Items.OrderBy(static value => value.ItemKey, StringComparer.OrdinalIgnoreCase))
+            {
+                RelationshipEndpoints.Add(
+                    new RelationshipEndpointOption(
+                        new RelationshipEndpoint("item", item.ItemId),
+                        $"{item.ItemKey} · {item.Title}"));
+            }
+        }
+        SelectedRelationship = Relationships.FirstOrDefault();
+        if (SelectedRelationship is null)
+        {
+            SelectedRelationshipType = RelationshipTypes.FirstOrDefault();
+            SelectedRelationshipSource = RelationshipEndpoints.FirstOrDefault();
+            SelectedRelationshipTarget = RelationshipEndpoints.Skip(1).FirstOrDefault();
+        }
+        OnPropertyChanged(nameof(RelationshipRevisionSummary));
 
         Members.Clear();
         foreach (var member in workspace.Members.Members
@@ -2117,6 +2433,8 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(HasSyncDiagnostics));
         OnPropertyChanged(nameof(HasTrustDiagnostics));
         OnPropertyChanged(nameof(CanApplyApprovedSourceProposals));
+        OnPropertyChanged(nameof(CanSaveRelationship));
+        OnPropertyChanged(nameof(CanRemoveRelationship));
         OnPropertyChanged(nameof(AdaptiveGuidanceTitle));
         OnPropertyChanged(nameof(AdaptiveGuidanceDetail));
         RefreshVersionSourceChangeDiagnostics();
@@ -2137,10 +2455,18 @@ public partial class MainWindowViewModel : ViewModelBase
         ActiveMemberCount = 0;
         MembershipRevision = 0;
         CanvasLayout = null;
+        RelationshipDocument = null;
         Sync = new SyncSummary(SyncHealth.Idle, 0, 0, 0);
         Versions.Clear();
         AvailableItemTypes.Clear();
         AvailableCategories.Clear();
+        RelationshipTypes.Clear();
+        Relationships.Clear();
+        RelationshipEndpoints.Clear();
+        SelectedRelationship = null;
+        SelectedRelationshipType = null;
+        SelectedRelationshipSource = null;
+        SelectedRelationshipTarget = null;
         Members.Clear();
         Conflicts.Clear();
         SyncDiagnostics.Clear();
@@ -2753,6 +3079,18 @@ public partial class MainWindowViewModel : ViewModelBase
             ];
         }
 
+        if (string.Equals(normalizedPath, "project/relationships.json", StringComparison.Ordinal))
+        {
+            return
+            [
+                ("Revision", "revision"),
+                ("Relationship types", "types"),
+                ("Relationships", "relationships"),
+                ("Last modified UTC", "updatedUtc"),
+                ("Last modified by", "lastModifiedByName"),
+            ];
+        }
+
         if (normalizedPath.StartsWith("versions/", StringComparison.Ordinal) &&
             normalizedPath.EndsWith("/version.json", StringComparison.Ordinal))
         {
@@ -2811,6 +3149,11 @@ public partial class MainWindowViewModel : ViewModelBase
         if (string.Equals(normalizedPath, "project/members.json", StringComparison.Ordinal))
         {
             return "Membership";
+        }
+
+        if (string.Equals(normalizedPath, "project/relationships.json", StringComparison.Ordinal))
+        {
+            return "Typed relationship graph";
         }
 
         if (normalizedPath.StartsWith("versions/", StringComparison.Ordinal) &&

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -21,6 +21,7 @@ public partial class BlueprintCanvasSurface : UserControl
     private const double ItemNodeHeight = 82;
     private readonly Dictionary<Guid, Point> _positions = [];
     private readonly Dictionary<Guid, Control> _nodes = [];
+    private readonly Dictionary<(string Type, Guid Id), Control> _typedNodes = [];
     private readonly HashSet<Guid> _selectedNodeIds = [];
     private readonly List<ConnectionVisual> _connections = [];
     private readonly List<Line> _alignmentGuideVisuals = [];
@@ -210,6 +211,10 @@ public partial class BlueprintCanvasSurface : UserControl
             RestoreLayout();
             RenderGraph();
         }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.RelationshipDocument))
+        {
+            RenderGraph();
+        }
         else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasViewState))
         {
             RestoreViewState();
@@ -271,6 +276,7 @@ public partial class BlueprintCanvasSurface : UserControl
     {
         Surface.Children.Clear();
         _nodes.Clear();
+        _typedNodes.Clear();
         _connections.Clear();
         _alignmentGuideVisuals.Clear();
         DrawGrid();
@@ -320,6 +326,30 @@ public partial class BlueprintCanvasSurface : UserControl
             }
         }
 
+        if (_viewModel.RelationshipDocument is { } relationshipDocument)
+        {
+            var types = relationshipDocument.Types.ToDictionary(
+                static type => type.TypeId,
+                StringComparer.Ordinal);
+            foreach (var relationship in relationshipDocument.Relationships)
+            {
+                if (_typedNodes.TryGetValue(
+                        (relationship.Source.NodeType, relationship.Source.EntityId),
+                        out var source) &&
+                    _typedNodes.TryGetValue(
+                        (relationship.Target.NodeType, relationship.Target.EntityId),
+                        out var target) &&
+                    types.TryGetValue(relationship.TypeId, out var type))
+                {
+                    AddConnection(
+                        source,
+                        target,
+                        type.ColorHex,
+                        type.IsDirectional ? 3.25 : 2.5);
+                }
+            }
+        }
+
         foreach (var connection in _connections)
         {
             Surface.Children.Insert(FindGridVisualCount(), connection.Line);
@@ -351,9 +381,10 @@ public partial class BlueprintCanvasSurface : UserControl
 
     private void RegisterNode(Control node)
     {
-        if (node.Tag is NodeTag { Id: Guid nodeId })
+        if (node.Tag is NodeTag { Type: var nodeType, Id: Guid nodeId })
         {
             _nodes[nodeId] = node;
+            _typedNodes[(nodeType, nodeId)] = node;
         }
     }
 

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Blueprints.App.ViewModels"
+             xmlns:models="using:Blueprints.App.Models"
+             xmlns:core="using:Blueprints.Core.Models"
              xmlns:views="using:Blueprints.App.Views.Components"
              x:Class="Blueprints.App.Views.Components.OverviewView"
              x:DataType="vm:MainWindowViewModel">
@@ -134,6 +136,104 @@
                           Content="Apply selected"
                           Command="{Binding SaveItemDetailsCommand}"
                           IsEnabled="{Binding HasSelectedItem}" />
+                </Grid>
+              </StackPanel>
+
+              <Border Height="1" Background="#C7DDE8" />
+
+              <StackPanel Spacing="10">
+                <Grid ColumnDefinitions="*,Auto">
+                  <StackPanel Spacing="2">
+                    <TextBlock Classes="eyebrow" Text="TYPED RELATIONSHIPS" />
+                    <TextBlock Text="{Binding RelationshipRevisionSummary}" FontSize="11" Foreground="#4E7184" />
+                  </StackPanel>
+                  <Button Grid.Column="1"
+                          Classes="tool square"
+                          Content="＋"
+                          Command="{Binding BeginNewRelationshipTypeCommand}"
+                          ToolTip.Tip="Create a relationship type" />
+                </Grid>
+
+                <ComboBox ItemsSource="{Binding RelationshipTypes}"
+                          SelectedItem="{Binding SelectedRelationshipType}">
+                  <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="core:RelationshipTypeDefinition">
+                      <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                  </ComboBox.ItemTemplate>
+                </ComboBox>
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                  <TextBox PlaceholderText="type-id"
+                           Text="{Binding RelationshipTypeId}"
+                           IsEnabled="{Binding CanMutateWorkspace}" />
+                  <TextBox Grid.Column="1"
+                           PlaceholderText="#52C7E8"
+                           Text="{Binding RelationshipTypeColor}"
+                           IsEnabled="{Binding CanMutateWorkspace}" />
+                </Grid>
+                <TextBox PlaceholderText="Relationship name"
+                         Text="{Binding RelationshipTypeName}"
+                         IsEnabled="{Binding CanMutateWorkspace}" />
+                <TextBox PlaceholderText="Meaning and usage"
+                         Text="{Binding RelationshipTypeDescription}"
+                         IsEnabled="{Binding CanMutateWorkspace}" />
+                <CheckBox Content="Directional"
+                          IsChecked="{Binding RelationshipTypeIsDirectional}"
+                          IsEnabled="{Binding CanMutateWorkspace}" />
+                <Button Classes="secondary"
+                        Content="Save relationship type"
+                        Command="{Binding SaveRelationshipTypeCommand}"
+                        IsEnabled="{Binding CanMutateWorkspace}" />
+
+                <ListBox ItemsSource="{Binding Relationships}"
+                         SelectedItem="{Binding SelectedRelationship}"
+                         MaxHeight="112">
+                  <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="core:RelationshipEdge">
+                      <StackPanel Margin="2,4">
+                        <TextBlock Text="{Binding TypeId}" Classes="mono" FontWeight="Bold" />
+                        <TextBlock Text="{Binding Label}" FontSize="10" Foreground="#537487" TextTrimming="CharacterEllipsis" />
+                      </StackPanel>
+                    </DataTemplate>
+                  </ListBox.ItemTemplate>
+                </ListBox>
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                  <ComboBox ItemsSource="{Binding RelationshipEndpoints}"
+                            SelectedItem="{Binding SelectedRelationshipSource}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="models:RelationshipEndpointOption">
+                        <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                  <ComboBox Grid.Column="1"
+                            ItemsSource="{Binding RelationshipEndpoints}"
+                            SelectedItem="{Binding SelectedRelationshipTarget}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate x:DataType="models:RelationshipEndpointOption">
+                        <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                </Grid>
+                <TextBox PlaceholderText="Optional relationship label"
+                         Text="{Binding RelationshipLabel}"
+                         IsEnabled="{Binding CanMutateWorkspace}" />
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="6">
+                  <Button Classes="secondary"
+                          Content="New"
+                          Command="{Binding BeginNewRelationshipCommand}"
+                          IsEnabled="{Binding CanMutateWorkspace}" />
+                  <Button Grid.Column="1"
+                          Classes="primary"
+                          Content="Save"
+                          Command="{Binding SaveRelationshipCommand}"
+                          IsEnabled="{Binding CanSaveRelationship}" />
+                  <Button Grid.Column="2"
+                          Classes="secondary"
+                          Content="Remove"
+                          Command="{Binding RemoveSelectedRelationshipCommand}"
+                          IsEnabled="{Binding CanRemoveRelationship}" />
                 </Grid>
               </StackPanel>
             </StackPanel>

--- a/Blueprints.Core/Models/RelationshipDocument.cs
+++ b/Blueprints.Core/Models/RelationshipDocument.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.Core.Models;
+
+public sealed record RelationshipDocument(
+    int SchemaVersion,
+    Guid ProjectId,
+    int Revision,
+    IReadOnlyList<RelationshipTypeDefinition> Types,
+    IReadOnlyList<RelationshipEdge> Relationships,
+    DateTimeOffset UpdatedUtc,
+    Guid LastModifiedByUserId,
+    string LastModifiedByName);

--- a/Blueprints.Core/Models/RelationshipEdge.cs
+++ b/Blueprints.Core/Models/RelationshipEdge.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.Core.Models;
+
+public sealed record RelationshipEdge(
+    Guid RelationshipId,
+    string TypeId,
+    RelationshipEndpoint Source,
+    RelationshipEndpoint Target,
+    string? Label);

--- a/Blueprints.Core/Models/RelationshipEndpoint.cs
+++ b/Blueprints.Core/Models/RelationshipEndpoint.cs
@@ -1,0 +1,5 @@
+namespace Blueprints.Core.Models;
+
+public sealed record RelationshipEndpoint(
+    string NodeType,
+    Guid EntityId);

--- a/Blueprints.Core/Models/RelationshipTypeDefinition.cs
+++ b/Blueprints.Core/Models/RelationshipTypeDefinition.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.Core.Models;
+
+public sealed record RelationshipTypeDefinition(
+    string TypeId,
+    string Name,
+    string? Description,
+    string ColorHex,
+    bool IsDirectional);

--- a/Blueprints.Core/Services/RelationshipDocumentValidator.cs
+++ b/Blueprints.Core/Services/RelationshipDocumentValidator.cs
@@ -1,0 +1,241 @@
+using System.Text.RegularExpressions;
+using Blueprints.Core.Models;
+
+namespace Blueprints.Core.Services;
+
+public static partial class RelationshipDocumentValidator
+{
+    public const int MaximumTypeCount = 100;
+    public const int MaximumRelationshipCount = 5_000;
+
+    private static readonly HashSet<string> SupportedNodeTypes =
+        new(StringComparer.Ordinal)
+        {
+            "project",
+            "version",
+            "item",
+        };
+
+    public static void Validate(
+        RelationshipDocument document,
+        Guid expectedProjectId)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.SchemaVersion != 1)
+        {
+            throw new InvalidOperationException(
+                $"Relationship schema {document.SchemaVersion} is not supported.");
+        }
+
+        if (document.ProjectId == Guid.Empty || document.ProjectId != expectedProjectId)
+        {
+            throw new InvalidOperationException(
+                "Relationship project identity does not match the workspace.");
+        }
+
+        if (document.Revision < 1)
+        {
+            throw new InvalidOperationException("Relationship revision must be at least 1.");
+        }
+
+        if (document.Types is null || document.Relationships is null)
+        {
+            throw new InvalidOperationException(
+                "Relationship type and relationship collections are required.");
+        }
+
+        if (document.Types.Count > MaximumTypeCount)
+        {
+            throw new InvalidOperationException(
+                $"Relationship documents cannot define more than {MaximumTypeCount} types.");
+        }
+
+        if (document.Relationships.Count > MaximumRelationshipCount)
+        {
+            throw new InvalidOperationException(
+                $"Relationship documents cannot contain more than {MaximumRelationshipCount} relationships.");
+        }
+
+        var types = new Dictionary<string, RelationshipTypeDefinition>(StringComparer.Ordinal);
+        foreach (var type in document.Types)
+        {
+            if (type is null)
+            {
+                throw new InvalidOperationException("Relationship type entries cannot be null.");
+            }
+
+            if (string.IsNullOrWhiteSpace(type.TypeId) ||
+                !TypeIdPattern().IsMatch(type.TypeId))
+            {
+                throw new InvalidOperationException(
+                    $"Relationship type ID '{type.TypeId}' must be a lowercase slug of at most 32 characters.");
+            }
+
+            ValidateText(type.Name, 80, "Relationship type name", required: true);
+            ValidateText(type.Description, 500, "Relationship type description", required: false);
+            if (string.IsNullOrWhiteSpace(type.ColorHex) ||
+                !ColorPattern().IsMatch(type.ColorHex))
+            {
+                throw new InvalidOperationException(
+                    $"Relationship type '{type.TypeId}' requires a #RRGGBB color.");
+            }
+
+            if (!types.TryAdd(type.TypeId, type))
+            {
+                throw new InvalidOperationException(
+                    $"Relationship type '{type.TypeId}' is duplicated.");
+            }
+        }
+
+        var relationshipIds = new HashSet<Guid>();
+        var logicalRelationships = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var relationship in document.Relationships)
+        {
+            if (relationship is null)
+            {
+                throw new InvalidOperationException("Relationship entries cannot be null.");
+            }
+
+            if (relationship.RelationshipId == Guid.Empty
+                || !relationshipIds.Add(relationship.RelationshipId))
+            {
+                throw new InvalidOperationException(
+                    "Relationship IDs must be non-empty and unique.");
+            }
+
+            if (string.IsNullOrWhiteSpace(relationship.TypeId) ||
+                !types.TryGetValue(relationship.TypeId, out var type))
+            {
+                throw new InvalidOperationException(
+                    $"Relationship '{relationship.RelationshipId}' references unknown type '{relationship.TypeId}'.");
+            }
+
+            ValidateEndpoint(relationship.Source, "source");
+            ValidateEndpoint(relationship.Target, "target");
+            if (relationship.Source == relationship.Target)
+            {
+                throw new InvalidOperationException("A relationship cannot connect a node to itself.");
+            }
+
+            ValidateText(relationship.Label, 120, "Relationship label", required: false);
+            var logicalKey = LogicalKey(relationship, type.IsDirectional);
+            if (!logicalRelationships.Add(logicalKey))
+            {
+                throw new InvalidOperationException(
+                    "Duplicate relationships with the same type and endpoints are not allowed.");
+            }
+        }
+
+        ValidateText(
+            document.LastModifiedByName,
+            200,
+            "Relationship modifier name",
+            required: true);
+        if (document.LastModifiedByUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                "Relationship documents require a last-modifier identity.");
+        }
+
+        if (document.UpdatedUtc == default)
+        {
+            throw new InvalidOperationException(
+                "Relationship documents require an update timestamp.");
+        }
+    }
+
+    public static void ValidateEntityReferences(
+        RelationshipDocument document,
+        Guid projectId,
+        IReadOnlySet<Guid> versionIds,
+        IReadOnlySet<Guid> itemIds)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(versionIds);
+        ArgumentNullException.ThrowIfNull(itemIds);
+
+        foreach (var relationship in document.Relationships)
+        {
+            ValidateEntityReference(relationship.Source, projectId, versionIds, itemIds);
+            ValidateEntityReference(relationship.Target, projectId, versionIds, itemIds);
+        }
+    }
+
+    private static void ValidateEndpoint(RelationshipEndpoint endpoint, string role)
+    {
+        if (endpoint is null)
+        {
+            throw new InvalidOperationException($"Relationship {role} is required.");
+        }
+        if (string.IsNullOrWhiteSpace(endpoint.NodeType) ||
+            !SupportedNodeTypes.Contains(endpoint.NodeType))
+        {
+            throw new InvalidOperationException(
+                $"Relationship {role} node type '{endpoint.NodeType}' is not supported.");
+        }
+
+        if (endpoint.EntityId == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                $"Relationship {role} requires a non-empty entity ID.");
+        }
+    }
+
+    private static void ValidateEntityReference(
+        RelationshipEndpoint endpoint,
+        Guid projectId,
+        IReadOnlySet<Guid> versionIds,
+        IReadOnlySet<Guid> itemIds)
+    {
+        var exists = endpoint.NodeType switch
+        {
+            "project" => endpoint.EntityId == projectId,
+            "version" => versionIds.Contains(endpoint.EntityId),
+            "item" => itemIds.Contains(endpoint.EntityId),
+            _ => false,
+        };
+        if (!exists)
+        {
+            throw new InvalidOperationException(
+                $"Relationship endpoint '{endpoint.NodeType}/{endpoint.EntityId}' does not exist in this workspace.");
+        }
+    }
+
+    private static string LogicalKey(
+        RelationshipEdge relationship,
+        bool directional)
+    {
+        var source = $"{relationship.Source.NodeType}/{relationship.Source.EntityId:N}";
+        var target = $"{relationship.Target.NodeType}/{relationship.Target.EntityId:N}";
+        if (!directional && string.CompareOrdinal(source, target) > 0)
+        {
+            (source, target) = (target, source);
+        }
+
+        return $"{relationship.TypeId}:{source}:{target}";
+    }
+
+    private static void ValidateText(
+        string? value,
+        int maximumLength,
+        string fieldName,
+        bool required)
+    {
+        if (required && string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{fieldName} is required.");
+        }
+
+        if (value?.Length > maximumLength)
+        {
+            throw new InvalidOperationException(
+                $"{fieldName} cannot exceed {maximumLength} characters.");
+        }
+    }
+
+    [GeneratedRegex("^[a-z][a-z0-9-]{0,31}$", RegexOptions.CultureInvariant)]
+    private static partial Regex TypeIdPattern();
+
+    [GeneratedRegex("^#[0-9A-Fa-f]{6}$", RegexOptions.CultureInvariant)]
+    private static partial Regex ColorPattern();
+}

--- a/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Abstractions/IProjectWorkspaceStore.cs
@@ -23,4 +23,9 @@ public interface IProjectWorkspaceStore
         string workspaceRoot,
         CanvasLayoutDocument layout,
         SignatureKeyMaterial signingKey);
+
+    void SaveRelationships(
+        string workspaceRoot,
+        RelationshipDocument relationships,
+        SignatureKeyMaterial signingKey);
 }

--- a/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
+++ b/Blueprints.Storage/Models/ProjectWorkspaceSnapshot.cs
@@ -6,4 +6,5 @@ public sealed record ProjectWorkspaceSnapshot(
     ProjectConfigurationDocument Project,
     MemberDocument Members,
     IReadOnlyList<VersionWorkspaceSnapshot> Versions,
-    CanvasLayoutDocument? CanvasLayout = null);
+    CanvasLayoutDocument? CanvasLayout = null,
+    RelationshipDocument? Relationships = null);

--- a/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
@@ -50,6 +50,7 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
             var totalDocuments = 2;
             var invalidSignatures = allSignaturesValid ? 0 : CountInvalid(projectResult.IsSignatureValid, membersResult.IsSignatureValid);
             CanvasLayoutDocument? canvasLayout = null;
+            RelationshipDocument? relationships = null;
 
             var canvasLayoutPath = GetCanvasLayoutDocumentPath(workspaceRoot);
             if (File.Exists(canvasLayoutPath))
@@ -61,6 +62,24 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                 canvasLayout = canvasLayoutResult.Document;
                 totalDocuments++;
                 if (!canvasLayoutResult.IsSignatureValid)
+                {
+                    invalidSignatures++;
+                    allSignaturesValid = false;
+                }
+            }
+
+            var relationshipsPath = GetRelationshipsDocumentPath(workspaceRoot);
+            if (File.Exists(relationshipsPath))
+            {
+                var relationshipsResult = _signedDocumentStore.Read<RelationshipDocument>(
+                    relationshipsPath,
+                    publicKeys);
+                RelationshipDocumentValidator.Validate(
+                    relationshipsResult.Document,
+                    projectResult.Document.ProjectId);
+                relationships = relationshipsResult.Document;
+                totalDocuments++;
+                if (!relationshipsResult.IsSignatureValid)
                 {
                     invalidSignatures++;
                     allSignaturesValid = false;
@@ -117,13 +136,30 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                         .ToHashSet());
             }
 
+            if (relationships is not null)
+            {
+                RelationshipDocumentValidator.ValidateEntityReferences(
+                    relationships,
+                    projectResult.Document.ProjectId,
+                    versionSnapshots.Select(static version => version.Version.VersionId).ToHashSet(),
+                    versionSnapshots
+                        .SelectMany(static version => version.Items)
+                        .Select(static item => item.ItemId)
+                        .ToHashSet());
+            }
+
             var trustState = allSignaturesValid ? TrustState.Trusted : TrustState.Untrusted;
             var summary = allSignaturesValid
                 ? $"Validated {totalDocuments} signed documents."
                 : $"Validated {totalDocuments} signed documents with {invalidSignatures} invalid signatures.";
 
             return new ProjectWorkspaceLoadResult(
-                new ProjectWorkspaceSnapshot(projectResult.Document, membersResult.Document, versionSnapshots, canvasLayout),
+                new ProjectWorkspaceSnapshot(
+                    projectResult.Document,
+                    membersResult.Document,
+                    versionSnapshots,
+                    canvasLayout,
+                    relationships),
                 new TrustReport(trustState, summary, DateTimeOffset.UtcNow));
         }
         catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException or InvalidOperationException)
@@ -160,6 +196,10 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
         if (workspace.CanvasLayout is not null)
         {
             SaveCanvasLayout(workspaceRoot, workspace.CanvasLayout, signingKey);
+        }
+        if (workspace.Relationships is not null)
+        {
+            SaveRelationships(workspaceRoot, workspace.Relationships, signingKey);
         }
 
         foreach (var versionSnapshot in workspace.Versions)
@@ -198,6 +238,21 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
             signingKey);
     }
 
+    public void SaveRelationships(
+        string workspaceRoot,
+        RelationshipDocument relationships,
+        SignatureKeyMaterial signingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(relationships);
+
+        RelationshipDocumentValidator.Validate(relationships, relationships.ProjectId);
+        _signedDocumentStore.Write(
+            GetRelationshipsDocumentPath(workspaceRoot),
+            relationships,
+            signingKey);
+    }
+
     private static ProjectWorkspaceSnapshot EmptyWorkspace() =>
         new(
             new ProjectConfigurationDocument(
@@ -231,6 +286,9 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
 
     private static string GetCanvasLayoutDocumentPath(string workspaceRoot) =>
         Path.Combine(GetProjectRoot(workspaceRoot), "canvas-layout.json");
+
+    private static string GetRelationshipsDocumentPath(string workspaceRoot) =>
+        Path.Combine(GetProjectRoot(workspaceRoot), "relationships.json");
 
     private static string GetVersionDirectory(string workspaceRoot, Guid versionId) =>
         Path.Combine(GetVersionsRoot(workspaceRoot), versionId.ToString("N"));

--- a/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
+++ b/Blueprints.Tests/FileSystemProjectWorkspaceStoreTests.cs
@@ -185,6 +185,93 @@ public sealed class FileSystemProjectWorkspaceStoreTests : IDisposable
         Assert.Contains("does not reference", result.TrustReport.Summary, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void SaveAndLoad_RoundTripsOptionalSignedRelationships()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        var workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        var workspace = CreateWorkspaceSnapshot();
+        var version = workspace.Versions.Single();
+        var relationships = new RelationshipDocument(
+            1,
+            workspace.Project.ProjectId,
+            2,
+            [new RelationshipTypeDefinition("blocks", "Blocks", null, "#E05A47", true)],
+            [
+                new RelationshipEdge(
+                    Guid.NewGuid(),
+                    "blocks",
+                    new RelationshipEndpoint("item", version.Items.Single().ItemId),
+                    new RelationshipEndpoint("version", version.Version.VersionId),
+                    "Required for release"),
+            ],
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Relationship Author");
+
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace with { Relationships = relationships },
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Trusted, result.TrustReport.State);
+        var loaded = Assert.IsType<RelationshipDocument>(result.Workspace.Relationships);
+        Assert.Equal(relationships.Types, loaded.Types);
+        Assert.Equal(relationships.Relationships, loaded.Relationships);
+        Assert.True(File.Exists(Path.Combine(_workspaceRoot, "project", "relationships.sig")));
+    }
+
+    [Fact]
+    public void Load_RejectsValidlySignedRelationshipsOutsideWorkspace()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+
+        var keyPair = new Ed25519KeyPairGenerator().Generate("workspace-admin");
+        var workspaceStore = new FileSystemProjectWorkspaceStore(
+            new FileSystemSignedDocumentStore(
+                new CanonicalJsonSerializer(),
+                new Ed25519SignatureService()));
+        var workspace = CreateWorkspaceSnapshot();
+        workspaceStore.Save(
+            _workspaceRoot,
+            workspace with
+            {
+                Relationships = new RelationshipDocument(
+                    1,
+                    workspace.Project.ProjectId,
+                    1,
+                    [new RelationshipTypeDefinition("related", "Related", null, "#52C7E8", false)],
+                    [
+                        new RelationshipEdge(
+                            Guid.NewGuid(),
+                            "related",
+                            new RelationshipEndpoint("project", workspace.Project.ProjectId),
+                            new RelationshipEndpoint("item", Guid.NewGuid()),
+                            null),
+                    ],
+                    DateTimeOffset.UtcNow,
+                    Guid.NewGuid(),
+                    "Relationship Author"),
+            },
+            new SignatureKeyMaterial(keyPair.KeyId, keyPair.PrivateKeyBytes));
+
+        var result = workspaceStore.Load(
+            _workspaceRoot,
+            new SignaturePublicKey(keyPair.KeyId, keyPair.PublicKeyBytes));
+
+        Assert.Equal(TrustState.Corrupt, result.TrustReport.State);
+        Assert.Contains("does not exist", result.TrustReport.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_workspaceRoot))

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -304,6 +304,119 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
     }
 
     [Fact]
+    public void Relationships_AreTypedSignedAuditedAndRemovable()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "relationships-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "relationships-shared", "BP");
+        var service = CreateService();
+        var created = service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "0.4.0", ReleaseStatus.InProgress, null));
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
+
+        var typeSession = service.SaveRelationshipType(
+            localRoot,
+            sharedRoot,
+            new RelationshipTypeEditRequest(
+                "blocks",
+                "Blocks",
+                "Must complete first",
+                "#E05A47",
+                true));
+        var edgeSession = service.SaveRelationship(
+            localRoot,
+            sharedRoot,
+            new RelationshipEditRequest(
+                null,
+                "blocks",
+                new RelationshipEndpoint("project", created.LoadResult.Workspace.Project.ProjectId),
+                new RelationshipEndpoint("version", versionId),
+                "Release gate"));
+
+        var document = Assert.IsType<RelationshipDocument>(
+            edgeSession.LoadResult.Workspace.Relationships);
+        Assert.Equal(2, document.Revision);
+        Assert.Single(document.Types);
+        var edge = Assert.Single(document.Relationships);
+        Assert.True(File.Exists(Path.Combine(localRoot, "project", "relationships.sig")));
+        Assert.Contains(
+            Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json"),
+            path => File.ReadAllText(path).Contains("relationship.create", StringComparison.Ordinal));
+
+        var removed = service.RemoveRelationship(
+            localRoot,
+            sharedRoot,
+            edge.RelationshipId);
+
+        Assert.Empty(removed.LoadResult.Workspace.Relationships!.Relationships);
+        Assert.Equal(3, removed.LoadResult.Workspace.Relationships.Revision);
+        Assert.NotNull(typeSession.LoadResult.Workspace.Relationships);
+    }
+
+    [Fact]
+    public void ArchiveItem_RemovesRelationshipsThatReferenceIt()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "relationship-archive-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "relationship-archive-shared", "BP");
+        var service = CreateService();
+        var created = service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "0.4.0", ReleaseStatus.InProgress, null));
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
+        var itemSession = service.SaveItem(
+            localRoot,
+            sharedRoot,
+            new ItemEditRequest(
+                versionId,
+                null,
+                "feature",
+                "added",
+                "Relationship target",
+                null,
+                false));
+        var itemId = itemSession.LoadResult.Workspace.Versions.Single().Items.Single().ItemId;
+        service.SaveRelationshipType(
+            localRoot,
+            sharedRoot,
+            new RelationshipTypeEditRequest(
+                "related",
+                "Related",
+                null,
+                "#52C7E8",
+                false));
+        service.SaveRelationship(
+            localRoot,
+            sharedRoot,
+            new RelationshipEditRequest(
+                null,
+                "related",
+                new RelationshipEndpoint("project", created.LoadResult.Workspace.Project.ProjectId),
+                new RelationshipEndpoint("item", itemId),
+                null));
+
+        var archived = service.ArchiveItem(localRoot, sharedRoot, versionId, itemId);
+
+        Assert.Empty(archived.Session.LoadResult.Workspace.Relationships!.Relationships);
+        Assert.Equal(3, archived.Session.LoadResult.Workspace.Relationships.Revision);
+    }
+
+    [Fact]
     public void PushWorkspace_PublishesLocalChangesAndRefreshesSyncState()
     {
         var localRoot = Path.Combine(_rootDirectory, "push-local", "BP");

--- a/Blueprints.Tests/RelationshipDocumentValidatorTests.cs
+++ b/Blueprints.Tests/RelationshipDocumentValidatorTests.cs
@@ -1,0 +1,140 @@
+using Blueprints.Core.Models;
+using Blueprints.Core.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class RelationshipDocumentValidatorTests
+{
+    [Fact]
+    public void Validate_AcceptsTypedDirectionalAndUndirectedRelationships()
+    {
+        var projectId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var document = CreateDocument(
+            projectId,
+            [
+                new RelationshipTypeDefinition("blocks", "Blocks", null, "#E05A47", true),
+                new RelationshipTypeDefinition("related", "Related", null, "#52C7E8", false),
+            ],
+            [
+                Edge("blocks", "item", itemId, "version", versionId),
+                Edge("related", "project", projectId, "item", itemId),
+            ]);
+
+        RelationshipDocumentValidator.Validate(document, projectId);
+        RelationshipDocumentValidator.ValidateEntityReferences(
+            document,
+            projectId,
+            new HashSet<Guid> { versionId },
+            new HashSet<Guid> { itemId });
+    }
+
+    [Fact]
+    public void Validate_RejectsUnknownTypesSelfLinksAndDuplicateUndirectedEdges()
+    {
+        var projectId = Guid.NewGuid();
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var type = new RelationshipTypeDefinition(
+            "related",
+            "Related",
+            null,
+            "#52C7E8",
+            false);
+
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.Validate(
+                CreateDocument(projectId, [type], [Edge("missing", "item", first, "item", second)]),
+                projectId));
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.Validate(
+                CreateDocument(projectId, [type], [Edge("related", "item", first, "item", first)]),
+                projectId));
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.Validate(
+                CreateDocument(
+                    projectId,
+                    [type],
+                    [
+                        Edge("related", "item", first, "item", second),
+                        Edge("related", "item", second, "item", first),
+                    ]),
+                projectId));
+    }
+
+    [Fact]
+    public void ValidateEntityReferences_RejectsEntitiesOutsideTheWorkspace()
+    {
+        var projectId = Guid.NewGuid();
+        var document = CreateDocument(
+            projectId,
+            [new RelationshipTypeDefinition("blocks", "Blocks", null, "#E05A47", true)],
+            [Edge("blocks", "item", Guid.NewGuid(), "project", projectId)]);
+
+        RelationshipDocumentValidator.Validate(document, projectId);
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.ValidateEntityReferences(
+                document,
+                projectId,
+                new HashSet<Guid>(),
+                new HashSet<Guid>()));
+    }
+
+    [Theory]
+    [InlineData("Uppercase")]
+    [InlineData("contains spaces")]
+    [InlineData("1starts-with-number")]
+    [InlineData("this-relationship-type-id-is-far-too-long")]
+    public void Validate_RejectsInvalidTypeIds(string typeId)
+    {
+        var projectId = Guid.NewGuid();
+        var document = CreateDocument(
+            projectId,
+            [new RelationshipTypeDefinition(typeId, "Type", null, "#52C7E8", true)],
+            []);
+
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.Validate(document, projectId));
+    }
+
+    [Fact]
+    public void Validate_RejectsNullFieldsAsValidationErrors()
+    {
+        var projectId = Guid.NewGuid();
+        var document = CreateDocument(
+            projectId,
+            [new RelationshipTypeDefinition(null!, "Type", null, null!, true)],
+            []);
+
+        Assert.Throws<InvalidOperationException>(
+            () => RelationshipDocumentValidator.Validate(document, projectId));
+    }
+
+    private static RelationshipDocument CreateDocument(
+        Guid projectId,
+        IReadOnlyList<RelationshipTypeDefinition> types,
+        IReadOnlyList<RelationshipEdge> relationships) =>
+        new(
+            1,
+            projectId,
+            1,
+            types,
+            relationships,
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Editor");
+
+    private static RelationshipEdge Edge(
+        string typeId,
+        string sourceType,
+        Guid sourceId,
+        string targetType,
+        Guid targetId) =>
+        new(
+            Guid.NewGuid(),
+            typeId,
+            new RelationshipEndpoint(sourceType, sourceId),
+            new RelationshipEndpoint(targetType, targetId),
+            null);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Bounded read-only discovery for up to 100 GitHub pull requests and 50 GitHub release records per linked repository, including merge/publication state and provider-neutral provenance.
 - Repository-linked GitHub Project discovery for standalone draft items through a bounded read-only GraphQL query covering at most 10 projects, 100 items per project, and 100 returned drafts.
 - An injectable provider-neutral hosted-source reader boundary, keeping repository discovery and approval workflows independent from the current authenticated GitHub CLI implementation.
+- User-defined directional or undirected relationship types with validated colors and optional descriptions, plus signed relationships between project, version, and work-item nodes.
+- Relationship authoring and removal in the canvas inspector, colored relationship projection on the canvas, archive cleanup, audit operations, and document-aware conflict summaries.
 
 ### Changed
 
@@ -22,6 +24,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Source Lens accepts one repository path per line and preserves the full repository-qualified provenance of combined proposals.
 - Source Lens proposals now expose structured provider, repository, artifact kind, identifier, and optional web location instead of relying only on GitHub-specific display strings.
 - Combined Source Lens summaries now separate issue, pull-request, release, and project-linked proposal counts.
+- Schema-1 workspaces may contain an optional signed `project/relationships.json`; missing files remain compatible with earlier workspaces and the complete relationship graph is one revisioned conflict domain.
 
 ## 0.3.0 — 2026-07-30
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -67,7 +67,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Read local Git root, branch, remote, dirty state, tag, and recent commits.
 - [x] Match item keys in commit subjects for changelog context.
 - [x] Expand canvas editing with box selection, multi-select, keyboard movement, alignment guides, and a minimap.
-- [ ] Add user-created typed relationships after defining their domain and conflict semantics.
+- [x] Add user-created typed relationships after defining their domain and conflict semantics.
 - [x] Link a Blueprints project to one or more repositories.
 - [x] Add release-readiness diagnostics for uncommitted and unmatched changes.
 - [x] Define provider-neutral issue, pull-request, and release references.

--- a/docs/canvas-engine.md
+++ b/docs/canvas-engine.md
@@ -15,9 +15,18 @@ project
 - The project node uses `ProjectConfigurationDocument.ProjectId`.
 - A version node uses `VersionDocument.VersionId`.
 - A work-item node uses `ItemDocument.ItemId`.
-- Connector lines are derived from version ownership; they are not persisted separately.
+- Ownership connector lines are derived from version ownership; they are not persisted separately.
+- User-created typed connectors are projected from the optional signed relationship graph.
 
 Changing a node title, state, category, or completion value uses the existing version and item workflows. Moving a node changes only the layout document.
+
+## Typed relationships
+
+The inspector can define a relationship type with a stable lowercase ID, display name, optional description, `#RRGGBB` canvas color, and directional flag. A relationship then connects any two different existing project, version, or item nodes and may carry a short label. Its color is projected on the canvas alongside the built-in ownership lines.
+
+Relationship types and edges are stored together in `project/relationships.json`. Every edit increments the document revision, writes canonical signed JSON, and adds a specific audit action. A type cannot change between directional and undirected while an edge uses it. Archiving a version or item removes dangling edges in the same signed archive operation.
+
+The validator permits at most 100 types and 5,000 edges, rejects unknown types and entities, empty or duplicate IDs, self-links, malformed colors, and duplicate logical edges. For an undirected type, reversing endpoints does not create a distinct edge.
 
 ## Interaction model
 
@@ -112,13 +121,16 @@ Two collaborators moving the same canvas from a common baseline may produce a co
 
 Version and work-item content remain separate documents. A layout conflict does not imply that their content has conflicted.
 
+The relationship graph follows the same whole-document rule. A conflict in `project/relationships.json` compares revision, types, edges, update time, and author for diagnosis, then requires choosing the complete local or shared graph. Schema 1 deliberately does not attempt an unsafe automatic edge merge.
+
 ## Current limits
 
 - There is one shared release-planning canvas per project.
 - Node positions are shared project state, not per-user preferences.
-- Connectors represent ownership and cannot yet be created as arbitrary edge types.
+- Directional typed relationships use distinct type semantics and color, but the canvas does not yet draw arrowheads or edit labels directly on an edge.
 - Multi-selection groups nodes for movement only; it does not create a persistent group entity.
 - Auto arrangement is deterministic but not a graph-optimization engine.
 - Layout conflict resolution is whole-document.
+- Relationship conflict resolution is whole-document.
 
 These are product limitations, not hidden behavior. Planned work belongs in the canonical [roadmap](../Roadmap.md).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,18 @@ A new teammate can export a signed identity invitation directly from the setup s
 5. Drag nodes to arrange the working view, and use zoom or **Fit view** to navigate larger plans.
 6. Mark completed items as ready for release notes.
 
-The lines on the canvas represent real project relationships: a work item is connected to the version that owns it. Item keys are generated from project rules. Released versions are immutable.
+The standard lines on the canvas represent ownership: a work item belongs to its version. Item keys are generated from project rules. Released versions are immutable.
+
+## Connect typed relationships
+
+Use **Typed relationships** in the canvas inspector when the ownership hierarchy is not enough:
+
+1. Select **+**, enter a lowercase type ID such as `blocks`, a name, color, and optional meaning.
+2. Choose whether the type is directional, then save it.
+3. Choose a source and target node, add an optional label, and select **Save**.
+4. Select an existing relationship to edit or remove it.
+
+Typed connectors appear in their configured color. Their definitions and endpoints are signed shared project state, so changes participate in audit, push, pull, trust checks, and whole-document conflict resolution. An endpoint must exist in the current project and cannot point to itself. Archiving a node also removes relationships that would otherwise dangle.
 
 ## Arrange and share the canvas
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -12,7 +12,9 @@ This document describes the current schema-1 layout. The format is pre-release a
 │   ├── members.json
 │   ├── members.sig
 │   ├── canvas-layout.json      # optional until first layout save
-│   └── canvas-layout.sig
+│   ├── canvas-layout.sig
+│   ├── relationships.json      # optional until first relationship type save
+│   └── relationships.sig
 ├── versions/
 │   └── <version-id-without-dashes>/
 │       ├── version.json
@@ -105,6 +107,43 @@ The real project ID replaces the illustrative zero GUIDs. The file is optional f
 
 See [canvas engine](canvas-engine.md) for validation limits and interaction behavior.
 
+### `relationships.json`
+
+Contains user-defined relationship types and edges without changing the ownership hierarchy:
+
+```json
+{
+  "schemaVersion": 1,
+  "projectId": "00000000-0000-0000-0000-000000000000",
+  "revision": 1,
+  "types": [
+    {
+      "typeId": "blocks",
+      "name": "Blocks",
+      "description": "Must complete first",
+      "colorHex": "#E05A47",
+      "isDirectional": true
+    }
+  ],
+  "relationships": [
+    {
+      "relationshipId": "00000000-0000-0000-0000-000000000000",
+      "typeId": "blocks",
+      "source": { "nodeType": "item", "entityId": "00000000-0000-0000-0000-000000000000" },
+      "target": { "nodeType": "version", "entityId": "00000000-0000-0000-0000-000000000000" },
+      "label": "Release gate"
+    }
+  ],
+  "updatedUtc": "2026-07-30T00:00:00+00:00",
+  "lastModifiedByUserId": "00000000-0000-0000-0000-000000000000",
+  "lastModifiedByName": "Local Admin"
+}
+```
+
+Real entity IDs replace the illustrative zero GUIDs. Type IDs are lowercase slugs, colors use `#RRGGBB`, endpoints must be different existing project/version/item nodes, and duplicate logical edges are rejected. Undirected edges treat A–B and B–A as the same relationship. Archiving an entity removes every edge that references it and advances the relationship revision.
+
+The file is signed, audited, synchronized, and optional for schema-1 compatibility. The complete document is one conflict domain: conflict resolution chooses the local or shared type-and-edge graph as a whole.
+
 ### `.blueprints/canvas-view.json`
 
 Contains machine-local zoom and scroll offsets. It is deliberately unsigned and excluded from exchange snapshots. Invalid or missing view state falls back to zoom `1` and zero offsets without changing workspace trust.
@@ -125,7 +164,7 @@ Contains a unique change ID, operation, human summary, author, membership revisi
 
 ## Compatibility
 
-There is no general migration engine yet. Optional schema-1 documents, including the canvas layout, use explicit missing-file compatibility. Do not manually change `schemaVersion`. Before adopting a future schema, preserve a complete copy of the workspace and identity data.
+There is no general migration engine yet. Optional schema-1 documents, including the canvas layout and relationship graph, use explicit missing-file compatibility. Do not manually change `schemaVersion`. Before adopting a future schema, preserve a complete copy of the workspace and identity data.
 
 ## Files that must never be shared as project data
 


### PR DESCRIPTION
## Summary
- add an optional signed, revisioned relationship graph with user-defined directional and undirected types
- validate entity endpoints, logical duplicates, bounded input, archive cleanup, audit operations, sync behavior, and whole-document conflict summaries
- add inspector authoring, colored canvas projection, schema documentation, roadmap tracking, and workspace compatibility guidance

## Verification
- `dotnet test Blueprints.sln --no-restore` (112 passed)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (no vulnerable packages)
- application startup smoke test