### PR TITLE
Replace CLI discovery with direct provider access

### DIFF
--- a/Blueprints.App/Models/ProviderOperationIntent.cs
+++ b/Blueprints.App/Models/ProviderOperationIntent.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record ProviderOperationIntent(
+    SourceProviderKind Provider,
+    string Repository,
+    ProviderOperationKind Operation,
+    string Target);

--- a/Blueprints.App/Models/ProviderOperationKind.cs
+++ b/Blueprints.App/Models/ProviderOperationKind.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.App.Models;
+
+public enum ProviderOperationKind
+{
+    ReadSource = 0,
+    CreateIssue = 1,
+    UpdateIssue = 2,
+    UpdateProject = 3,
+    CreateDraftRelease = 4,
+    PublishRelease = 5,
+}

--- a/Blueprints.App/Models/ProviderWriteApproval.cs
+++ b/Blueprints.App/Models/ProviderWriteApproval.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record ProviderWriteApproval(
+    Guid ApprovalId,
+    ProviderOperationIntent Intent,
+    DateTimeOffset ApprovedUtc,
+    DateTimeOffset ExpiresUtc);

--- a/Blueprints.App/Services/EnvironmentProviderCredentialSource.cs
+++ b/Blueprints.App/Services/EnvironmentProviderCredentialSource.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.App.Services;
+
+public sealed class EnvironmentProviderCredentialSource : IProviderCredentialSource
+{
+    public string? GetGitHubToken()
+    {
+        var token = Environment.GetEnvironmentVariable("BLUEPRINTS_GITHUB_TOKEN");
+        return string.IsNullOrWhiteSpace(token) ? null : token.Trim();
+    }
+}

--- a/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
+++ b/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class GitHubRestSourceProviderReader : IHostedSourceProviderReader
+{
+    private const string ApiVersion = "2022-11-28";
+    private const string ProjectDraftQuery =
+        "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){" +
+        "projectsV2(first:10){nodes{number title url items(first:100){nodes{id type content{" +
+        "__typename ... on DraftIssue{title body} ... on Issue{" +
+        "number title body state url labels(first:20){nodes{name}}} ... on PullRequest{number}" +
+        "}}}}}}}";
+    private readonly HttpClient _httpClient;
+    private readonly IProviderCredentialSource _credentialSource;
+
+    public GitHubRestSourceProviderReader()
+        : this(
+            new HttpClient
+            {
+                BaseAddress = new Uri("https://api.github.com/", UriKind.Absolute),
+                Timeout = TimeSpan.FromSeconds(15),
+            },
+            new EnvironmentProviderCredentialSource())
+    {
+    }
+
+    public GitHubRestSourceProviderReader(
+        HttpClient httpClient,
+        IProviderCredentialSource credentialSource)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(credentialSource);
+        _httpClient = httpClient;
+        _credentialSource = credentialSource;
+    }
+
+    public HostedSourceDiscoveryResult Read(
+        string repositoryRoot,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        ValidateRepositoryName(repositoryName);
+
+        var token = _credentialSource.GetGitHubToken();
+        var issuesTask = ReadRestAsync(
+            $"repos/{repositoryName}/issues?state=all&per_page=100",
+            repositoryName,
+            "issues",
+            GitHubSourceJsonParser.ParseIssues,
+            token);
+        var pullRequestsTask = ReadRestAsync(
+            $"repos/{repositoryName}/pulls?state=all&per_page=100",
+            repositoryName,
+            "pull requests",
+            GitHubSourceJsonParser.ParsePullRequests,
+            token);
+        var releasesTask = ReadRestAsync(
+            $"repos/{repositoryName}/releases?per_page=50",
+            repositoryName,
+            "releases",
+            GitHubSourceJsonParser.ParseReleases,
+            token);
+        var projectItemsTask = string.IsNullOrWhiteSpace(token)
+            ? Task.FromResult(new ProviderReadResult(
+                [],
+                ["GitHub Projects require BLUEPRINTS_GITHUB_TOKEN and were skipped."]))
+            : ReadProjectItemsAsync(repositoryName, token);
+        Task.WhenAll(
+                issuesTask,
+                pullRequestsTask,
+                releasesTask,
+                projectItemsTask)
+            .GetAwaiter()
+            .GetResult();
+        var issues = issuesTask.Result;
+        var pullRequests = pullRequestsTask.Result;
+        var releases = releasesTask.Result;
+        var projectItems = projectItemsTask.Result;
+        var projectIssueIds = projectItems.Candidates
+            .Where(static candidate =>
+                candidate.ProviderReference?.Kind == ProviderReferenceKind.Issue)
+            .Select(static candidate => candidate.ProviderReference!.Identifier)
+            .ToHashSet(StringComparer.Ordinal);
+        var unlinkedIssues = issues.Candidates
+            .Where(candidate =>
+                candidate.ProviderReference is null ||
+                !projectIssueIds.Contains(candidate.ProviderReference.Identifier))
+            .ToArray();
+
+        return new HostedSourceDiscoveryResult(
+            [
+                .. unlinkedIssues,
+                .. pullRequests.Candidates,
+                .. releases.Candidates,
+                .. projectItems.Candidates,
+            ],
+            [
+                .. issues.Warnings,
+                .. pullRequests.Warnings,
+                .. releases.Warnings,
+                .. projectItems.Warnings,
+            ],
+            issues.Candidates.Count,
+            projectItems.Candidates.Count,
+            pullRequests.Candidates.Count,
+            releases.Candidates.Count);
+    }
+
+    private async Task<ProviderReadResult> ReadRestAsync(
+        string relativeUri,
+        string repositoryName,
+        string sourceName,
+        Func<string, string, IReadOnlyList<SourceDiscoveryCandidate>> parser,
+        string? token)
+    {
+        try
+        {
+            using var request = CreateRequest(HttpMethod.Get, relativeUri, token);
+            using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead)
+                .ConfigureAwait(false);
+            var body = await ReadBoundedBodyAsync(response).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return Failure(sourceName, response.StatusCode);
+            }
+
+            return new ProviderReadResult(parser(body, repositoryName), []);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or
+            TaskCanceledException or
+            JsonException or
+            InvalidOperationException)
+        {
+            return new ProviderReadResult(
+                [],
+                [$"GitHub {sourceName} were skipped: {SafeMessage(exception.Message)}"]);
+        }
+    }
+
+    private async Task<ProviderReadResult> ReadProjectItemsAsync(
+        string repositoryName,
+        string token)
+    {
+        var separator = repositoryName.IndexOf('/');
+        var payload = JsonSerializer.Serialize(
+            new
+            {
+                query = ProjectDraftQuery,
+                variables = new
+                {
+                    owner = repositoryName[..separator],
+                    name = repositoryName[(separator + 1)..],
+                },
+            });
+        try
+        {
+            using var request = CreateRequest(HttpMethod.Post, "graphql", token);
+            request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead)
+                .ConfigureAwait(false);
+            var body = await ReadBoundedBodyAsync(response).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return Failure("Projects", response.StatusCode);
+            }
+
+            using (var document = JsonDocument.Parse(body))
+            {
+                if (document.RootElement.TryGetProperty("errors", out var errors) &&
+                    errors.ValueKind == JsonValueKind.Array &&
+                    errors.GetArrayLength() > 0)
+                {
+                    return new ProviderReadResult(
+                        [],
+                        ["GitHub Projects were skipped: GraphQL returned an error."]);
+                }
+            }
+
+            return new ProviderReadResult(
+                GitHubSourceJsonParser.ParseProjectItems(body, repositoryName),
+                []);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or
+            TaskCanceledException or
+            JsonException or
+            InvalidOperationException)
+        {
+            return new ProviderReadResult(
+                [],
+                [$"GitHub Projects were skipped: {SafeMessage(exception.Message)}"]);
+        }
+    }
+
+    private static HttpRequestMessage CreateRequest(
+        HttpMethod method,
+        string relativeUri,
+        string? token)
+    {
+        var request = new HttpRequestMessage(method, relativeUri);
+        request.Headers.UserAgent.ParseAdd("Blueprints/0.4");
+        request.Headers.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.Add("X-GitHub-Api-Version", ApiVersion);
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return request;
+    }
+
+    private static async Task<string> ReadBoundedBodyAsync(
+        HttpResponseMessage response)
+    {
+        const int maximumResponseBytes = 4 * 1024 * 1024;
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength > maximumResponseBytes)
+        {
+            throw new InvalidOperationException(
+                "GitHub response exceeded the 4 MiB safety limit.");
+        }
+
+        await using var stream = await response.Content
+            .ReadAsStreamAsync()
+            .ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        while (true)
+        {
+            var read = await stream
+                .ReadAsync(chunk.AsMemory())
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            if (buffer.Length + read > maximumResponseBytes)
+            {
+                throw new InvalidOperationException(
+                    "GitHub response exceeded the 4 MiB safety limit.");
+            }
+            buffer.Write(chunk, 0, read);
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static ProviderReadResult Failure(
+        string sourceName,
+        HttpStatusCode statusCode) =>
+        new(
+            [],
+            [
+                $"GitHub {sourceName} were skipped: API returned " +
+                $"{(int)statusCode} {statusCode}.",
+            ]);
+
+    private static void ValidateRepositoryName(string repositoryName)
+    {
+        var parts = repositoryName.Split('/');
+        if (parts.Length != 2 ||
+            parts.Any(static part =>
+                string.IsNullOrWhiteSpace(part) ||
+                part is "." or ".." ||
+                part.Any(static character =>
+                    !(char.IsAsciiLetterOrDigit(character) ||
+                      character is '-' or '_' or '.'))))
+        {
+            throw new InvalidOperationException(
+                "GitHub repository identity must use owner/name syntax.");
+        }
+    }
+
+    private static string SafeMessage(string message)
+    {
+        const int maximumLength = 300;
+        var normalized = message.ReplaceLineEndings(" ").Trim();
+        return normalized.Length <= maximumLength
+            ? normalized
+            : normalized[..maximumLength] + "…";
+    }
+
+    private sealed record ProviderReadResult(
+        IReadOnlyList<SourceDiscoveryCandidate> Candidates,
+        IReadOnlyList<string> Warnings);
+}

--- a/Blueprints.App/Services/GitHubSourceJsonParser.cs
+++ b/Blueprints.App/Services/GitHubSourceJsonParser.cs
@@ -5,6 +5,20 @@ namespace Blueprints.App.Services;
 
 public static class GitHubSourceJsonParser
 {
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseIssues(
+        string json,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(100)
+            .Where(static issue => !issue.TryGetProperty("pull_request", out _))
+            .Select(issue => ParseIssue(issue, repositoryName))
+            .ToArray();
+    }
+
     public static IReadOnlyList<SourceDiscoveryCandidate> ParseProjectDrafts(
         string json,
         string repositoryName)
@@ -27,6 +41,30 @@ public static class GitHubSourceJsonParser
             .SelectMany(project => ParseProjectDrafts(project, repositoryName))
             .Take(100)
             .ToArray();
+    }
+
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseProjectItems(
+        string json,
+        string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        using var document = JsonDocument.Parse(json);
+        if (!TryReadProjectNodes(document.RootElement, out var projectNodes))
+        {
+            return [];
+        }
+
+        var projects = projectNodes
+            .EnumerateArray()
+            .Take(10)
+            .ToArray();
+        var drafts = projects
+            .SelectMany(project => ParseProjectDrafts(project, repositoryName))
+            .Take(100);
+        var linkedIssues = projects
+            .SelectMany(project => ParseProjectLinkedIssues(project, repositoryName))
+            .Take(100);
+        return [.. drafts, .. linkedIssues];
     }
 
     public static IReadOnlyList<SourceDiscoveryCandidate> ParsePullRequests(
@@ -63,8 +101,8 @@ public static class GitHubSourceJsonParser
         var title = pullRequest.GetProperty("title").GetString()?.Trim() ?? $"Pull request #{number}";
         var body = ReadString(pullRequest, "body");
         var state = ReadString(pullRequest, "state");
-        var mergedAt = ReadString(pullRequest, "mergedAt");
-        var url = ReadString(pullRequest, "url");
+        var mergedAt = ReadString(pullRequest, "mergedAt", "merged_at");
+        var url = ReadString(pullRequest, "html_url", "url");
         var labels = ReadLabels(pullRequest);
         var completed = !string.Equals(state, "OPEN", StringComparison.OrdinalIgnoreCase);
         var context = string.IsNullOrWhiteSpace(mergedAt)
@@ -136,16 +174,80 @@ public static class GitHubSourceJsonParser
             .ToArray();
     }
 
+    private static IReadOnlyList<SourceDiscoveryCandidate> ParseProjectLinkedIssues(
+        JsonElement project,
+        string repositoryName)
+    {
+        var projectNumber = project.GetProperty("number").GetInt32();
+        var projectTitle = ReadString(project, "title") ?? $"Project {projectNumber}";
+        var projectUrl = ReadString(project, "url");
+        if (!project.TryGetProperty("items", out var items) ||
+            !items.TryGetProperty("nodes", out var itemNodes) ||
+            itemNodes.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var linkedIssues = itemNodes
+            .EnumerateArray()
+            .Take(100)
+            .Where(static item =>
+                item.TryGetProperty("content", out var content) &&
+                content.ValueKind == JsonValueKind.Object &&
+                ReadString(content, "__typename") == "Issue")
+            .Select(item =>
+            {
+                var content = item.GetProperty("content");
+                var number = content.GetProperty("number").GetInt32();
+                var title = ReadString(content, "title") ?? $"Issue #{number}";
+                var state = ReadString(content, "state");
+                var labels = ReadLabels(content);
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.GitHubProject,
+                    title,
+                    Truncate(ReadString(content, "body"), 2_000),
+                    SuggestItemType(labels, title),
+                    SuggestCategory(
+                        labels,
+                        string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase)),
+                    string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase),
+                    $"github:#{number}",
+                    $"{projectTitle} · linked issue #{number}",
+                    0.97,
+                    new ProviderReference(
+                        SourceProviderKind.GitHub,
+                        ProviderReferenceKind.Issue,
+                        repositoryName,
+                        $"#{number}",
+                        ReadString(content, "url") ?? projectUrl));
+            });
+
+        return linkedIssues.ToArray();
+    }
+
+    private static bool TryReadProjectNodes(
+        JsonElement root,
+        out JsonElement projectNodes)
+    {
+        projectNodes = default;
+        return root.TryGetProperty("data", out var data) &&
+               data.TryGetProperty("repository", out var repository) &&
+               repository.ValueKind == JsonValueKind.Object &&
+               repository.TryGetProperty("projectsV2", out var projects) &&
+               projects.TryGetProperty("nodes", out projectNodes) &&
+               projectNodes.ValueKind == JsonValueKind.Array;
+    }
+
     private static SourceDiscoveryCandidate ParseRelease(
         JsonElement release,
         string repositoryName)
     {
-        var tag = ReadString(release, "tagName") ?? "(untagged)";
+        var tag = ReadString(release, "tagName", "tag_name") ?? "(untagged)";
         var name = ReadString(release, "name");
-        var isDraft = ReadBoolean(release, "isDraft");
-        var isPrerelease = ReadBoolean(release, "isPrerelease");
-        var publishedAt = ReadString(release, "publishedAt");
-        var url = ReadString(release, "url")
+        var isDraft = ReadBoolean(release, "isDraft", "draft");
+        var isPrerelease = ReadBoolean(release, "isPrerelease", "prerelease");
+        var publishedAt = ReadString(release, "publishedAt", "published_at");
+        var url = ReadString(release, "html_url", "url")
             ?? $"https://github.com/{repositoryName}/releases/tag/{Uri.EscapeDataString(tag)}";
         var title = string.IsNullOrWhiteSpace(name) ? tag : name;
         var states = new[]
@@ -174,15 +276,98 @@ public static class GitHubSourceJsonParser
                 url));
     }
 
-    private static IReadOnlyList<string> ReadLabels(JsonElement element) =>
-        element.TryGetProperty("labels", out var labels) && labels.ValueKind == JsonValueKind.Array
+    private static SourceDiscoveryCandidate ParseIssue(
+        JsonElement issue,
+        string repositoryName)
+    {
+        var number = issue.GetProperty("number").GetInt32();
+        var title = ReadString(issue, "title") ?? $"Issue #{number}";
+        var body = ReadString(issue, "body");
+        var state = ReadString(issue, "state");
+        var url = ReadString(issue, "html_url", "url");
+        var labels = ReadLabels(issue);
+        var milestone = issue.TryGetProperty("milestone", out var milestoneElement) &&
+                        milestoneElement.ValueKind == JsonValueKind.Object
+            ? ReadString(milestoneElement, "title")
+            : null;
+        var projects = ReadProjectNames(issue);
+        var context = new[]
+            {
+                milestone is null ? null : $"Milestone: {milestone}",
+                projects.Count == 0 ? null : $"Projects: {string.Join(", ", projects)}",
+                labels.Count == 0 ? null : $"Labels: {string.Join(", ", labels)}",
+            }
+            .Where(static value => value is not null)
+            .DefaultIfEmpty($"GitHub issue #{number}");
+
+        return new SourceDiscoveryCandidate(
+            projects.Count > 0
+                ? SourceArtifactKind.GitHubProject
+                : SourceArtifactKind.GitHubIssue,
+            title,
+            Truncate(body, 2_000),
+            SuggestItemType(labels, title),
+            SuggestCategory(
+                labels,
+                string.Equals(state, "closed", StringComparison.OrdinalIgnoreCase)),
+            string.Equals(state, "closed", StringComparison.OrdinalIgnoreCase),
+            $"github:#{number}",
+            string.Join(" · ", context),
+            projects.Count > 0 ? 0.97 : 0.93,
+            new ProviderReference(
+                SourceProviderKind.GitHub,
+                ProviderReferenceKind.Issue,
+                repositoryName,
+                $"#{number}",
+                url));
+    }
+
+    private static IReadOnlyList<string> ReadProjectNames(JsonElement issue)
+    {
+        if (!issue.TryGetProperty("projectItems", out var projects) ||
+            projects.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return projects
+            .EnumerateArray()
+            .Select(static project =>
+                ReadString(project, "title") ??
+                (project.TryGetProperty("project", out var nested)
+                    ? ReadString(nested, "title")
+                    : null))
+            .Where(static title => !string.IsNullOrWhiteSpace(title))
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> ReadLabels(JsonElement element)
+    {
+        if (!element.TryGetProperty("labels", out var labels))
+        {
+            return [];
+        }
+
+        if (labels.ValueKind == JsonValueKind.Object &&
+            labels.TryGetProperty("nodes", out var nodes))
+        {
+            labels = nodes;
+        }
+
+        return labels.ValueKind == JsonValueKind.Array
             ? labels
                 .EnumerateArray()
-                .Select(static label => label.TryGetProperty("name", out var name) ? name.GetString() : null)
+                .Select(static label =>
+                    label.TryGetProperty("name", out var name)
+                        ? name.GetString()
+                        : null)
                 .Where(static name => !string.IsNullOrWhiteSpace(name))
                 .Cast<string>()
                 .ToArray()
             : [];
+    }
 
     private static string SuggestItemType(IReadOnlyList<string> labels, string title)
     {
@@ -218,15 +403,38 @@ public static class GitHubSourceJsonParser
         return completed ? "changed" : "added";
     }
 
-    private static string? ReadString(JsonElement element, string propertyName) =>
-        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+    private static string? ReadString(
+        JsonElement element,
+        string propertyName,
+        string? alternativePropertyName = null)
+    {
+        if (!element.TryGetProperty(propertyName, out var value) &&
+            (alternativePropertyName is null ||
+             !element.TryGetProperty(alternativePropertyName, out value)))
+        {
+            return null;
+        }
+
+        return value.ValueKind == JsonValueKind.String
             ? value.GetString()?.Trim()
             : null;
+    }
 
-    private static bool ReadBoolean(JsonElement element, string propertyName) =>
-        element.TryGetProperty(propertyName, out var value)
-        && value.ValueKind is JsonValueKind.True or JsonValueKind.False
-        && value.GetBoolean();
+    private static bool ReadBoolean(
+        JsonElement element,
+        string propertyName,
+        string? alternativePropertyName = null)
+    {
+        if (!element.TryGetProperty(propertyName, out var value) &&
+            (alternativePropertyName is null ||
+             !element.TryGetProperty(alternativePropertyName, out value)))
+        {
+            return false;
+        }
+
+        return value.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+               value.GetBoolean();
+    }
 
     private static string? Truncate(string? value, int maximumLength) =>
         string.IsNullOrWhiteSpace(value)

--- a/Blueprints.App/Services/IProviderCredentialSource.cs
+++ b/Blueprints.App/Services/IProviderCredentialSource.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.App.Services;
+
+public interface IProviderCredentialSource
+{
+    string? GetGitHubToken();
+}

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -6,20 +6,34 @@ public sealed class IntegrationStatusService
 {
     private readonly IIntegrationSettingsStore _settingsStore;
     private readonly ILocalGitRepositoryInspector _localGitRepositoryInspector;
+    private readonly IProviderCredentialSource _providerCredentialSource;
 
     public IntegrationStatusService()
         : this(
             new FileSystemIntegrationSettingsStore(AppEnvironment.GetIntegrationSettingsPath()),
-            new GitCommandLocalGitRepositoryInspector())
+            new GitCommandLocalGitRepositoryInspector(),
+            new EnvironmentProviderCredentialSource())
     {
     }
 
     public IntegrationStatusService(
         IIntegrationSettingsStore settingsStore,
         ILocalGitRepositoryInspector localGitRepositoryInspector)
+        : this(
+            settingsStore,
+            localGitRepositoryInspector,
+            new EnvironmentProviderCredentialSource())
+    {
+    }
+
+    public IntegrationStatusService(
+        IIntegrationSettingsStore settingsStore,
+        ILocalGitRepositoryInspector localGitRepositoryInspector,
+        IProviderCredentialSource providerCredentialSource)
     {
         _settingsStore = settingsStore;
         _localGitRepositoryInspector = localGitRepositoryInspector;
+        _providerCredentialSource = providerCredentialSource;
     }
 
     public IReadOnlyList<IntegrationStatusCard> GetIntegrationStatuses()
@@ -30,16 +44,7 @@ public sealed class IntegrationStatusService
         return
         [
             .. GetLocalGitStatuses(settings, checkedAtUtc),
-            new IntegrationStatusCard(
-                IntegrationProviderType.GitHub,
-                "GitHub",
-                IntegrationConnectionState.NotConfigured,
-                "No GitHub repository linked",
-                "GitHub should enrich releases with issues, pull requests, checks, and draft release publishing.",
-                "Connect only after the provider-agnostic repository and release models are stable. Remote writes must be explicit user actions.",
-                BlueprintsTrustBoundary(),
-                checkedAtUtc,
-                []),
+            GetGitHubStatus(checkedAtUtc),
             new IntegrationStatusCard(
                 IntegrationProviderType.GitLab,
                 "GitLab",
@@ -66,6 +71,30 @@ public sealed class IntegrationStatusService
     public IntegrationSettings GetSettings() => _settingsStore.Load();
 
     public void SaveSettings(IntegrationSettings settings) => _settingsStore.Save(settings);
+
+    private IntegrationStatusCard GetGitHubStatus(DateTimeOffset checkedAtUtc)
+    {
+        var hasCredential = !string.IsNullOrWhiteSpace(
+            _providerCredentialSource.GetGitHubToken());
+        return new IntegrationStatusCard(
+            IntegrationProviderType.GitHub,
+            "GitHub",
+            hasCredential
+                ? IntegrationConnectionState.Connected
+                : IntegrationConnectionState.Warning,
+            hasCredential
+                ? "Direct API credential available"
+                : "Public API discovery only",
+            hasCredential
+                ? "Source Lens can read issues, pull requests, releases, and repository-linked Project drafts through GitHub's API."
+                : "Source Lens can read public issues, pull requests, and releases. Private repositories and Project drafts require an environment credential.",
+            hasCredential
+                ? "The credential is read from BLUEPRINTS_GITHUB_TOKEN and is never persisted by Blueprints. Provider access remains read-only."
+                : "Set BLUEPRINTS_GITHUB_TOKEN in the application environment when private or Project discovery is needed.",
+            BlueprintsTrustBoundary(),
+            checkedAtUtc,
+            []);
+    }
 
     private IReadOnlyList<IntegrationStatusCard> GetLocalGitStatuses(
         IntegrationSettings settings,

--- a/Blueprints.App/Services/ProviderOperationPolicy.cs
+++ b/Blueprints.App/Services/ProviderOperationPolicy.cs
@@ -1,0 +1,59 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class ProviderOperationPolicy
+{
+    public static readonly TimeSpan MaximumApprovalLifetime = TimeSpan.FromMinutes(10);
+    private readonly HashSet<Guid> _consumedApprovals = [];
+    private readonly Lock _lock = new();
+
+    public void Authorize(
+        ProviderOperationIntent intent,
+        ProviderWriteApproval? approval,
+        DateTimeOffset nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(intent);
+        ValidateIntent(intent);
+        if (intent.Operation == ProviderOperationKind.ReadSource)
+        {
+            return;
+        }
+
+        if (approval is null)
+        {
+            throw new InvalidOperationException(
+                "Provider write operations require a separate explicit approval.");
+        }
+
+        if (approval.ApprovalId == Guid.Empty ||
+            approval.Intent != intent ||
+            approval.ApprovedUtc > nowUtc ||
+            approval.ExpiresUtc <= nowUtc ||
+            approval.ExpiresUtc - approval.ApprovedUtc > MaximumApprovalLifetime)
+        {
+            throw new InvalidOperationException(
+                "Provider write approval is invalid, expired, or does not match the exact operation.");
+        }
+
+        lock (_lock)
+        {
+            if (!_consumedApprovals.Add(approval.ApprovalId))
+            {
+                throw new InvalidOperationException(
+                    "Provider write approval has already been consumed.");
+            }
+        }
+    }
+
+    private static void ValidateIntent(ProviderOperationIntent intent)
+    {
+        if (intent.Provider == SourceProviderKind.Local ||
+            string.IsNullOrWhiteSpace(intent.Repository) ||
+            string.IsNullOrWhiteSpace(intent.Target))
+        {
+            throw new InvalidOperationException(
+                "Provider operations require a hosted provider, repository, and exact target.");
+        }
+    }
+}

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Blueprints.App.Models;
 
@@ -7,26 +6,18 @@ namespace Blueprints.App.Services;
 
 public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryService
 {
-    private const int MaximumGitHubIssues = 100;
-    private const int MaximumGitHubPullRequests = 100;
-    private const int MaximumGitHubReleases = 50;
-    private const string GitHubProjectDraftQuery =
-        "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){" +
-        "projectsV2(first:10){nodes{number title url items(first:100){nodes{id type content{" +
-        "__typename ... on DraftIssue{title body} ... on Issue{number} ... on PullRequest{number}" +
-        "}}}}}}}";
     private readonly MarkdownSourceDiscoveryParser _markdownParser;
     private readonly IHostedSourceProviderReader _hostedSourceProviderReader;
 
     public RepositorySourceDiscoveryService()
         : this(
             new MarkdownSourceDiscoveryParser(),
-            new GitHubCliSourceProviderReader())
+            new GitHubRestSourceProviderReader())
     {
     }
 
     public RepositorySourceDiscoveryService(MarkdownSourceDiscoveryParser markdownParser)
-        : this(markdownParser, new GitHubCliSourceProviderReader())
+        : this(markdownParser, new GitHubRestSourceProviderReader())
     {
     }
 
@@ -122,291 +113,6 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         return candidates.Count - countBefore;
     }
 
-    private static GitHubDiscovery ReadGitHubIssues(string root, string repositoryName)
-    {
-        var command = RunProcess(
-            root,
-            "gh",
-            [
-                "issue",
-                "list",
-                "--repo",
-                repositoryName,
-                "--state",
-                "all",
-                "--limit",
-                MaximumGitHubIssues.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                "--json",
-                "number,title,body,state,labels,milestone,url,projectItems",
-            ]);
-
-        if (!command.Success)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub issues were skipped: {command.Error}"]);
-        }
-
-        try
-        {
-            using var document = JsonDocument.Parse(command.Output);
-            var candidates = document.RootElement
-                .EnumerateArray()
-                .Select(issue => ParseGitHubIssue(issue, repositoryName))
-                .ToArray();
-            return new GitHubDiscovery(candidates, []);
-        }
-        catch (JsonException exception)
-        {
-            return new GitHubDiscovery([], [$"GitHub returned unreadable issue data: {exception.Message}"]);
-        }
-    }
-
-    private static GitHubDiscovery ReadGitHubPullRequests(string root, string repositoryName)
-    {
-        var command = RunProcess(
-            root,
-            "gh",
-            [
-                "pr",
-                "list",
-                "--repo",
-                repositoryName,
-                "--state",
-                "all",
-                "--limit",
-                MaximumGitHubPullRequests.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                "--json",
-                "number,title,body,state,labels,url,mergedAt",
-            ]);
-        if (!command.Success)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub pull requests were skipped: {command.Error}"]);
-        }
-
-        try
-        {
-            return new GitHubDiscovery(
-                GitHubSourceJsonParser.ParsePullRequests(command.Output, repositoryName),
-                []);
-        }
-        catch (JsonException exception)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub returned unreadable pull-request data: {exception.Message}"]);
-        }
-    }
-
-    private static GitHubDiscovery ReadGitHubReleases(string root, string repositoryName)
-    {
-        var command = RunProcess(
-            root,
-            "gh",
-            [
-                "release",
-                "list",
-                "--repo",
-                repositoryName,
-                "--limit",
-                MaximumGitHubReleases.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                "--json",
-                "tagName,name,isDraft,isPrerelease,publishedAt",
-            ]);
-        if (!command.Success)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub releases were skipped: {command.Error}"]);
-        }
-
-        try
-        {
-            return new GitHubDiscovery(
-                GitHubSourceJsonParser.ParseReleases(command.Output, repositoryName),
-                []);
-        }
-        catch (JsonException exception)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub returned unreadable release data: {exception.Message}"]);
-        }
-    }
-
-    private static GitHubDiscovery ReadGitHubProjectDrafts(
-        string root,
-        string repositoryName)
-    {
-        var separator = repositoryName.IndexOf('/');
-        if (separator <= 0 || separator == repositoryName.Length - 1)
-        {
-            return new GitHubDiscovery(
-                [],
-                ["GitHub Project drafts were skipped because the repository identity is malformed."]);
-        }
-
-        var command = RunProcess(
-            root,
-            "gh",
-            [
-                "api",
-                "graphql",
-                "-f",
-                $"owner={repositoryName[..separator]}",
-                "-f",
-                $"name={repositoryName[(separator + 1)..]}",
-                "-f",
-                $"query={GitHubProjectDraftQuery}",
-            ]);
-        if (!command.Success)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub Project drafts were skipped: {command.Error}"]);
-        }
-
-        try
-        {
-            return new GitHubDiscovery(
-                GitHubSourceJsonParser.ParseProjectDrafts(command.Output, repositoryName),
-                []);
-        }
-        catch (JsonException exception)
-        {
-            return new GitHubDiscovery(
-                [],
-                [$"GitHub returned unreadable Project draft data: {exception.Message}"]);
-        }
-    }
-
-    private static SourceDiscoveryCandidate ParseGitHubIssue(
-        JsonElement issue,
-        string repositoryName)
-    {
-        var number = issue.GetProperty("number").GetInt32();
-        var title = issue.GetProperty("title").GetString()?.Trim() ?? $"Issue #{number}";
-        var body = issue.TryGetProperty("body", out var bodyElement)
-            ? Truncate(bodyElement.GetString()?.Trim(), 2_000)
-            : null;
-        var state = issue.TryGetProperty("state", out var stateElement)
-            ? stateElement.GetString()
-            : null;
-        var url = issue.TryGetProperty("url", out var urlElement)
-            ? urlElement.GetString()
-            : null;
-        var labels = issue.TryGetProperty("labels", out var labelsElement)
-            ? labelsElement.EnumerateArray()
-                .Select(static label => label.TryGetProperty("name", out var name) ? name.GetString() : null)
-                .Where(static name => !string.IsNullOrWhiteSpace(name))
-                .Cast<string>()
-                .ToArray()
-            : [];
-        var milestone = issue.TryGetProperty("milestone", out var milestoneElement) &&
-                        milestoneElement.ValueKind == JsonValueKind.Object &&
-                        milestoneElement.TryGetProperty("title", out var milestoneTitle)
-            ? milestoneTitle.GetString()
-            : null;
-        var projectNames = ReadProjectNames(issue);
-        var isProjectLinked = projectNames.Count > 0;
-        var contextParts = new[]
-            {
-                milestone is null ? null : $"Milestone: {milestone}",
-                projectNames.Count == 0 ? null : $"Projects: {string.Join(", ", projectNames)}",
-                labels.Length == 0 ? null : $"Labels: {string.Join(", ", labels)}",
-            }
-            .Where(static value => value is not null);
-
-        return new SourceDiscoveryCandidate(
-            isProjectLinked ? SourceArtifactKind.GitHubProject : SourceArtifactKind.GitHubIssue,
-            title,
-            body,
-            SuggestGitHubItemType(labels, title),
-            SuggestGitHubCategory(labels, state),
-            string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase),
-            $"github:#{number}",
-            string.Join(" · ", contextParts.DefaultIfEmpty($"GitHub issue #{number}")),
-            isProjectLinked ? 0.97 : 0.93,
-            new ProviderReference(
-                SourceProviderKind.GitHub,
-                ProviderReferenceKind.Issue,
-                repositoryName,
-                $"#{number}",
-                url));
-    }
-
-    private static IReadOnlyList<string> ReadProjectNames(JsonElement issue)
-    {
-        if (!issue.TryGetProperty("projectItems", out var projects) ||
-            projects.ValueKind != JsonValueKind.Array)
-        {
-            return [];
-        }
-
-        return projects
-            .EnumerateArray()
-            .Select(static project =>
-            {
-                if (project.TryGetProperty("title", out var title))
-                {
-                    return title.GetString();
-                }
-
-                return project.TryGetProperty("project", out var nested) &&
-                       nested.TryGetProperty("title", out var nestedTitle)
-                    ? nestedTitle.GetString()
-                    : null;
-            })
-            .Where(static title => !string.IsNullOrWhiteSpace(title))
-            .Cast<string>()
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-    }
-
-    private static string SuggestGitHubItemType(IReadOnlyList<string> labels, string title)
-    {
-        var text = $"{string.Join(' ', labels)} {title}";
-        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
-        {
-            return "security";
-        }
-
-        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
-            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
-        {
-            return "bug";
-        }
-
-        if (text.Contains("feature", StringComparison.OrdinalIgnoreCase) ||
-            text.Contains("enhancement", StringComparison.OrdinalIgnoreCase))
-        {
-            return "feature";
-        }
-
-        return "issue";
-    }
-
-    private static string SuggestGitHubCategory(IReadOnlyList<string> labels, string? state)
-    {
-        var text = string.Join(' ', labels);
-        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
-        {
-            return "security";
-        }
-
-        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
-            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
-        {
-            return "fixed";
-        }
-
-        return string.Equals(state, "CLOSED", StringComparison.OrdinalIgnoreCase)
-            ? "changed"
-            : "added";
-    }
-
     private static string ReadGitHubRepositoryName(string root)
     {
         var remote = RunProcess(root, "git", ["-C", root, "config", "--get", "remote.origin.url"]);
@@ -474,13 +180,6 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
     private static string NormalizeTitle(string title) =>
         WhitespacePattern().Replace(title.Trim().ToUpperInvariant(), " ");
 
-    private static string? Truncate(string? value, int maximumLength) =>
-        string.IsNullOrWhiteSpace(value)
-            ? null
-            : value.Length <= maximumLength
-                ? value
-                : $"{value[..maximumLength]}…";
-
     [GeneratedRegex(@"(?:github\.com[:/])(?<owner>[^/\s]+)/(?<repo>[^/\s]+)$")]
     private static partial Regex GitHubRemotePattern();
 
@@ -489,38 +188,4 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
 
     private sealed record ProcessResult(bool Success, string Output, string Error);
 
-    private sealed record GitHubDiscovery(
-        IReadOnlyList<SourceDiscoveryCandidate> Candidates,
-        IReadOnlyList<string> Warnings);
-
-    private sealed class GitHubCliSourceProviderReader : IHostedSourceProviderReader
-    {
-        public HostedSourceDiscoveryResult Read(
-            string repositoryRoot,
-            string repositoryName)
-        {
-            var issues = ReadGitHubIssues(repositoryRoot, repositoryName);
-            var pullRequests = ReadGitHubPullRequests(repositoryRoot, repositoryName);
-            var releases = ReadGitHubReleases(repositoryRoot, repositoryName);
-            var projectDrafts = ReadGitHubProjectDrafts(repositoryRoot, repositoryName);
-            return new HostedSourceDiscoveryResult(
-                [
-                    .. issues.Candidates,
-                    .. pullRequests.Candidates,
-                    .. releases.Candidates,
-                    .. projectDrafts.Candidates,
-                ],
-                [
-                    .. issues.Warnings,
-                    .. pullRequests.Warnings,
-                    .. releases.Warnings,
-                    .. projectDrafts.Warnings,
-                ],
-                issues.Candidates.Count,
-                issues.Candidates.Count(static candidate => candidate.Kind == SourceArtifactKind.GitHubProject)
-                + projectDrafts.Candidates.Count,
-                pullRequests.Candidates.Count,
-                releases.Candidates.Count);
-        }
-    }
 }

--- a/Blueprints.Tests/GitHubRestSourceProviderReaderTests.cs
+++ b/Blueprints.Tests/GitHubRestSourceProviderReaderTests.cs
@@ -1,0 +1,259 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class GitHubRestSourceProviderReaderTests
+{
+    [Fact]
+    public void Read_UsesBoundedAnonymousRestDiscoveryWithoutProjectAccess()
+    {
+        var handler = new GitHubHandler();
+        var reader = CreateReader(handler, null);
+
+        var result = reader.Read("/repository", "example/project");
+
+        Assert.Equal(1, result.IssueCount);
+        Assert.Equal(1, result.PullRequestCount);
+        Assert.Equal(1, result.ReleaseCount);
+        Assert.Equal(0, result.ProjectCount);
+        Assert.Contains(
+            result.Warnings,
+            static warning => warning.Contains(
+                "BLUEPRINTS_GITHUB_TOKEN",
+                StringComparison.Ordinal));
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.All(handler.Requests, static request =>
+            Assert.Null(request.Authorization));
+        Assert.All(handler.Requests, static request =>
+            Assert.Equal("2022-11-28", request.ApiVersion));
+        Assert.DoesNotContain(
+            result.Candidates,
+            static candidate => candidate.Title == "Pull duplicated by issues API");
+    }
+
+    [Fact]
+    public void Read_UsesBearerCredentialForRestAndGraphQlWithoutPersistingIt()
+    {
+        var handler = new GitHubHandler();
+        var reader = CreateReader(handler, "test-secret");
+
+        var result = reader.Read("/repository", "example/project");
+
+        Assert.Equal(2, result.ProjectCount);
+        Assert.Empty(result.Warnings);
+        Assert.Equal(4, handler.Requests.Count);
+        Assert.All(handler.Requests, static request =>
+        {
+            Assert.Equal("Bearer", request.Authorization?.Scheme);
+            Assert.Equal("test-secret", request.Authorization?.Parameter);
+        });
+        Assert.Contains(
+            result.Candidates,
+            static candidate =>
+                candidate.Kind == SourceArtifactKind.GitHubProject &&
+                candidate.Title == "Standalone draft");
+        Assert.Single(
+            result.Candidates,
+            static candidate => candidate.Title == "Fix direct discovery");
+        Assert.Contains(
+            result.Candidates,
+            static candidate =>
+                candidate.Kind == SourceArtifactKind.GitHubProject &&
+                candidate.Title == "Fix direct discovery");
+    }
+
+    [Fact]
+    public void Read_ReportsHttpFailuresWithoutExposingTheCredential()
+    {
+        var handler = new GitHubHandler(HttpStatusCode.Unauthorized);
+        var reader = CreateReader(handler, "test-secret");
+
+        var result = reader.Read("/repository", "example/project");
+
+        Assert.Empty(result.Candidates);
+        Assert.Equal(4, result.Warnings.Count);
+        Assert.All(
+            result.Warnings,
+            static warning =>
+            {
+                Assert.Contains("401", warning, StringComparison.Ordinal);
+                Assert.DoesNotContain(
+                    "test-secret",
+                    warning,
+                    StringComparison.Ordinal);
+            });
+    }
+
+    [Theory]
+    [InlineData("owner")]
+    [InlineData("../repo")]
+    [InlineData("owner/repo/extra")]
+    [InlineData("owner/repo?query")]
+    public void Read_RejectsMalformedRepositoryNames(string repositoryName)
+    {
+        var reader = CreateReader(new GitHubHandler(), null);
+
+        Assert.Throws<InvalidOperationException>(
+            () => reader.Read("/repository", repositoryName));
+    }
+
+    private static GitHubRestSourceProviderReader CreateReader(
+        GitHubHandler handler,
+        string? token) =>
+        new(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://api.github.test/", UriKind.Absolute),
+            },
+            new TestCredentialSource(token));
+
+    private sealed class TestCredentialSource(string? token) : IProviderCredentialSource
+    {
+        public string? GetGitHubToken() => token;
+    }
+
+    private sealed class GitHubHandler : HttpMessageHandler
+    {
+        private readonly Lock _lock = new();
+        private readonly HttpStatusCode _statusCode;
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        public GitHubHandler(HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _statusCode = statusCode;
+        }
+
+        protected override HttpResponseMessage Send(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Handle(request);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(Handle(request));
+
+        private HttpResponseMessage Handle(HttpRequestMessage request)
+        {
+            lock (_lock)
+            {
+                Requests.Add(
+                    new CapturedRequest(
+                        request.RequestUri!.PathAndQuery,
+                        request.Headers.Authorization,
+                        request.Headers.TryGetValues(
+                            "X-GitHub-Api-Version",
+                            out var versions)
+                            ? versions.Single()
+                            : null));
+            }
+            if (_statusCode != HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(_statusCode)
+                {
+                    Content = new StringContent("provider error"),
+                };
+            }
+
+            var json = request.RequestUri.AbsolutePath switch
+            {
+                "/repos/example/project/issues" =>
+                    """
+                    [
+                      {
+                        "number": 7,
+                        "title": "Fix direct discovery",
+                        "body": "Use the REST API.",
+                        "state": "closed",
+                        "html_url": "https://github.test/example/project/issues/7",
+                        "labels": [{ "name": "bug" }],
+                        "milestone": { "title": "0.4.0" }
+                      },
+                      {
+                        "number": 8,
+                        "title": "Pull duplicated by issues API",
+                        "state": "open",
+                        "pull_request": { "url": "https://api.github.test/pulls/8" }
+                      }
+                    ]
+                    """,
+                "/repos/example/project/pulls" =>
+                    """
+                    [{
+                      "number": 8,
+                      "title": "Direct provider adapter",
+                      "body": "Remove the CLI dependency.",
+                      "state": "closed",
+                      "merged_at": "2026-07-30T00:00:00Z",
+                      "html_url": "https://github.test/example/project/pull/8",
+                      "labels": [{ "name": "feature" }]
+                    }]
+                    """,
+                "/repos/example/project/releases" =>
+                    """
+                    [{
+                      "tag_name": "v0.4.0",
+                      "name": "Source awareness",
+                      "draft": false,
+                      "prerelease": true,
+                      "published_at": "2026-07-30T00:00:00Z",
+                      "html_url": "https://github.test/example/project/releases/tag/v0.4.0"
+                    }]
+                    """,
+                "/graphql" =>
+                    """
+                    {
+                      "data": {
+                        "repository": {
+                          "projectsV2": {
+                            "nodes": [{
+                              "number": 2,
+                              "title": "Roadmap",
+                              "url": "https://github.test/orgs/example/projects/2",
+                              "items": {
+                                "nodes": [{
+                                  "id": "PVTI_1",
+                                  "type": "REDACTED",
+                                  "content": {
+                                    "__typename": "DraftIssue",
+                                    "title": "Standalone draft",
+                                    "body": "Draft detail"
+                                  }
+                                }, {
+                                  "id": "PVTI_2",
+                                  "type": "ISSUE",
+                                  "content": {
+                                    "__typename": "Issue",
+                                    "number": 7,
+                                    "title": "Fix direct discovery",
+                                    "body": "Use the REST API.",
+                                    "state": "CLOSED",
+                                    "url": "https://github.test/example/project/issues/7",
+                                    "labels": { "nodes": [{ "name": "bug" }] }
+                                  }
+                                }]
+                              }
+                            }]
+                          }
+                        }
+                      }
+                    }
+                    """,
+                _ => "[]",
+            };
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json),
+            };
+        }
+    }
+
+    private sealed record CapturedRequest(
+        string Path,
+        AuthenticationHeaderValue? Authorization,
+        string? ApiVersion);
+}

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -18,7 +18,37 @@ public sealed class IntegrationStatusServiceTests
             status => Assert.Equal(IntegrationProviderType.GitHub, status.Provider),
             status => Assert.Equal(IntegrationProviderType.GitLab, status.Provider),
             status => Assert.Equal(IntegrationProviderType.VaultSync, status.Provider));
-        Assert.All(statuses, status => Assert.Equal(IntegrationConnectionState.NotConfigured, status.State));
+        Assert.Equal(
+            IntegrationConnectionState.Warning,
+            statuses.Single(status =>
+                status.Provider == IntegrationProviderType.GitHub).State);
+        Assert.All(
+            statuses.Where(status =>
+                status.Provider != IntegrationProviderType.GitHub),
+            status => Assert.Equal(
+                IntegrationConnectionState.NotConfigured,
+                status.State));
+    }
+
+    [Fact]
+    public void GetIntegrationStatuses_ReportsEnvironmentCredentialWithoutPersistingIt()
+    {
+        var service = CreateService(
+            IntegrationSettings.Empty,
+            credential: "test-secret");
+
+        var github = service.GetIntegrationStatuses()
+            .Single(status => status.Provider == IntegrationProviderType.GitHub);
+
+        Assert.Equal(IntegrationConnectionState.Connected, github.State);
+        Assert.Contains(
+            "BLUEPRINTS_GITHUB_TOKEN",
+            github.Guidance,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "test-secret",
+            $"{github.Target}{github.Summary}{github.Guidance}",
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -138,10 +168,18 @@ public sealed class IntegrationStatusServiceTests
 
     private static IntegrationStatusService CreateService(
         IntegrationSettings settings,
-        LocalGitRepositoryStatus? gitStatus = null) =>
+        LocalGitRepositoryStatus? gitStatus = null,
+        string? credential = null) =>
         new(
             new TestIntegrationSettingsStore(settings),
-            new TestLocalGitRepositoryInspector(gitStatus));
+            new TestLocalGitRepositoryInspector(gitStatus),
+            new TestProviderCredentialSource(credential));
+
+    private sealed class TestProviderCredentialSource(string? credential)
+        : IProviderCredentialSource
+    {
+        public string? GetGitHubToken() => credential;
+    }
 
     private sealed class TestIntegrationSettingsStore : IIntegrationSettingsStore
     {

--- a/Blueprints.Tests/ProviderOperationPolicyTests.cs
+++ b/Blueprints.Tests/ProviderOperationPolicyTests.cs
@@ -1,0 +1,83 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class ProviderOperationPolicyTests
+{
+    [Fact]
+    public void Authorize_AllowsReadWithoutApproval()
+    {
+        var policy = new ProviderOperationPolicy();
+
+        policy.Authorize(
+            Intent(ProviderOperationKind.ReadSource),
+            null,
+            DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void Authorize_RequiresExactFreshSingleUseApprovalForWrites()
+    {
+        var policy = new ProviderOperationPolicy();
+        var now = DateTimeOffset.UtcNow;
+        var intent = Intent(ProviderOperationKind.PublishRelease);
+        var approval = new ProviderWriteApproval(
+            Guid.NewGuid(),
+            intent,
+            now,
+            now.AddMinutes(5));
+
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Authorize(intent, null, now));
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Authorize(
+                intent,
+                approval with
+                {
+                    Intent = intent with { Target = "v0.4.1" },
+                },
+                now));
+
+        policy.Authorize(intent, approval, now);
+
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Authorize(intent, approval, now));
+    }
+
+    [Fact]
+    public void Authorize_RejectsExpiredAndOverlongApprovals()
+    {
+        var policy = new ProviderOperationPolicy();
+        var now = DateTimeOffset.UtcNow;
+        var intent = Intent(ProviderOperationKind.CreateIssue);
+
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Authorize(
+                intent,
+                new ProviderWriteApproval(
+                    Guid.NewGuid(),
+                    intent,
+                    now.AddMinutes(-2),
+                    now.AddSeconds(-1)),
+                now));
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Authorize(
+                intent,
+                new ProviderWriteApproval(
+                    Guid.NewGuid(),
+                    intent,
+                    now,
+                    now.AddMinutes(11)),
+                now));
+    }
+
+    private static ProviderOperationIntent Intent(ProviderOperationKind operation) =>
+        new(
+            SourceProviderKind.GitHub,
+            "example/project",
+            operation,
+            operation == ProviderOperationKind.PublishRelease
+                ? "v0.4.0"
+                : "new");
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - An injectable provider-neutral hosted-source reader boundary, keeping repository discovery and approval workflows independent from the current authenticated GitHub CLI implementation.
 - User-defined directional or undirected relationship types with validated colors and optional descriptions, plus signed relationships between project, version, and work-item nodes.
 - Relationship authoring and removal in the canvas inspector, colored relationship projection on the canvas, archive cleanup, audit operations, and document-aware conflict summaries.
+- Direct bounded GitHub REST and GraphQL discovery for issues, pull requests, releases, project-linked issues, and standalone Project drafts, including anonymous public-repository reads.
+- A provider-operation policy that allows reads directly but requires a fresh, exact-target, single-use approval before any future hosted-provider write.
 
 ### Changed
 
@@ -25,6 +27,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Source Lens proposals now expose structured provider, repository, artifact kind, identifier, and optional web location instead of relying only on GitHub-specific display strings.
 - Combined Source Lens summaries now separate issue, pull-request, release, and project-linked proposal counts.
 - Schema-1 workspaces may contain an optional signed `project/relationships.json`; missing files remain compatible with earlier workspaces and the complete relationship graph is one revisioned conflict domain.
+- Source Lens no longer requires the GitHub CLI. Private repository and GitHub Project discovery uses the environment-only `BLUEPRINTS_GITHUB_TOKEN`; Blueprints does not persist the credential.
 
 ## 0.3.0 — 2026-07-30
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -73,9 +73,9 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Define provider-neutral issue, pull-request, and release references.
 - [x] Add a bounded read-only GitHub issue/Project discovery adapter through the authenticated GitHub CLI.
 - [x] Route hosted discovery through a provider-neutral reader contract and add pull-request/release references.
-- [ ] Replace the authenticated GitHub CLI implementation with a direct provider adapter.
+- [x] Replace the authenticated GitHub CLI implementation with a direct provider adapter.
 - [x] Add standalone GitHub Project draft-item discovery.
-- [ ] Define and separately approve any future provider write operations.
+- [x] Define and separately approve any future provider write operations.
 - [ ] Add GitLab parity after the provider contract stabilizes.
 
 Exit criteria:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ There is no dependency-injection container. Constructor composition keeps the cu
 1. Resolve local and shared paths.
 2. Load the local identity.
 3. Load project, membership, versions, and items.
-4. Load the optional canvas layout and validate schema, project identity, entity references, and rendering bounds.
+4. Load the optional canvas layout and typed relationship graph, then validate schema, project identity, entity references, and rendering bounds.
 5. Verify detached signatures with the project member key selected by the current workflow.
 6. Validate the signed audit chain.
 7. Analyze local/shared changes against local sync state.
@@ -77,7 +77,7 @@ Zoom and scroll offsets follow a separate local-preference flow: validate bounde
 
 1. Resolve the linked local Git worktree.
 2. Parse bounded changelog and roadmap Markdown locally.
-3. Resolve a GitHub origin and query issue/project metadata through the authenticated `gh` CLI when available.
+3. Resolve a GitHub origin and query bounded issue, pull-request, and release metadata through the direct REST adapter; query Project metadata through GraphQL when an environment credential is available.
 4. Normalize source entries into transient `SourceDiscoveryCandidate` values.
 5. Present editable `SourceImportProposal` values and flag exact-title duplicates.
 6. Require the user to choose inclusion, target version, type, category, title, description, and completion state.
@@ -85,6 +85,8 @@ Zoom and scroll offsets follow a separate local-preference flow: validate bounde
 8. Write the approved batch as signed item documents and append one signed `source.import.apply` audit entry.
 
 Discovery never mutates the repository, provider, or Blueprints workspace. Provider data remains an input suggestion and never becomes authoritative without the explicit apply action.
+
+The hosted-provider operation policy allows discovery reads without a write approval. Future provider mutations must present a fresh approval matching one exact provider, repository, operation, and target; approval expires within ten minutes and is consumed once.
 
 ### Push
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -58,7 +58,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Invalid canvas signatures place the workspace in read-only untrusted state.
 - Source discovery uses read-only local/GitHub commands and enforces count, line, and text bounds.
 - Source apply validates the complete batch before persistence and requires trusted, conflict-free, mutable targets.
-- GitHub CLI credentials remain outside Blueprints workspaces and settings.
+- GitHub API credentials are accepted only through the process environment variable `BLUEPRINTS_GITHUB_TOKEN` and remain outside Blueprints workspaces and settings.
+- Hosted-provider reads are allowed directly. Any future write must have a fresh, exact-target, single-use approval with a maximum ten-minute lifetime; credentials alone never authorize a write.
 
 ## Important limitations
 

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -8,10 +8,10 @@ Source Lens converts existing project signals into editable Blueprints work-item
 | --- | --- | --- |
 | `CHANGELOG.md` | Local read-only Markdown parsing | Bullet entries, completed by default |
 | `Roadmap.md` | Local read-only Markdown parsing | Bullet and task-list entries with checkbox state |
-| GitHub issues | Authenticated `gh issue list` request | Open and closed issue metadata |
-| GitHub pull requests | Authenticated `gh pr list` request | Open, closed, and merged pull-request metadata |
-| GitHub releases | Authenticated `gh release list` request | Draft and published release records |
-| GitHub Projects | Repository-linked Projects query plus `projectItems` attached to issues | Standalone draft items and project-linked issues |
+| GitHub issues | Direct REST API request | Open and closed issue metadata |
+| GitHub pull requests | Direct REST API request | Open, closed, and merged pull-request metadata |
+| GitHub releases | Direct REST API request | Draft and published release records |
+| GitHub Projects | Direct authenticated GraphQL query | Standalone draft items and project-linked issues |
 
 The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues, 100 pull requests, and 50 releases per repository. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
 
@@ -21,12 +21,13 @@ Standalone draft discovery reads only Projects linked to the repository, checks 
 
 - Link one or more local Git worktrees in **Source Lens**, one path per line.
 - Install Git.
-- For GitHub discovery, install and authenticate the GitHub CLI with `gh auth login`.
 - The Git worktree must have a recognizable `github.com` origin remote.
+- Public issues, pull requests, and releases can be discovered anonymously.
+- Set `BLUEPRINTS_GITHUB_TOKEN` in the application environment for private repositories, draft releases, or GitHub Projects. Use the narrowest read-only repository permissions that cover the sources you need.
 
 Local Markdown discovery still works if GitHub is unavailable. Source Lens reports the skipped provider as a warning instead of failing the entire scan.
 
-Repository discovery talks to hosted services through a provider-neutral reader contract. The current GitHub implementation uses the authenticated GitHub CLI behind that boundary; replacing its transport does not require changing proposal approval, provenance, or signed workspace behavior.
+Repository discovery talks to hosted services through a provider-neutral reader contract. The GitHub implementation calls the versioned REST and GraphQL endpoints directly with a 15-second timeout, a 4 MiB response limit, bounded result counts, and parallel source reads. Transport does not change proposal approval, provenance, or signed workspace behavior.
 
 ## Approval workflow
 
@@ -78,10 +79,16 @@ Local Markdown and GitHub issue discovery already emit this structure. Pull-requ
 
 - Discovery is read-only for the repository and GitHub.
 - Blueprints never invokes provider write commands during discovery or apply.
-- GitHub credentials remain owned by the GitHub CLI and are not copied into project files.
+- GitHub credentials are read only from `BLUEPRINTS_GITHUB_TOKEN`. They are not written to integration settings, signed project files, logs, warnings, or proposal provenance.
 - Untrusted source text is length- and count-bounded and rendered as text.
 - Proposals are transient UI state until explicit approval.
 - Invalid taxonomy, missing versions, frozen/released targets, broken trust, and sync conflicts block apply.
 - Apply signs Blueprints documents with the local member identity; it does not sign or modify source-provider data.
+
+## Provider write boundary
+
+No Source Lens workflow writes to a hosted provider. The provider-operation contract distinguishes reads from create/update/project/release writes. A future write implementation must pass a separate approval matching the exact provider, repository, operation, and target. That approval is valid for no more than ten minutes and can be consumed only once. Batch or standing approval is intentionally unsupported.
+
+Adding a transport method is not enough to authorize a write: a UI workflow must show the exact mutation, collect approval for that one target, and pass it through the policy at execution time. Credentials and a Blueprints workspace edit do not imply provider-write consent.
 
 Source Lens does not prove that imported statements are true. Review is the human trust decision.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -97,7 +97,7 @@ Draft versions and items in Planned or In Progress state can be archived. Select
 
 Discovery is read-only. It does not commit, push, edit issues, change Projects, or modify planning files. Proposals are not project data until Apply. Apply requires a trusted workspace, adds the reviewed proposals as signed work items, records their provenance, and writes one audit action.
 
-GitHub discovery requires the authenticated GitHub CLI. Local changelog and roadmap discovery remains available if GitHub is not configured. See [Source Lens](source-lens.md) for limits, duplicate behavior, and security details.
+Public GitHub issues, pull requests, and releases are read directly without requiring the GitHub CLI. For private repositories, draft releases, and GitHub Projects, start Blueprints with a read-only token in `BLUEPRINTS_GITHUB_TOKEN`. Blueprints reads that variable for the current process and does not store it in project or integration settings. Local changelog and roadmap discovery remains available when GitHub cannot be reached. See [Source Lens](source-lens.md) for limits, duplicate behavior, and security details.
 
 ## Exchange changes
 


### PR DESCRIPTION
## Summary
- replace GitHub CLI-backed discovery with bounded parallel REST and GraphQL reads
- allow anonymous public discovery and use an environment-only token for private repositories and Projects
- preserve project-linked issue classification, filter issue/pull duplicates, and bound response sizes and counts
- define an exact-target, expiring, single-use approval policy for any future provider write operation
- update integration status, security guidance, Source Lens docs, changelog, and roadmap

## Verification
- `dotnet test Blueprints.sln --no-restore` (123 passed)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (no vulnerable packages)
- live GitHub GraphQL query contract validation
- application startup smoke test