### PR TITLE
Add GitLab source discovery parity

### DIFF
--- a/Blueprints.App/Models/HostedRepositoryDescriptor.cs
+++ b/Blueprints.App/Models/HostedRepositoryDescriptor.cs
@@ -1,0 +1,5 @@
+namespace Blueprints.App.Models;
+
+public sealed record HostedRepositoryDescriptor(
+    SourceProviderKind Provider,
+    string RepositoryName);

--- a/Blueprints.App/Models/HostedSourceDiscoveryResult.cs
+++ b/Blueprints.App/Models/HostedSourceDiscoveryResult.cs
@@ -5,5 +5,5 @@ public sealed record HostedSourceDiscoveryResult(
     IReadOnlyList<string> Warnings,
     int IssueCount,
     int ProjectCount,
-    int PullRequestCount,
+    int ChangeRequestCount,
     int ReleaseCount);

--- a/Blueprints.App/Models/ProviderReferenceKind.cs
+++ b/Blueprints.App/Models/ProviderReferenceKind.cs
@@ -5,7 +5,7 @@ public enum ProviderReferenceKind
     PlanningDocument,
     Commit,
     Issue,
-    PullRequest,
+    ChangeRequest,
     Release,
     Project,
 }

--- a/Blueprints.App/Models/SourceArtifactKind.cs
+++ b/Blueprints.App/Models/SourceArtifactKind.cs
@@ -4,8 +4,8 @@ public enum SourceArtifactKind
 {
     Changelog,
     Roadmap,
-    GitHubIssue,
-    GitHubProject,
-    PullRequest,
+    Issue,
+    Project,
+    ChangeRequest,
     Release,
 }

--- a/Blueprints.App/Models/SourceDiscoveryResult.cs
+++ b/Blueprints.App/Models/SourceDiscoveryResult.cs
@@ -5,13 +5,13 @@ public sealed record SourceDiscoveryResult(
     IReadOnlyList<string> Warnings,
     int ChangelogCount,
     int RoadmapCount,
-    int GitHubIssueCount,
-    int GitHubProjectCount,
-    int PullRequestCount = 0,
+    int HostedIssueCount,
+    int HostedPlanningCount,
+    int ChangeRequestCount = 0,
     int ReleaseCount = 0)
 {
     public string Summary =>
         $"Found {Candidates.Count} proposals · {ChangelogCount} changelog · {RoadmapCount} roadmap · " +
-        $"{GitHubIssueCount} issues · {PullRequestCount} pull requests · {ReleaseCount} releases · " +
-        $"{GitHubProjectCount} project-linked";
+        $"{HostedIssueCount} issues · {ChangeRequestCount} change requests · {ReleaseCount} releases · " +
+        $"{HostedPlanningCount} planning-linked";
 }

--- a/Blueprints.App/Services/EnvironmentProviderCredentialSource.cs
+++ b/Blueprints.App/Services/EnvironmentProviderCredentialSource.cs
@@ -7,4 +7,10 @@ public sealed class EnvironmentProviderCredentialSource : IProviderCredentialSou
         var token = Environment.GetEnvironmentVariable("BLUEPRINTS_GITHUB_TOKEN");
         return string.IsNullOrWhiteSpace(token) ? null : token.Trim();
     }
+
+    public string? GetGitLabToken()
+    {
+        var token = Environment.GetEnvironmentVariable("BLUEPRINTS_GITLAB_TOKEN");
+        return string.IsNullOrWhiteSpace(token) ? null : token.Trim();
+    }
 }

--- a/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
+++ b/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
@@ -41,9 +41,16 @@ public sealed class GitHubRestSourceProviderReader : IHostedSourceProviderReader
 
     public HostedSourceDiscoveryResult Read(
         string repositoryRoot,
-        string repositoryName)
+        HostedRepositoryDescriptor repository)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+        ArgumentNullException.ThrowIfNull(repository);
+        if (repository.Provider != SourceProviderKind.GitHub)
+        {
+            throw new InvalidOperationException(
+                "The GitHub reader only accepts GitHub repositories.");
+        }
+        var repositoryName = repository.RepositoryName;
         ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
         ValidateRepositoryName(repositoryName);
 

--- a/Blueprints.App/Services/GitHubSourceJsonParser.cs
+++ b/Blueprints.App/Services/GitHubSourceJsonParser.cs
@@ -110,7 +110,7 @@ public static class GitHubSourceJsonParser
             : $"GitHub pull request #{number} · merged {mergedAt}";
 
         return new SourceDiscoveryCandidate(
-            SourceArtifactKind.PullRequest,
+            SourceArtifactKind.ChangeRequest,
             title,
             Truncate(body, 2_000),
             SuggestItemType(labels, title),
@@ -121,7 +121,7 @@ public static class GitHubSourceJsonParser
             0.96,
             new ProviderReference(
                 SourceProviderKind.GitHub,
-                ProviderReferenceKind.PullRequest,
+                ProviderReferenceKind.ChangeRequest,
                 repositoryName,
                 $"#{number}",
                 url));
@@ -155,7 +155,7 @@ public static class GitHubSourceJsonParser
                 var title = ReadString(content, "title") ?? "Untitled project draft";
                 var body = ReadString(content, "body");
                 return new SourceDiscoveryCandidate(
-                    SourceArtifactKind.GitHubProject,
+                    SourceArtifactKind.Project,
                     title,
                     Truncate(body, 2_000),
                     SuggestItemType([], title),
@@ -203,7 +203,7 @@ public static class GitHubSourceJsonParser
                 var state = ReadString(content, "state");
                 var labels = ReadLabels(content);
                 return new SourceDiscoveryCandidate(
-                    SourceArtifactKind.GitHubProject,
+                    SourceArtifactKind.Project,
                     title,
                     Truncate(ReadString(content, "body"), 2_000),
                     SuggestItemType(labels, title),
@@ -302,8 +302,8 @@ public static class GitHubSourceJsonParser
 
         return new SourceDiscoveryCandidate(
             projects.Count > 0
-                ? SourceArtifactKind.GitHubProject
-                : SourceArtifactKind.GitHubIssue,
+                ? SourceArtifactKind.Project
+                : SourceArtifactKind.Issue,
             title,
             Truncate(body, 2_000),
             SuggestItemType(labels, title),

--- a/Blueprints.App/Services/GitLabRestSourceProviderReader.cs
+++ b/Blueprints.App/Services/GitLabRestSourceProviderReader.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class GitLabRestSourceProviderReader : IHostedSourceProviderReader
+{
+    private readonly HttpClient _httpClient;
+    private readonly IProviderCredentialSource _credentialSource;
+
+    public GitLabRestSourceProviderReader()
+        : this(
+            new HttpClient
+            {
+                BaseAddress = new Uri(
+                    "https://gitlab.com/api/v4/",
+                    UriKind.Absolute),
+                Timeout = TimeSpan.FromSeconds(15),
+            },
+            new EnvironmentProviderCredentialSource())
+    {
+    }
+
+    public GitLabRestSourceProviderReader(
+        HttpClient httpClient,
+        IProviderCredentialSource credentialSource)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(credentialSource);
+        _httpClient = httpClient;
+        _credentialSource = credentialSource;
+    }
+
+    public HostedSourceDiscoveryResult Read(
+        string repositoryRoot,
+        HostedRepositoryDescriptor repository)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+        ArgumentNullException.ThrowIfNull(repository);
+        if (repository.Provider != SourceProviderKind.GitLab)
+        {
+            throw new InvalidOperationException(
+                "The GitLab reader only accepts GitLab repositories.");
+        }
+        ValidateRepositoryName(repository.RepositoryName);
+
+        var project = Uri.EscapeDataString(repository.RepositoryName);
+        var token = _credentialSource.GetGitLabToken();
+        var issuesTask = ReadAsync(
+            $"projects/{project}/issues?scope=all&per_page=100",
+            repository.RepositoryName,
+            "issues",
+            GitLabSourceJsonParser.ParseIssues,
+            token);
+        var mergeRequestsTask = ReadAsync(
+            $"projects/{project}/merge_requests?scope=all&state=all&per_page=100",
+            repository.RepositoryName,
+            "merge requests",
+            GitLabSourceJsonParser.ParseMergeRequests,
+            token);
+        var releasesTask = ReadAsync(
+            $"projects/{project}/releases?per_page=50",
+            repository.RepositoryName,
+            "releases",
+            GitLabSourceJsonParser.ParseReleases,
+            token);
+        var milestonesTask = ReadAsync(
+            $"projects/{project}/milestones?per_page=100",
+            repository.RepositoryName,
+            "milestones",
+            GitLabSourceJsonParser.ParseMilestones,
+            token);
+        Task.WhenAll(
+                issuesTask,
+                mergeRequestsTask,
+                releasesTask,
+                milestonesTask)
+            .GetAwaiter()
+            .GetResult();
+        var issues = issuesTask.Result;
+        var mergeRequests = mergeRequestsTask.Result;
+        var releases = releasesTask.Result;
+        var milestones = milestonesTask.Result;
+        return new HostedSourceDiscoveryResult(
+            [
+                .. issues.Candidates,
+                .. mergeRequests.Candidates,
+                .. releases.Candidates,
+                .. milestones.Candidates,
+            ],
+            [
+                .. issues.Warnings,
+                .. mergeRequests.Warnings,
+                .. releases.Warnings,
+                .. milestones.Warnings,
+            ],
+            issues.Candidates.Count,
+            milestones.Candidates.Count,
+            mergeRequests.Candidates.Count,
+            releases.Candidates.Count);
+    }
+
+    private async Task<ProviderReadResult> ReadAsync(
+        string relativeUri,
+        string repositoryName,
+        string sourceName,
+        Func<string, string, IReadOnlyList<SourceDiscoveryCandidate>> parser,
+        string? token)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, relativeUri);
+            request.Headers.UserAgent.ParseAdd("Blueprints/0.4");
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                request.Headers.Add("PRIVATE-TOKEN", token);
+            }
+            using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead)
+                .ConfigureAwait(false);
+            var body = await ReadBoundedBodyAsync(response).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return Failure(sourceName, response.StatusCode);
+            }
+            return new ProviderReadResult(parser(body, repositoryName), []);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or
+            TaskCanceledException or
+            System.Text.Json.JsonException or
+            InvalidOperationException)
+        {
+            return new ProviderReadResult(
+                [],
+                [$"GitLab {sourceName} were skipped: {SafeMessage(exception.Message)}"]);
+        }
+    }
+
+    private static async Task<string> ReadBoundedBodyAsync(
+        HttpResponseMessage response)
+    {
+        const int maximumResponseBytes = 4 * 1024 * 1024;
+        if (response.Content.Headers.ContentLength > maximumResponseBytes)
+        {
+            throw new InvalidOperationException(
+                "GitLab response exceeded the 4 MiB safety limit.");
+        }
+
+        await using var stream = await response.Content
+            .ReadAsStreamAsync()
+            .ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        while (true)
+        {
+            var read = await stream.ReadAsync(chunk.AsMemory()).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+            if (buffer.Length + read > maximumResponseBytes)
+            {
+                throw new InvalidOperationException(
+                    "GitLab response exceeded the 4 MiB safety limit.");
+            }
+            buffer.Write(chunk, 0, read);
+        }
+        return System.Text.Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static ProviderReadResult Failure(
+        string sourceName,
+        HttpStatusCode statusCode) =>
+        new(
+            [],
+            [
+                $"GitLab {sourceName} were skipped: API returned " +
+                $"{(int)statusCode} {statusCode}.",
+            ]);
+
+    private static void ValidateRepositoryName(string repositoryName)
+    {
+        var parts = repositoryName.Split('/');
+        if (parts.Length < 2 ||
+            parts.Any(static part =>
+                string.IsNullOrWhiteSpace(part) ||
+                part is "." or ".." ||
+                part.Any(static character =>
+                    !(char.IsAsciiLetterOrDigit(character) ||
+                      character is '-' or '_' or '.'))))
+        {
+            throw new InvalidOperationException(
+                "GitLab repository identity must use namespace/project syntax.");
+        }
+    }
+
+    private static string SafeMessage(string message)
+    {
+        const int maximumLength = 300;
+        var normalized = message.ReplaceLineEndings(" ").Trim();
+        return normalized.Length <= maximumLength
+            ? normalized
+            : normalized[..maximumLength] + "…";
+    }
+
+    private sealed record ProviderReadResult(
+        IReadOnlyList<SourceDiscoveryCandidate> Candidates,
+        IReadOnlyList<string> Warnings);
+}

--- a/Blueprints.App/Services/GitLabSourceJsonParser.cs
+++ b/Blueprints.App/Services/GitLabSourceJsonParser.cs
@@ -1,0 +1,247 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public static class GitLabSourceJsonParser
+{
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseIssues(
+        string json,
+        string repositoryName)
+    {
+        using var document = Parse(json, repositoryName);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(100)
+            .Select(issue =>
+            {
+                var iid = ReadInt(issue, "iid");
+                var title = ReadString(issue, "title") ?? $"Issue #{iid}";
+                var labels = ReadLabels(issue);
+                var closed = string.Equals(
+                    ReadString(issue, "state"),
+                    "closed",
+                    StringComparison.OrdinalIgnoreCase);
+                var milestone = ReadNestedString(issue, "milestone", "title");
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.Issue,
+                    title,
+                    Truncate(ReadString(issue, "description"), 2_000),
+                    SuggestItemType(labels, title),
+                    SuggestCategory(labels, closed),
+                    closed,
+                    $"gitlab:#{iid}",
+                    milestone is null
+                        ? $"GitLab issue #{iid}"
+                        : $"GitLab issue #{iid} · Milestone: {milestone}",
+                    0.93,
+                    new ProviderReference(
+                        SourceProviderKind.GitLab,
+                        ProviderReferenceKind.Issue,
+                        repositoryName,
+                        $"#{iid}",
+                        ReadString(issue, "web_url")));
+            })
+            .ToArray();
+    }
+
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseMergeRequests(
+        string json,
+        string repositoryName)
+    {
+        using var document = Parse(json, repositoryName);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(100)
+            .Select(mergeRequest =>
+            {
+                var iid = ReadInt(mergeRequest, "iid");
+                var title = ReadString(mergeRequest, "title")
+                    ?? $"Merge request !{iid}";
+                var labels = ReadLabels(mergeRequest);
+                var state = ReadString(mergeRequest, "state");
+                var mergedAt = ReadString(mergeRequest, "merged_at");
+                var completed =
+                    string.Equals(state, "merged", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(state, "closed", StringComparison.OrdinalIgnoreCase);
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.ChangeRequest,
+                    title,
+                    Truncate(ReadString(mergeRequest, "description"), 2_000),
+                    SuggestItemType(labels, title),
+                    SuggestCategory(labels, completed),
+                    completed,
+                    $"gitlab:mr:!{iid}",
+                    mergedAt is null
+                        ? $"GitLab merge request !{iid} · {state ?? "unknown state"}"
+                        : $"GitLab merge request !{iid} · merged {mergedAt}",
+                    0.96,
+                    new ProviderReference(
+                        SourceProviderKind.GitLab,
+                        ProviderReferenceKind.ChangeRequest,
+                        repositoryName,
+                        $"!{iid}",
+                        ReadString(mergeRequest, "web_url")));
+            })
+            .ToArray();
+    }
+
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseReleases(
+        string json,
+        string repositoryName)
+    {
+        using var document = Parse(json, repositoryName);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(50)
+            .Select(release =>
+            {
+                var tag = ReadString(release, "tag_name") ?? "(untagged)";
+                var name = ReadString(release, "name");
+                var releasedAt = ReadString(release, "released_at");
+                var upcoming = ReadBoolean(release, "upcoming_release");
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.Release,
+                    string.IsNullOrWhiteSpace(name) ? tag : name,
+                    Truncate(ReadString(release, "description"), 2_000),
+                    "feature",
+                    "changed",
+                    !upcoming && releasedAt is not null,
+                    $"gitlab:release:{tag}",
+                    upcoming
+                        ? $"GitLab upcoming release · {tag}"
+                        : $"GitLab release · {tag} · {releasedAt ?? "unpublished"}",
+                    0.98,
+                    new ProviderReference(
+                        SourceProviderKind.GitLab,
+                        ProviderReferenceKind.Release,
+                        repositoryName,
+                        tag,
+                        ReadNestedString(release, "_links", "self")));
+            })
+            .ToArray();
+    }
+
+    public static IReadOnlyList<SourceDiscoveryCandidate> ParseMilestones(
+        string json,
+        string repositoryName)
+    {
+        using var document = Parse(json, repositoryName);
+        return document.RootElement
+            .EnumerateArray()
+            .Take(100)
+            .Select(milestone =>
+            {
+                var iid = ReadInt(milestone, "iid");
+                var title = ReadString(milestone, "title")
+                    ?? $"Milestone {iid}";
+                var closed = string.Equals(
+                    ReadString(milestone, "state"),
+                    "closed",
+                    StringComparison.OrdinalIgnoreCase);
+                return new SourceDiscoveryCandidate(
+                    SourceArtifactKind.Project,
+                    title,
+                    Truncate(ReadString(milestone, "description"), 2_000),
+                    "feature",
+                    closed ? "changed" : "added",
+                    closed,
+                    $"gitlab:milestone:{iid}",
+                    $"GitLab milestone {iid} · {(closed ? "closed" : "active")}",
+                    0.9,
+                    new ProviderReference(
+                        SourceProviderKind.GitLab,
+                        ProviderReferenceKind.Project,
+                        repositoryName,
+                        iid.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        $"https://gitlab.com/{repositoryName}/-/milestones/{iid}"));
+            })
+            .ToArray();
+    }
+
+    private static JsonDocument Parse(string json, string repositoryName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryName);
+        return JsonDocument.Parse(json);
+    }
+
+    private static int ReadInt(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) &&
+        value.TryGetInt32(out var result)
+            ? result
+            : 0;
+
+    private static string? ReadString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()?.Trim()
+            : null;
+
+    private static string? ReadNestedString(
+        JsonElement element,
+        string objectProperty,
+        string valueProperty) =>
+        element.TryGetProperty(objectProperty, out var nested) &&
+        nested.ValueKind == JsonValueKind.Object
+            ? ReadString(nested, valueProperty)
+            : null;
+
+    private static bool ReadBoolean(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) &&
+        value.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+        value.GetBoolean();
+
+    private static IReadOnlyList<string> ReadLabels(JsonElement element) =>
+        element.TryGetProperty("labels", out var labels) &&
+        labels.ValueKind == JsonValueKind.Array
+            ? labels
+                .EnumerateArray()
+                .Select(static label => label.ValueKind == JsonValueKind.String
+                    ? label.GetString()
+                    : null)
+                .Where(static label => !string.IsNullOrWhiteSpace(label))
+                .Cast<string>()
+                .ToArray()
+            : [];
+
+    private static string SuggestItemType(
+        IReadOnlyList<string> labels,
+        string title)
+    {
+        var text = $"{string.Join(' ', labels)} {title}";
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "bug";
+        }
+        return "feature";
+    }
+
+    private static string SuggestCategory(
+        IReadOnlyList<string> labels,
+        bool completed)
+    {
+        var text = string.Join(' ', labels);
+        if (text.Contains("security", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security";
+        }
+        if (text.Contains("bug", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("fix", StringComparison.OrdinalIgnoreCase))
+        {
+            return "fixed";
+        }
+        return completed ? "changed" : "added";
+    }
+
+    private static string? Truncate(string? value, int maximumLength) =>
+        string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Length <= maximumLength
+                ? value
+                : value[..maximumLength] + "…";
+}

--- a/Blueprints.App/Services/HostedSourceProviderRouter.cs
+++ b/Blueprints.App/Services/HostedSourceProviderRouter.cs
@@ -1,0 +1,42 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class HostedSourceProviderRouter : IHostedSourceProviderReader
+{
+    private readonly IReadOnlyDictionary<SourceProviderKind, IHostedSourceProviderReader> _readers;
+
+    public HostedSourceProviderRouter()
+        : this(
+            new GitHubRestSourceProviderReader(),
+            new GitLabRestSourceProviderReader())
+    {
+    }
+
+    public HostedSourceProviderRouter(
+        GitHubRestSourceProviderReader gitHubReader,
+        GitLabRestSourceProviderReader gitLabReader)
+    {
+        ArgumentNullException.ThrowIfNull(gitHubReader);
+        ArgumentNullException.ThrowIfNull(gitLabReader);
+        _readers = new Dictionary<SourceProviderKind, IHostedSourceProviderReader>
+        {
+            [SourceProviderKind.GitHub] = gitHubReader,
+            [SourceProviderKind.GitLab] = gitLabReader,
+        };
+    }
+
+    public HostedSourceDiscoveryResult Read(
+        string repositoryRoot,
+        HostedRepositoryDescriptor repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+        if (!_readers.TryGetValue(repository.Provider, out var reader))
+        {
+            throw new InvalidOperationException(
+                $"No hosted-source reader supports {repository.Provider}.");
+        }
+
+        return reader.Read(repositoryRoot, repository);
+    }
+}

--- a/Blueprints.App/Services/IHostedSourceProviderReader.cs
+++ b/Blueprints.App/Services/IHostedSourceProviderReader.cs
@@ -6,5 +6,5 @@ public interface IHostedSourceProviderReader
 {
     HostedSourceDiscoveryResult Read(
         string repositoryRoot,
-        string repositoryName);
+        HostedRepositoryDescriptor repository);
 }

--- a/Blueprints.App/Services/IProviderCredentialSource.cs
+++ b/Blueprints.App/Services/IProviderCredentialSource.cs
@@ -3,4 +3,6 @@ namespace Blueprints.App.Services;
 public interface IProviderCredentialSource
 {
     string? GetGitHubToken();
+
+    string? GetGitLabToken();
 }

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -45,16 +45,7 @@ public sealed class IntegrationStatusService
         [
             .. GetLocalGitStatuses(settings, checkedAtUtc),
             GetGitHubStatus(checkedAtUtc),
-            new IntegrationStatusCard(
-                IntegrationProviderType.GitLab,
-                "GitLab",
-                IntegrationConnectionState.NotConfigured,
-                "No GitLab project linked",
-                "GitLab should reuse the same source-control model as GitHub for issues, merge requests, pipelines, and releases.",
-                "Implement after the common provider model exists so GitHub does not become the only supported worldview.",
-                BlueprintsTrustBoundary(),
-                checkedAtUtc,
-                []),
+            GetGitLabStatus(checkedAtUtc),
             new IntegrationStatusCard(
                 IntegrationProviderType.VaultSync,
                 "VaultSync",
@@ -91,6 +82,30 @@ public sealed class IntegrationStatusService
             hasCredential
                 ? "The credential is read from BLUEPRINTS_GITHUB_TOKEN and is never persisted by Blueprints. Provider access remains read-only."
                 : "Set BLUEPRINTS_GITHUB_TOKEN in the application environment when private or Project discovery is needed.",
+            BlueprintsTrustBoundary(),
+            checkedAtUtc,
+            []);
+    }
+
+    private IntegrationStatusCard GetGitLabStatus(DateTimeOffset checkedAtUtc)
+    {
+        var hasCredential = !string.IsNullOrWhiteSpace(
+            _providerCredentialSource.GetGitLabToken());
+        return new IntegrationStatusCard(
+            IntegrationProviderType.GitLab,
+            "GitLab",
+            hasCredential
+                ? IntegrationConnectionState.Connected
+                : IntegrationConnectionState.Warning,
+            hasCredential
+                ? "Direct API credential available"
+                : "Public API discovery only",
+            hasCredential
+                ? "Source Lens can read issues, merge requests, releases, and milestones from private and public GitLab.com projects."
+                : "Source Lens can read public GitLab.com issues, merge requests, releases, and milestones.",
+            hasCredential
+                ? "The credential is read from BLUEPRINTS_GITLAB_TOKEN and is never persisted by Blueprints. Provider access remains read-only."
+                : "Set BLUEPRINTS_GITLAB_TOKEN in the application environment when private-project discovery is needed.",
             BlueprintsTrustBoundary(),
             checkedAtUtc,
             []);

--- a/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
+++ b/Blueprints.App/Services/RepositorySourceDiscoveryService.cs
@@ -12,12 +12,12 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
     public RepositorySourceDiscoveryService()
         : this(
             new MarkdownSourceDiscoveryParser(),
-            new GitHubRestSourceProviderReader())
+            new HostedSourceProviderRouter())
     {
     }
 
     public RepositorySourceDiscoveryService(MarkdownSourceDiscoveryParser markdownParser)
-        : this(markdownParser, new GitHubRestSourceProviderReader())
+        : this(markdownParser, new HostedSourceProviderRouter())
     {
     }
 
@@ -46,23 +46,24 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         var changelogCount = AddMarkdownCandidates(root, SourceArtifactKind.Changelog, candidates);
         var roadmapCount = AddMarkdownCandidates(root, SourceArtifactKind.Roadmap, candidates);
 
-        var repositoryName = ReadGitHubRepositoryName(root);
-        var githubIssueCount = 0;
-        var githubProjectCount = 0;
-        var pullRequestCount = 0;
+        var hostedRepository = ReadHostedRepository(root);
+        var hostedIssueCount = 0;
+        var hostedPlanningCount = 0;
+        var changeRequestCount = 0;
         var releaseCount = 0;
-        if (string.IsNullOrWhiteSpace(repositoryName))
+        if (hostedRepository is null)
         {
-            warnings.Add("GitHub sources were skipped because the origin remote is not a recognizable GitHub repository.");
+            warnings.Add(
+                "Hosted sources were skipped because the origin remote is not a recognizable GitHub or GitLab repository.");
         }
         else
         {
-            var hosted = _hostedSourceProviderReader.Read(root, repositoryName);
+            var hosted = _hostedSourceProviderReader.Read(root, hostedRepository);
             candidates.AddRange(hosted.Candidates);
             warnings.AddRange(hosted.Warnings);
-            githubIssueCount = hosted.IssueCount;
-            githubProjectCount = hosted.ProjectCount;
-            pullRequestCount = hosted.PullRequestCount;
+            hostedIssueCount = hosted.IssueCount;
+            hostedPlanningCount = hosted.ProjectCount;
+            changeRequestCount = hosted.ChangeRequestCount;
             releaseCount = hosted.ReleaseCount;
         }
 
@@ -79,9 +80,9 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
             warnings,
             changelogCount,
             roadmapCount,
-            githubIssueCount,
-            githubProjectCount,
-            pullRequestCount,
+            hostedIssueCount,
+            hostedPlanningCount,
+            changeRequestCount,
             releaseCount);
     }
 
@@ -113,27 +114,40 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
         return candidates.Count - countBefore;
     }
 
-    private static string ReadGitHubRepositoryName(string root)
+    private static HostedRepositoryDescriptor? ReadHostedRepository(string root)
     {
         var remote = RunProcess(root, "git", ["-C", root, "config", "--get", "remote.origin.url"]);
         if (!remote.Success)
         {
-            return string.Empty;
+            return null;
         }
 
-        var match = GitHubRemotePattern().Match(remote.Output.Trim());
-        if (!match.Success)
+        var remoteUrl = remote.Output.Trim();
+        var gitHubMatch = GitHubRemotePattern().Match(remoteUrl);
+        if (gitHubMatch.Success)
         {
-            return string.Empty;
+            var repository = RemoveGitSuffix(gitHubMatch.Groups["repo"].Value);
+            return new HostedRepositoryDescriptor(
+                SourceProviderKind.GitHub,
+                $"{gitHubMatch.Groups["owner"].Value}/{repository}");
         }
 
-        var repository = match.Groups["repo"].Value;
+        var gitLabMatch = GitLabRemotePattern().Match(remoteUrl);
+        return gitLabMatch.Success
+            ? new HostedRepositoryDescriptor(
+                SourceProviderKind.GitLab,
+                RemoveGitSuffix(gitLabMatch.Groups["repo"].Value))
+            : null;
+    }
+
+    private static string RemoveGitSuffix(string repository)
+    {
         if (repository.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
         {
             repository = repository[..^4];
         }
 
-        return $"{match.Groups["owner"].Value}/{repository}";
+        return repository;
     }
 
     private static ProcessResult RunProcess(
@@ -182,6 +196,9 @@ public sealed partial class RepositorySourceDiscoveryService : ISourceDiscoveryS
 
     [GeneratedRegex(@"(?:github\.com[:/])(?<owner>[^/\s]+)/(?<repo>[^/\s]+)$")]
     private static partial Regex GitHubRemotePattern();
+
+    [GeneratedRegex(@"(?:gitlab\.com[:/])(?<repo>[^\s]+)$")]
+    private static partial Regex GitLabRemotePattern();
 
     [GeneratedRegex(@"\s+")]
     private static partial Regex WhitespacePattern();

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -2623,7 +2623,7 @@ public partial class MainWindowViewModel : ViewModelBase
             new SourceDiscoveryResult(
                 [
                     new SourceDiscoveryCandidate(
-                        SourceArtifactKind.GitHubProject,
+                        SourceArtifactKind.Project,
                         "Interactive dependency map",
                         "Let users connect work visually and reveal release blockers.",
                         "feature",
@@ -2747,9 +2747,9 @@ public partial class MainWindowViewModel : ViewModelBase
             warnings,
             results.Sum(static pair => pair.Result.ChangelogCount),
             results.Sum(static pair => pair.Result.RoadmapCount),
-            results.Sum(static pair => pair.Result.GitHubIssueCount),
-            results.Sum(static pair => pair.Result.GitHubProjectCount),
-            results.Sum(static pair => pair.Result.PullRequestCount),
+            results.Sum(static pair => pair.Result.HostedIssueCount),
+            results.Sum(static pair => pair.Result.HostedPlanningCount),
+            results.Sum(static pair => pair.Result.ChangeRequestCount),
             results.Sum(static pair => pair.Result.ReleaseCount));
     }
 

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -10,7 +10,7 @@
         <StackPanel Spacing="6">
           <TextBlock Text="SOURCE LENS" Foreground="#68D5EF" FontSize="11" FontWeight="Bold" LetterSpacing="1.6" />
           <TextBlock Text="Turn project signals into an editable blueprint" Foreground="White" FontSize="22" FontWeight="Black" />
-          <TextBlock Text="Blueprints reads local planning files and GitHub metadata. Every result remains a draft until you edit and approve it."
+          <TextBlock Text="Blueprints reads local planning files plus GitHub and GitLab metadata. Every result remains a draft until you edit and approve it."
                      Foreground="#B5D4E3"
                      TextWrapping="Wrap"
                      MaxWidth="760" />

--- a/Blueprints.Tests/GitHubRestSourceProviderReaderTests.cs
+++ b/Blueprints.Tests/GitHubRestSourceProviderReaderTests.cs
@@ -13,10 +13,14 @@ public sealed class GitHubRestSourceProviderReaderTests
         var handler = new GitHubHandler();
         var reader = CreateReader(handler, null);
 
-        var result = reader.Read("/repository", "example/project");
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitHub,
+                "example/project"));
 
         Assert.Equal(1, result.IssueCount);
-        Assert.Equal(1, result.PullRequestCount);
+        Assert.Equal(1, result.ChangeRequestCount);
         Assert.Equal(1, result.ReleaseCount);
         Assert.Equal(0, result.ProjectCount);
         Assert.Contains(
@@ -40,7 +44,11 @@ public sealed class GitHubRestSourceProviderReaderTests
         var handler = new GitHubHandler();
         var reader = CreateReader(handler, "test-secret");
 
-        var result = reader.Read("/repository", "example/project");
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitHub,
+                "example/project"));
 
         Assert.Equal(2, result.ProjectCount);
         Assert.Empty(result.Warnings);
@@ -53,7 +61,7 @@ public sealed class GitHubRestSourceProviderReaderTests
         Assert.Contains(
             result.Candidates,
             static candidate =>
-                candidate.Kind == SourceArtifactKind.GitHubProject &&
+                candidate.Kind == SourceArtifactKind.Project &&
                 candidate.Title == "Standalone draft");
         Assert.Single(
             result.Candidates,
@@ -61,7 +69,7 @@ public sealed class GitHubRestSourceProviderReaderTests
         Assert.Contains(
             result.Candidates,
             static candidate =>
-                candidate.Kind == SourceArtifactKind.GitHubProject &&
+                candidate.Kind == SourceArtifactKind.Project &&
                 candidate.Title == "Fix direct discovery");
     }
 
@@ -71,7 +79,11 @@ public sealed class GitHubRestSourceProviderReaderTests
         var handler = new GitHubHandler(HttpStatusCode.Unauthorized);
         var reader = CreateReader(handler, "test-secret");
 
-        var result = reader.Read("/repository", "example/project");
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitHub,
+                "example/project"));
 
         Assert.Empty(result.Candidates);
         Assert.Equal(4, result.Warnings.Count);
@@ -97,7 +109,11 @@ public sealed class GitHubRestSourceProviderReaderTests
         var reader = CreateReader(new GitHubHandler(), null);
 
         Assert.Throws<InvalidOperationException>(
-            () => reader.Read("/repository", repositoryName));
+            () => reader.Read(
+                "/repository",
+                new HostedRepositoryDescriptor(
+                    SourceProviderKind.GitHub,
+                    repositoryName)));
     }
 
     private static GitHubRestSourceProviderReader CreateReader(
@@ -113,6 +129,8 @@ public sealed class GitHubRestSourceProviderReaderTests
     private sealed class TestCredentialSource(string? token) : IProviderCredentialSource
     {
         public string? GetGitHubToken() => token;
+
+        public string? GetGitLabToken() => null;
     }
 
     private sealed class GitHubHandler : HttpMessageHandler

--- a/Blueprints.Tests/GitHubSourceJsonParserTests.cs
+++ b/Blueprints.Tests/GitHubSourceJsonParserTests.cs
@@ -50,7 +50,7 @@ public sealed class GitHubSourceJsonParserTests
             "example/project");
 
         var candidate = Assert.Single(candidates);
-        Assert.Equal(SourceArtifactKind.GitHubProject, candidate.Kind);
+        Assert.Equal(SourceArtifactKind.Project, candidate.Kind);
         Assert.Equal("Design offline provider cache", candidate.Title);
         Assert.False(candidate.IsDone);
         var reference = Assert.IsType<ProviderReference>(candidate.ProviderReference);
@@ -78,13 +78,13 @@ public sealed class GitHubSourceJsonParserTests
             "example/project");
 
         var candidate = Assert.Single(candidates);
-        Assert.Equal(SourceArtifactKind.PullRequest, candidate.Kind);
+        Assert.Equal(SourceArtifactKind.ChangeRequest, candidate.Kind);
         Assert.True(candidate.IsDone);
         Assert.Equal("bug", candidate.SuggestedItemTypeId);
         Assert.Equal("fixed", candidate.SuggestedCategoryId);
         var reference = Assert.IsType<ProviderReference>(candidate.ProviderReference);
         Assert.Equal(SourceProviderKind.GitHub, reference.Provider);
-        Assert.Equal(ProviderReferenceKind.PullRequest, reference.Kind);
+        Assert.Equal(ProviderReferenceKind.ChangeRequest, reference.Kind);
         Assert.Equal("example/project", reference.Repository);
         Assert.Equal("#42", reference.Identifier);
     }

--- a/Blueprints.Tests/GitLabRestSourceProviderReaderTests.cs
+++ b/Blueprints.Tests/GitLabRestSourceProviderReaderTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class GitLabRestSourceProviderReaderTests
+{
+    [Fact]
+    public void Read_MapsBoundedGitLabSourcesAndUsesEncodedProjectPath()
+    {
+        var handler = new GitLabHandler();
+        var reader = CreateReader(handler, "gitlab-secret");
+
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitLab,
+                "example/platform/project"));
+
+        Assert.Equal(1, result.IssueCount);
+        Assert.Equal(1, result.ChangeRequestCount);
+        Assert.Equal(1, result.ReleaseCount);
+        Assert.Equal(1, result.ProjectCount);
+        Assert.Empty(result.Warnings);
+        Assert.Equal(4, handler.Requests.Count);
+        Assert.All(handler.Requests, static request =>
+            Assert.Equal("gitlab-secret", request.Token));
+        Assert.All(handler.Requests, static request =>
+            Assert.Contains(
+                "example%2Fplatform%2Fproject",
+                request.Path,
+                StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            result.Candidates,
+            static candidate =>
+                candidate.Kind == SourceArtifactKind.ChangeRequest &&
+                candidate.ProviderReference?.Provider == SourceProviderKind.GitLab);
+    }
+
+    [Fact]
+    public void Read_AllowsAnonymousPublicDiscovery()
+    {
+        var handler = new GitLabHandler();
+        var reader = CreateReader(handler, null);
+
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitLab,
+                "example/project"));
+
+        Assert.Empty(result.Warnings);
+        Assert.All(handler.Requests, static request =>
+            Assert.Null(request.Token));
+    }
+
+    [Fact]
+    public void Read_ReportsFailuresWithoutExposingCredential()
+    {
+        var reader = CreateReader(
+            new GitLabHandler(HttpStatusCode.Unauthorized),
+            "gitlab-secret");
+
+        var result = reader.Read(
+            "/repository",
+            new HostedRepositoryDescriptor(
+                SourceProviderKind.GitLab,
+                "example/project"));
+
+        Assert.Empty(result.Candidates);
+        Assert.Equal(4, result.Warnings.Count);
+        Assert.All(result.Warnings, static warning =>
+        {
+            Assert.Contains("401", warning, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "gitlab-secret",
+                warning,
+                StringComparison.Ordinal);
+        });
+    }
+
+    private static GitLabRestSourceProviderReader CreateReader(
+        GitLabHandler handler,
+        string? token) =>
+        new(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri(
+                    "https://gitlab.example/api/v4/",
+                    UriKind.Absolute),
+            },
+            new TestCredentialSource(token));
+
+    private sealed class TestCredentialSource(string? token)
+        : IProviderCredentialSource
+    {
+        public string? GetGitHubToken() => null;
+
+        public string? GetGitLabToken() => token;
+    }
+
+    private sealed class GitLabHandler : HttpMessageHandler
+    {
+        private readonly Lock _lock = new();
+        private readonly HttpStatusCode _statusCode;
+
+        public GitLabHandler(HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _statusCode = statusCode;
+        }
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                Requests.Add(
+                    new CapturedRequest(
+                        request.RequestUri!.PathAndQuery,
+                        request.Headers.TryGetValues(
+                            "PRIVATE-TOKEN",
+                            out var values)
+                            ? values.Single()
+                            : null));
+            }
+            if (_statusCode != HttpStatusCode.OK)
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(_statusCode)
+                    {
+                        Content = new StringContent("provider error"),
+                    });
+            }
+
+            var json = request.RequestUri!.AbsolutePath switch
+            {
+                var path when path.EndsWith("/issues", StringComparison.Ordinal) =>
+                    """
+                    [{
+                      "iid": 4,
+                      "title": "Fix GitLab discovery",
+                      "description": "Provider parity.",
+                      "state": "closed",
+                      "web_url": "https://gitlab.example/example/project/-/issues/4",
+                      "labels": ["bug"],
+                      "milestone": { "title": "0.4.0" }
+                    }]
+                    """,
+                var path when path.EndsWith("/merge_requests", StringComparison.Ordinal) =>
+                    """
+                    [{
+                      "iid": 5,
+                      "title": "Add merge request discovery",
+                      "description": "Provider parity.",
+                      "state": "merged",
+                      "merged_at": "2026-07-30T00:00:00Z",
+                      "web_url": "https://gitlab.example/example/project/-/merge_requests/5",
+                      "labels": ["feature"]
+                    }]
+                    """,
+                var path when path.EndsWith("/releases", StringComparison.Ordinal) =>
+                    """
+                    [{
+                      "tag_name": "v0.4.0",
+                      "name": "Source awareness",
+                      "description": "GitLab parity.",
+                      "released_at": "2026-07-30T00:00:00Z",
+                      "upcoming_release": false,
+                      "_links": {
+                        "self": "https://gitlab.example/example/project/-/releases/v0.4.0"
+                      }
+                    }]
+                    """,
+                var path when path.EndsWith("/milestones", StringComparison.Ordinal) =>
+                    """
+                    [{
+                      "iid": 6,
+                      "title": "0.4.0",
+                      "description": "Source awareness.",
+                      "state": "active"
+                    }]
+                    """,
+                _ => "[]",
+            };
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json),
+                });
+        }
+    }
+
+    private sealed record CapturedRequest(string Path, string? Token);
+}

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -18,13 +18,17 @@ public sealed class IntegrationStatusServiceTests
             status => Assert.Equal(IntegrationProviderType.GitHub, status.Provider),
             status => Assert.Equal(IntegrationProviderType.GitLab, status.Provider),
             status => Assert.Equal(IntegrationProviderType.VaultSync, status.Provider));
-        Assert.Equal(
-            IntegrationConnectionState.Warning,
-            statuses.Single(status =>
-                status.Provider == IntegrationProviderType.GitHub).State);
         Assert.All(
             statuses.Where(status =>
-                status.Provider != IntegrationProviderType.GitHub),
+                status.Provider is IntegrationProviderType.GitHub or
+                IntegrationProviderType.GitLab),
+            status => Assert.Equal(
+                IntegrationConnectionState.Warning,
+                status.State));
+        Assert.All(
+            statuses.Where(status =>
+                status.Provider is not IntegrationProviderType.GitHub and not
+                IntegrationProviderType.GitLab),
             status => Assert.Equal(
                 IntegrationConnectionState.NotConfigured,
                 status.State));
@@ -48,6 +52,27 @@ public sealed class IntegrationStatusServiceTests
         Assert.DoesNotContain(
             "test-secret",
             $"{github.Target}{github.Summary}{github.Guidance}",
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetIntegrationStatuses_ReportsGitLabCredentialWithoutPersistingIt()
+    {
+        var service = CreateService(
+            IntegrationSettings.Empty,
+            gitLabCredential: "gitlab-secret");
+
+        var gitLab = service.GetIntegrationStatuses()
+            .Single(status => status.Provider == IntegrationProviderType.GitLab);
+
+        Assert.Equal(IntegrationConnectionState.Connected, gitLab.State);
+        Assert.Contains(
+            "BLUEPRINTS_GITLAB_TOKEN",
+            gitLab.Guidance,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "gitlab-secret",
+            $"{gitLab.Target}{gitLab.Summary}{gitLab.Guidance}",
             StringComparison.Ordinal);
     }
 
@@ -169,16 +194,21 @@ public sealed class IntegrationStatusServiceTests
     private static IntegrationStatusService CreateService(
         IntegrationSettings settings,
         LocalGitRepositoryStatus? gitStatus = null,
-        string? credential = null) =>
+        string? credential = null,
+        string? gitLabCredential = null) =>
         new(
             new TestIntegrationSettingsStore(settings),
             new TestLocalGitRepositoryInspector(gitStatus),
-            new TestProviderCredentialSource(credential));
+            new TestProviderCredentialSource(credential, gitLabCredential));
 
-    private sealed class TestProviderCredentialSource(string? credential)
+    private sealed class TestProviderCredentialSource(
+        string? credential,
+        string? gitLabCredential)
         : IProviderCredentialSource
     {
         public string? GetGitHubToken() => credential;
+
+        public string? GetGitLabToken() => gitLabCredential;
     }
 
     private sealed class TestIntegrationSettingsStore : IIntegrationSettingsStore

--- a/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
+++ b/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
@@ -104,7 +104,7 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
         Assert.Equal(2, result.Candidates.Count);
         Assert.Equal(1, result.ChangelogCount);
         Assert.Equal(1, result.RoadmapCount);
-        Assert.Equal(0, result.GitHubIssueCount);
+        Assert.Equal(0, result.HostedIssueCount);
         Assert.Contains(
             result.Warnings,
             static warning => warning.Contains("GitHub", StringComparison.OrdinalIgnoreCase));
@@ -123,12 +123,38 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
 
         var result = service.Discover(_root);
 
-        Assert.Equal("example/project", hostedReader.RepositoryName);
+        Assert.Equal("example/project", hostedReader.Repository.RepositoryName);
+        Assert.Equal(SourceProviderKind.GitHub, hostedReader.Repository.Provider);
         Assert.Equal(_root, hostedReader.RepositoryRoot);
-        Assert.Equal(1, result.PullRequestCount);
+        Assert.Equal(1, result.ChangeRequestCount);
         Assert.Contains(
             result.Candidates,
-            static candidate => candidate.Kind == SourceArtifactKind.PullRequest);
+            static candidate => candidate.Kind == SourceArtifactKind.ChangeRequest);
+    }
+
+    [Fact]
+    public void Discover_RoutesNestedGitLabOriginThroughProviderBoundary()
+    {
+        Directory.CreateDirectory(_root);
+        RunGit("init", _root);
+        RunGit(
+            "-C",
+            _root,
+            "remote",
+            "add",
+            "origin",
+            "git@gitlab.com:example/platform/project.git");
+        var hostedReader = new TestHostedSourceProviderReader();
+        var service = new RepositorySourceDiscoveryService(
+            new MarkdownSourceDiscoveryParser(),
+            hostedReader);
+
+        service.Discover(_root);
+
+        Assert.Equal(SourceProviderKind.GitLab, hostedReader.Repository.Provider);
+        Assert.Equal(
+            "example/platform/project",
+            hostedReader.Repository.RepositoryName);
     }
 
     private string Write(string name, string content)
@@ -170,18 +196,19 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
     {
         public string RepositoryRoot { get; private set; } = string.Empty;
 
-        public string RepositoryName { get; private set; } = string.Empty;
+        public HostedRepositoryDescriptor Repository { get; private set; } =
+            new(SourceProviderKind.Local, string.Empty);
 
         public HostedSourceDiscoveryResult Read(
             string repositoryRoot,
-            string repositoryName)
+            HostedRepositoryDescriptor repository)
         {
             RepositoryRoot = repositoryRoot;
-            RepositoryName = repositoryName;
+            Repository = repository;
             return new HostedSourceDiscoveryResult(
                 [
                     new SourceDiscoveryCandidate(
-                        SourceArtifactKind.PullRequest,
+                        SourceArtifactKind.ChangeRequest,
                         "Provider-neutral reader",
                         null,
                         "feature",
@@ -192,8 +219,8 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
                         1,
                         new ProviderReference(
                             SourceProviderKind.GitHub,
-                            ProviderReferenceKind.PullRequest,
-                            repositoryName,
+                            ProviderReferenceKind.ChangeRequest,
+                            repository.RepositoryName,
                             "#1",
                             null)),
                 ],

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -1053,7 +1053,7 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
                         "Visualize GitHub issues",
                         "Approval-first source ingestion.",
                         false,
-                        SourceArtifactKind.GitHubIssue,
+                        SourceArtifactKind.Issue,
                         "github:#42"),
                     new ApprovedSourceImportItem(
                         versionId,
@@ -1071,7 +1071,7 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Contains(items, static item =>
             item.Title == "Visualize GitHub issues" &&
             item.Tags.Contains("source-import") &&
-            item.Tags.Contains("source:githubissue") &&
+            item.Tags.Contains("source:issue") &&
             item.Tags.Contains("github:#42"));
         Assert.Contains(items, static item => item.ItemKey.StartsWith("BUG-", StringComparison.Ordinal));
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Relationship authoring and removal in the canvas inspector, colored relationship projection on the canvas, archive cleanup, audit operations, and document-aware conflict summaries.
 - Direct bounded GitHub REST and GraphQL discovery for issues, pull requests, releases, project-linked issues, and standalone Project drafts, including anonymous public-repository reads.
 - A provider-operation policy that allows reads directly but requires a fresh, exact-target, single-use approval before any future hosted-provider write.
+- GitLab.com remote detection and bounded parallel discovery for issues, merge requests, releases, and milestones, with anonymous public reads and environment-only private-project credentials.
 
 ### Changed
 
@@ -28,6 +29,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Combined Source Lens summaries now separate issue, pull-request, release, and project-linked proposal counts.
 - Schema-1 workspaces may contain an optional signed `project/relationships.json`; missing files remain compatible with earlier workspaces and the complete relationship graph is one revisioned conflict domain.
 - Source Lens no longer requires the GitHub CLI. Private repository and GitHub Project discovery uses the environment-only `BLUEPRINTS_GITHUB_TOKEN`; Blueprints does not persist the credential.
+- Hosted source kinds and counts are provider-neutral, so GitHub pull requests and GitLab merge requests share the same change-request workflow without provider-specific signed data.
 
 ## 0.3.0 — 2026-07-30
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -76,7 +76,7 @@ Goal: connect release intent to source history without weakening local ownership
 - [x] Replace the authenticated GitHub CLI implementation with a direct provider adapter.
 - [x] Add standalone GitHub Project draft-item discovery.
 - [x] Define and separately approve any future provider write operations.
-- [ ] Add GitLab parity after the provider contract stabilizes.
+- [x] Add GitLab parity after the provider contract stabilizes.
 
 Exit criteria:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ Zoom and scroll offsets follow a separate local-preference flow: validate bounde
 
 1. Resolve the linked local Git worktree.
 2. Parse bounded changelog and roadmap Markdown locally.
-3. Resolve a GitHub origin and query bounded issue, pull-request, and release metadata through the direct REST adapter; query Project metadata through GraphQL when an environment credential is available.
+3. Resolve a GitHub or GitLab.com origin and route it through the matching provider-neutral reader. GitHub uses bounded REST plus authenticated GraphQL for Projects; GitLab uses bounded REST for issues, merge requests, releases, and milestones.
 4. Normalize source entries into transient `SourceDiscoveryCandidate` values.
 5. Present editable `SourceImportProposal` values and flag exact-title duplicates.
 6. Require the user to choose inclusion, target version, type, category, title, description, and completion state.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -59,6 +59,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Source discovery uses read-only local/GitHub commands and enforces count, line, and text bounds.
 - Source apply validates the complete batch before persistence and requires trusted, conflict-free, mutable targets.
 - GitHub API credentials are accepted only through the process environment variable `BLUEPRINTS_GITHUB_TOKEN` and remain outside Blueprints workspaces and settings.
+- GitLab API credentials follow the same isolation rule through `BLUEPRINTS_GITLAB_TOKEN`.
 - Hosted-provider reads are allowed directly. Any future write must have a fresh, exact-target, single-use approval with a maximum ten-minute lifetime; credentials alone never authorize a write.
 
 ## Important limitations

--- a/docs/source-lens.md
+++ b/docs/source-lens.md
@@ -12,6 +12,10 @@ Source Lens converts existing project signals into editable Blueprints work-item
 | GitHub pull requests | Direct REST API request | Open, closed, and merged pull-request metadata |
 | GitHub releases | Direct REST API request | Draft and published release records |
 | GitHub Projects | Direct authenticated GraphQL query | Standalone draft items and project-linked issues |
+| GitLab issues | Direct REST API request | Open and closed issue metadata |
+| GitLab merge requests | Direct REST API request | Open, closed, and merged change-request metadata |
+| GitLab releases | Direct REST API request | Published and upcoming release records |
+| GitLab milestones | Direct REST API request | Active and closed planning milestones |
 
 The scanner checks each linked repository root and its `docs` directory for common changelog and roadmap filename casing. It reads at most 5,000 lines and 100 candidates per Markdown file. GitHub reads are limited to 100 issues, 100 pull requests, and 50 releases per repository. A per-repository scan returns at most 250 deduplicated proposals, and combined discovery returns at most 500 proposals across up to eight worktrees.
 
@@ -24,6 +28,8 @@ Standalone draft discovery reads only Projects linked to the repository, checks 
 - The Git worktree must have a recognizable `github.com` origin remote.
 - Public issues, pull requests, and releases can be discovered anonymously.
 - Set `BLUEPRINTS_GITHUB_TOKEN` in the application environment for private repositories, draft releases, or GitHub Projects. Use the narrowest read-only repository permissions that cover the sources you need.
+- A `gitlab.com` origin is detected for GitLab discovery, including nested group paths.
+- Public GitLab.com sources can be discovered anonymously. Set a read-only `BLUEPRINTS_GITLAB_TOKEN` in the application environment for private projects.
 
 Local Markdown discovery still works if GitHub is unavailable. Source Lens reports the skipped provider as a warning instead of failing the entire scan.
 
@@ -65,7 +71,7 @@ Applied items retain tags that identify:
 
 When several repositories are scanned, the source reference is qualified with the full local worktree path before it enters the proposal inbox. Source content remains informational. It does not inherit authority from GitHub, a roadmap, or a changelog.
 
-Internally, Source Lens classifies references without making one hosted provider the domain model. A reference records:
+Internally, Source Lens classifies references without making one hosted provider the domain model. GitHub pull requests and GitLab merge requests are both change requests; GitHub Projects and GitLab milestones are both hosted planning records. A reference records:
 
 - provider (`Local`, `GitHub`, or `GitLab`);
 - artifact kind (planning document, commit, issue, pull request, release, or project);
@@ -73,13 +79,14 @@ Internally, Source Lens classifies references without making one hosted provider
 - provider identifier;
 - an optional web location.
 
-Local Markdown and GitHub issue discovery already emit this structure. Pull-request, release, standalone project, and GitLab readers can use the same contract without changing signed Blueprints project truth.
+Local Markdown, GitHub, and GitLab discovery all emit this structure without changing signed Blueprints project truth.
 
 ## Security and privacy
 
 - Discovery is read-only for the repository and GitHub.
 - Blueprints never invokes provider write commands during discovery or apply.
 - GitHub credentials are read only from `BLUEPRINTS_GITHUB_TOKEN`. They are not written to integration settings, signed project files, logs, warnings, or proposal provenance.
+- GitLab credentials follow the same rule through `BLUEPRINTS_GITLAB_TOKEN`.
 - Untrusted source text is length- and count-bounded and rendered as text.
 - Proposals are transient UI state until explicit approval.
 - Invalid taxonomy, missing versions, frozen/released targets, broken trust, and sync conflicts block apply.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -99,6 +99,8 @@ Discovery is read-only. It does not commit, push, edit issues, change Projects, 
 
 Public GitHub issues, pull requests, and releases are read directly without requiring the GitHub CLI. For private repositories, draft releases, and GitHub Projects, start Blueprints with a read-only token in `BLUEPRINTS_GITHUB_TOKEN`. Blueprints reads that variable for the current process and does not store it in project or integration settings. Local changelog and roadmap discovery remains available when GitHub cannot be reached. See [Source Lens](source-lens.md) for limits, duplicate behavior, and security details.
 
+GitLab.com worktrees use the same flow for issues, merge requests, releases, and milestones. Public projects need no credential; private projects use a read-only `BLUEPRINTS_GITLAB_TOKEN` in the application environment. Nested GitLab group paths are supported.
+
 ## Exchange changes
 
 The shared root is an exchange layer, not the editable workspace.


### PR DESCRIPTION
## Summary
- detect GitLab.com origins, including nested group paths, and route hosted reads by provider
- add bounded parallel issue, merge-request, release, and milestone discovery with anonymous public access and environment-only private credentials
- generalize hosted source kinds and counts from GitHub-specific names to provider-neutral issue, planning, and change-request concepts
- update integration status, security guidance, Source Lens docs, changelog, and roadmap

## Verification
- `dotnet test Blueprints.sln --no-restore` (128 passed)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (no vulnerable packages)
- live GitLab.com route and endpoint contract checks
- application startup smoke test