### PR TITLE
Prepare Blueprints 0.4.0 milestone release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+## 0.4.0 — 2026-07-30
+
+Provider-neutral source-control awareness milestone. This release connects the signed release plan to local Git, GitHub, and GitLab evidence while keeping discovery read-only, credentials local, and every imported proposal subject to explicit review.
+
 ### Added
 
 - Canvas box selection, additive multi-selection, grouped node dragging, `Ctrl+A`, `Escape`, precise arrow-key movement, live alignment guides, and a viewport minimap.
@@ -21,7 +25,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ### Changed
 
-- Alpha 4 development builds now identify themselves as `0.4.0-alpha.4-dev`.
+- Completed release builds now identify themselves as `0.4.0`.
 - Canvas guidance now exposes the active selection and the available multi-node keyboard controls; resulting layout changes keep using signed, audited persistence.
 - The release planner now presents source-control blockers and follow-up guidance next to source trace and changelog review.
 - Source Lens accepts one repository path per line and preserves the full repository-qualified provenance of combined proposals.
@@ -30,6 +34,26 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Schema-1 workspaces may contain an optional signed `project/relationships.json`; missing files remain compatible with earlier workspaces and the complete relationship graph is one revisioned conflict domain.
 - Source Lens no longer requires the GitHub CLI. Private repository and GitHub Project discovery uses the environment-only `BLUEPRINTS_GITHUB_TOKEN`; Blueprints does not persist the credential.
 - Hosted source kinds and counts are provider-neutral, so GitHub pull requests and GitLab merge requests share the same change-request workflow without provider-specific signed data.
+
+### Security
+
+- Hosted API responses are fetched in parallel with per-request timeouts, 4 MiB response limits, provider-specific count limits, repository-identity validation, and credential-free error messages.
+- GitHub and GitLab credentials are accepted only from process environment variables and never enter signed project truth, integration settings, proposal provenance, or warnings.
+- Future provider writes require a fresh approval matching the exact provider, repository, operation, and target; approval expires within ten minutes and is consumed once.
+
+### Workspace compatibility
+
+- Signed workspace schema remains version 1.
+- `project/relationships.json` and its signature are optional schema-1 documents. Older projects remain readable until the first relationship type is saved.
+- Provider references and credentials remain application-layer and machine-local data; no hosted provider is required to open, edit, sign, or exchange a project.
+
+### Known limitations
+
+- This release contains no installers or application binaries.
+- Hosted-provider integrations are discovery-only; no issue, project, merge-request, pull-request, or release writes are implemented.
+- GitLab hosted discovery currently recognizes `gitlab.com` origins, not arbitrary self-managed GitLab hosts.
+- Provider credentials use process environment variables rather than an OAuth/device flow or operating-system credential UI.
+- Directional relationship types do not yet render arrowheads, and relationship conflicts resolve as a whole document.
 
 ## 0.3.0 — 2026-07-30
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <VersionSuffix>alpha.4-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -60,7 +60,7 @@ Exit criteria:
 - conflicts explain what changed and produce a recoverable result;
 - membership changes cannot remove the last active administrator.
 
-## In progress — v0.4: source-control awareness
+## Completed — v0.4: source-control awareness
 
 Goal: connect release intent to source history without weakening local ownership.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,7 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.4.0` | 2026-07-30 | Provider-neutral source-control awareness | Advanced canvas editing, signed typed relationships, multi-repository readiness analysis, provider-neutral references, direct bounded GitHub and GitLab discovery, isolated credentials, and an explicit approval boundary for future provider writes |
 | `v0.3.0` | 2026-07-30 | Understandable collaboration | Distinct signing identities, signed invitation onboarding, member-key-aware trust, staged and recoverable sync, semantic conflict comparison, manifest/audit evidence, recoverable archives, explicit identity setup, and disaster-recovery guidance |
 | `v0.2.0-alpha.2` | 2026-07-30 | Interactive workspace | Diagram-first canvas, signed shared layouts, machine-local viewport state, approval-first Source Lens, adaptive workflow navigation, .NET 10, Avalonia 12, and expanded security/user documentation |
 | [`v0.1.0-alpha.1`](https://github.com/ATAC-Helicopter/Blueprints/releases/tag/v0.1.0-alpha.1) | 2026-02-28 | Foundation | Domain contracts, canonical signed persistence, protected identities, shared-folder sync foundation, audit chaining, and the initial Avalonia application scaffold |
@@ -15,7 +16,6 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 | Version | Milestone outcome |
 | --- | --- |
 | `v0.2.0` | Complete the coherent solo workflow with identity onboarding, editing history, archive/delete flows, and release polish |
-| `v0.4.0` | Provider-neutral source-control awareness |
 | `v0.5.0` | Explicit VaultSync transport and backup-health integration |
 | `v1.0.0` | A dependable, supported small-team release planner |
 


### PR DESCRIPTION
## Summary
- finalize the v0.4 source-control awareness roadmap milestone
- freeze the changelog with security, compatibility, and known-limitations notes
- remove the alpha development suffix so release builds report 0.4.0
- add the completed milestone to release history

## Verification
- `./scripts/verify.sh` (Release build, 128 tests passed)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- resolved package version: `0.4.0`