### PR TITLE
Add passive VaultSync backup health awareness

### DIFF
--- a/Blueprints.App/Models/VaultSyncStatusSummary.cs
+++ b/Blueprints.App/Models/VaultSyncStatusSummary.cs
@@ -1,0 +1,19 @@
+namespace Blueprints.App.Models;
+
+public sealed record VaultSyncStatusSummary(
+    bool MetadataStoreFound,
+    string MetadataStorePath,
+    string StatusDocumentPath,
+    DateTimeOffset? LastMetadataWriteUtc,
+    string ProjectExternalId,
+    string ProjectName,
+    string DestinationAlias,
+    bool? DestinationReachable,
+    DateTimeOffset? LatestSnapshotUtc,
+    DateTimeOffset? LatestBackupUtc,
+    DateTimeOffset? LatestVerificationUtc,
+    bool? BackupIndexConsistent,
+    string RestoreReadiness,
+    int MetadataConflictCount,
+    IReadOnlyList<string> Warnings,
+    string Summary);

--- a/Blueprints.App/Services/FileSystemIntegrationSettingsStore.cs
+++ b/Blueprints.App/Services/FileSystemIntegrationSettingsStore.cs
@@ -5,6 +5,8 @@ namespace Blueprints.App.Services;
 
 public sealed class FileSystemIntegrationSettingsStore : IIntegrationSettingsStore
 {
+    public const long MaximumSettingsBytes = 1024 * 1024;
+
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -26,21 +28,47 @@ public sealed class FileSystemIntegrationSettingsStore : IIntegrationSettingsSto
             return IntegrationSettings.Empty;
         }
 
-        var json = File.ReadAllText(_settingsPath);
-        return JsonSerializer.Deserialize<IntegrationSettings>(json, SerializerOptions)
-            ?? IntegrationSettings.Empty;
+        try
+        {
+            if (new FileInfo(_settingsPath).Length > MaximumSettingsBytes)
+            {
+                return IntegrationSettings.Empty;
+            }
+
+            var json = File.ReadAllText(_settingsPath);
+            return JsonSerializer.Deserialize<IntegrationSettings>(json, SerializerOptions)
+                ?? IntegrationSettings.Empty;
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return IntegrationSettings.Empty;
+        }
     }
 
     public void Save(IntegrationSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
 
-        var directory = Path.GetDirectoryName(_settingsPath);
-        if (!string.IsNullOrWhiteSpace(directory))
+        var fullPath = Path.GetFullPath(_settingsPath);
+        var directory = Path.GetDirectoryName(fullPath)!;
+        Directory.CreateDirectory(directory);
+        var temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+        try
         {
-            Directory.CreateDirectory(directory);
+            File.WriteAllText(
+                temporaryPath,
+                JsonSerializer.Serialize(settings, SerializerOptions));
+            File.Move(temporaryPath, fullPath, overwrite: true);
         }
-
-        File.WriteAllText(_settingsPath, JsonSerializer.Serialize(settings, SerializerOptions));
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
     }
 }

--- a/Blueprints.App/Services/FileSystemVaultSyncStatusReader.cs
+++ b/Blueprints.App/Services/FileSystemVaultSyncStatusReader.cs
@@ -1,0 +1,305 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class FileSystemVaultSyncStatusReader : IVaultSyncStatusReader
+{
+    public const string MetadataFileName = "vaultsync.meta.db";
+    public const string StatusFileName = "blueprints.status.json";
+    public const long MaximumStatusDocumentBytes = 1024 * 1024;
+    private const int MaximumWarnings = 32;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        MaxDepth = 16,
+    };
+
+    public VaultSyncStatusSummary Inspect(string configuredRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredRoot);
+
+        string normalizedRoot;
+        try
+        {
+            normalizedRoot = Path.GetFullPath(configuredRoot.Trim());
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return Missing(configuredRoot.Trim(), $"The configured VaultSync path is invalid: {exception.Message}");
+        }
+
+        var metadataPath = ResolveMetadataPath(normalizedRoot);
+        if (metadataPath is null)
+        {
+            return Missing(
+                normalizedRoot,
+                $"No {MetadataFileName} store was found below the configured location.");
+        }
+
+        DateTimeOffset metadataWriteUtc;
+        try
+        {
+            metadataWriteUtc = File.GetLastWriteTimeUtc(metadataPath);
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException)
+        {
+            return Invalid(
+                metadataPath,
+                string.Empty,
+                null,
+                $"VaultSync metadata could not be inspected: {exception.Message}");
+        }
+
+        var statusPath = Path.Combine(
+            Path.GetDirectoryName(metadataPath) ?? normalizedRoot,
+            StatusFileName);
+        if (!File.Exists(statusPath))
+        {
+            return new VaultSyncStatusSummary(
+                true,
+                metadataPath,
+                statusPath,
+                metadataWriteUtc,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Unknown",
+                0,
+                [$"{StatusFileName} is not available; detailed backup health was not inferred from SQLite."],
+                "VaultSync metadata detected; detailed backup health is unavailable.");
+        }
+
+        try
+        {
+            var statusInfo = new FileInfo(statusPath);
+            if (statusInfo.Length > MaximumStatusDocumentBytes)
+            {
+                return Invalid(
+                    metadataPath,
+                    statusPath,
+                    metadataWriteUtc,
+                    $"The VaultSync health document exceeds the {MaximumStatusDocumentBytes / 1024} KiB read limit.");
+            }
+
+            using var stream = File.OpenRead(statusPath);
+            var document = JsonSerializer.Deserialize<VaultSyncHealthDocument>(
+                stream,
+                SerializerOptions);
+            if (document is null || document.SchemaVersion != 1)
+            {
+                return Invalid(
+                    metadataPath,
+                    statusPath,
+                    metadataWriteUtc,
+                    "The VaultSync health document must use schemaVersion 1.");
+            }
+
+            var warnings = (document.Warnings ?? [])
+                .Where(static warning => !string.IsNullOrWhiteSpace(warning))
+                .Select(static warning => warning.Trim())
+                .ToList();
+            if (document.DestinationReachable is not true)
+            {
+                warnings.Add("The VaultSync destination is not reported as reachable.");
+            }
+
+            if (document.BackupIndexConsistent is not true)
+            {
+                warnings.Add("The VaultSync backup index is not reported as consistent.");
+            }
+
+            if (document.LatestBackupUtc is null)
+            {
+                warnings.Add("VaultSync did not report a latest backup.");
+            }
+
+            if (document.LatestSnapshotUtc is null)
+            {
+                warnings.Add("VaultSync did not report a latest snapshot.");
+            }
+
+            if (document.LatestVerificationUtc is null)
+            {
+                warnings.Add("VaultSync did not report a latest verification.");
+            }
+
+            if (!IsReady(document.RestoreReadiness))
+            {
+                warnings.Add($"VaultSync restore readiness is {Bounded(document.RestoreReadiness, "Unknown")}.");
+            }
+
+            if (document.MetadataConflictCount > 0)
+            {
+                warnings.Add($"{document.MetadataConflictCount} VaultSync metadata conflicts require review.");
+            }
+
+            var boundedWarnings = warnings
+                .Distinct(StringComparer.Ordinal)
+                .Take(MaximumWarnings)
+                .ToArray();
+
+            return new VaultSyncStatusSummary(
+                true,
+                metadataPath,
+                statusPath,
+                metadataWriteUtc,
+                Bounded(document.ProjectExternalId),
+                Bounded(document.ProjectName),
+                Bounded(document.DestinationAlias),
+                document.DestinationReachable,
+                document.LatestSnapshotUtc,
+                document.LatestBackupUtc,
+                document.LatestVerificationUtc,
+                document.BackupIndexConsistent,
+                Bounded(document.RestoreReadiness, "Unknown"),
+                Math.Max(0, document.MetadataConflictCount),
+                boundedWarnings,
+                BuildSummary(document));
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return Invalid(
+                metadataPath,
+                statusPath,
+                metadataWriteUtc,
+                $"VaultSync health could not be read: {exception.Message}");
+        }
+    }
+
+    private static string? ResolveMetadataPath(string configuredRoot)
+    {
+        if (File.Exists(configuredRoot))
+        {
+            return string.Equals(
+                Path.GetFileName(configuredRoot),
+                MetadataFileName,
+                StringComparison.OrdinalIgnoreCase)
+                ? configuredRoot
+                : null;
+        }
+
+        if (!Directory.Exists(configuredRoot))
+        {
+            return null;
+        }
+
+        var candidates = new[]
+        {
+            Path.Combine(configuredRoot, ".vaultsync", "meta", MetadataFileName),
+            Path.Combine(configuredRoot, "meta", MetadataFileName),
+            Path.Combine(configuredRoot, MetadataFileName),
+        };
+
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static VaultSyncStatusSummary Missing(string target, string summary) =>
+        new(
+            false,
+            target,
+            string.Empty,
+            null,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Unavailable",
+            0,
+            [summary],
+            summary);
+
+    private static VaultSyncStatusSummary Invalid(
+        string metadataPath,
+        string statusPath,
+        DateTimeOffset? metadataWriteUtc,
+        string summary) =>
+        new(
+            true,
+            metadataPath,
+            statusPath,
+            metadataWriteUtc,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Unavailable",
+            0,
+            [summary],
+            summary);
+
+    private static string BuildSummary(VaultSyncHealthDocument document)
+    {
+        var readiness = Bounded(document.RestoreReadiness, "Unknown");
+        var snapshot = document.LatestSnapshotUtc is null
+            ? "no snapshot reported"
+            : $"latest snapshot {document.LatestSnapshotUtc:yyyy-MM-dd HH:mm} UTC";
+        var backup = document.LatestBackupUtc is null
+            ? "no backup reported"
+            : $"latest backup {document.LatestBackupUtc:yyyy-MM-dd HH:mm} UTC";
+        var verification = document.LatestVerificationUtc is null
+            ? "no verification reported"
+            : $"verified {document.LatestVerificationUtc:yyyy-MM-dd HH:mm} UTC";
+        return $"Restore readiness: {readiness}. {snapshot}; {backup}; {verification}.";
+    }
+
+    private static bool IsReady(string? restoreReadiness) =>
+        restoreReadiness?.Trim() is { } readiness &&
+        (readiness.Equals("Ready", StringComparison.OrdinalIgnoreCase) ||
+         readiness.Equals("Healthy", StringComparison.OrdinalIgnoreCase));
+
+    private static string Bounded(string? value, string fallback = "")
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed[..Math.Min(trimmed.Length, 256)];
+    }
+
+    private sealed record VaultSyncHealthDocument
+    {
+        public int SchemaVersion { get; init; }
+
+        public string? ProjectExternalId { get; init; }
+
+        public string? ProjectName { get; init; }
+
+        public string? DestinationAlias { get; init; }
+
+        public bool? DestinationReachable { get; init; }
+
+        public DateTimeOffset? LatestSnapshotUtc { get; init; }
+
+        public DateTimeOffset? LatestBackupUtc { get; init; }
+
+        public DateTimeOffset? LatestVerificationUtc { get; init; }
+
+        public bool? BackupIndexConsistent { get; init; }
+
+        public string? RestoreReadiness { get; init; }
+
+        public int MetadataConflictCount { get; init; }
+
+        public IReadOnlyList<string>? Warnings { get; init; }
+    }
+}

--- a/Blueprints.App/Services/IVaultSyncStatusReader.cs
+++ b/Blueprints.App/Services/IVaultSyncStatusReader.cs
@@ -1,0 +1,8 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public interface IVaultSyncStatusReader
+{
+    VaultSyncStatusSummary Inspect(string configuredRoot);
+}

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -7,12 +7,14 @@ public sealed class IntegrationStatusService
     private readonly IIntegrationSettingsStore _settingsStore;
     private readonly ILocalGitRepositoryInspector _localGitRepositoryInspector;
     private readonly IProviderCredentialSource _providerCredentialSource;
+    private readonly IVaultSyncStatusReader _vaultSyncStatusReader;
 
     public IntegrationStatusService()
         : this(
             new FileSystemIntegrationSettingsStore(AppEnvironment.GetIntegrationSettingsPath()),
             new GitCommandLocalGitRepositoryInspector(),
-            new EnvironmentProviderCredentialSource())
+            new EnvironmentProviderCredentialSource(),
+            new FileSystemVaultSyncStatusReader())
     {
     }
 
@@ -22,18 +24,21 @@ public sealed class IntegrationStatusService
         : this(
             settingsStore,
             localGitRepositoryInspector,
-            new EnvironmentProviderCredentialSource())
+            new EnvironmentProviderCredentialSource(),
+            new FileSystemVaultSyncStatusReader())
     {
     }
 
     public IntegrationStatusService(
         IIntegrationSettingsStore settingsStore,
         ILocalGitRepositoryInspector localGitRepositoryInspector,
-        IProviderCredentialSource providerCredentialSource)
+        IProviderCredentialSource providerCredentialSource,
+        IVaultSyncStatusReader? vaultSyncStatusReader = null)
     {
         _settingsStore = settingsStore;
         _localGitRepositoryInspector = localGitRepositoryInspector;
         _providerCredentialSource = providerCredentialSource;
+        _vaultSyncStatusReader = vaultSyncStatusReader ?? new FileSystemVaultSyncStatusReader();
     }
 
     public IReadOnlyList<IntegrationStatusCard> GetIntegrationStatuses()
@@ -46,16 +51,7 @@ public sealed class IntegrationStatusService
             .. GetLocalGitStatuses(settings, checkedAtUtc),
             GetGitHubStatus(checkedAtUtc),
             GetGitLabStatus(checkedAtUtc),
-            new IntegrationStatusCard(
-                IntegrationProviderType.VaultSync,
-                "VaultSync",
-                IntegrationConnectionState.NotConfigured,
-                "No VaultSync metadata root configured",
-                "VaultSync passive awareness should detect .vaultsync/meta/vaultsync.meta.db and surface destination, snapshot, backup, verify, and restore-readiness health.",
-                "Treat VaultSync as transport and backup health. Do not modify the production VaultSync app from Blueprints work; read metadata first and keep Blueprints signatures authoritative.",
-                BlueprintsTrustBoundary(),
-                checkedAtUtc,
-                []),
+            GetVaultSyncStatus(settings, checkedAtUtc),
         ];
     }
 
@@ -106,6 +102,57 @@ public sealed class IntegrationStatusService
             hasCredential
                 ? "The credential is read from BLUEPRINTS_GITLAB_TOKEN and is never persisted by Blueprints. Provider access remains read-only."
                 : "Set BLUEPRINTS_GITLAB_TOKEN in the application environment when private-project discovery is needed.",
+            BlueprintsTrustBoundary(),
+            checkedAtUtc,
+            []);
+    }
+
+    private IntegrationStatusCard GetVaultSyncStatus(
+        IntegrationSettings settings,
+        DateTimeOffset checkedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(settings.VaultSyncMetadataRoot))
+        {
+            return new IntegrationStatusCard(
+                IntegrationProviderType.VaultSync,
+                "VaultSync",
+                IntegrationConnectionState.NotConfigured,
+                "No VaultSync metadata root configured",
+                $"Link a destination or metadata root containing .vaultsync/meta/{FileSystemVaultSyncStatusReader.MetadataFileName}.",
+                "Blueprints reads passive backup health only. VaultSync remains responsible for transport and recovery; Blueprints signatures remain authoritative.",
+                BlueprintsTrustBoundary(),
+                checkedAtUtc,
+                []);
+        }
+
+        var status = _vaultSyncStatusReader.Inspect(settings.VaultSyncMetadataRoot);
+        var hasRisk = !status.MetadataStoreFound ||
+            status.DestinationReachable is not true ||
+            status.BackupIndexConsistent is not true ||
+            status.LatestSnapshotUtc is null ||
+            status.LatestBackupUtc is null ||
+            status.LatestVerificationUtc is null ||
+            status.MetadataConflictCount > 0 ||
+            status.Warnings.Count > 0 ||
+            !(status.RestoreReadiness.Equals("Ready", StringComparison.OrdinalIgnoreCase) ||
+              status.RestoreReadiness.Equals("Healthy", StringComparison.OrdinalIgnoreCase));
+        var target = string.IsNullOrWhiteSpace(status.DestinationAlias)
+            ? status.MetadataStorePath
+            : $"{status.DestinationAlias} · {status.MetadataStorePath}";
+
+        return new IntegrationStatusCard(
+            IntegrationProviderType.VaultSync,
+            "VaultSync",
+            !status.MetadataStoreFound
+                ? IntegrationConnectionState.Error
+                : hasRisk
+                    ? IntegrationConnectionState.Warning
+                    : IntegrationConnectionState.Connected,
+            target,
+            status.Summary,
+            status.Warnings.Count == 0
+                ? "Backup metadata is healthy. Blueprints used read-only evidence and did not modify VaultSync or signed project truth."
+                : string.Join(" ", status.Warnings),
             BlueprintsTrustBoundary(),
             checkedAtUtc,
             []);

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -87,6 +87,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _selectedConflictLocalPreview = string.Empty;
     private string _selectedConflictSharedPreview = string.Empty;
     private string _localGitRepositoryPath = string.Empty;
+    private string _vaultSyncMetadataRoot = string.Empty;
     private string _integrationMessage = string.Empty;
     private WorkspaceSection _selectedWorkspaceSection = WorkspaceSection.Overview;
     private CanvasLayoutDocument? _canvasLayout;
@@ -276,6 +277,12 @@ public partial class MainWindowViewModel : ViewModelBase
                 OnPropertyChanged(nameof(CanDiscoverSources));
             }
         }
+    }
+
+    public string VaultSyncMetadataRoot
+    {
+        get => _vaultSyncMetadataRoot;
+        set => SetProperty(ref _vaultSyncMetadataRoot, value);
     }
 
     public string IntegrationMessage
@@ -1724,6 +1731,28 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private void SaveVaultSyncMetadataRoot()
+    {
+        try
+        {
+            var configuredRoot = VaultSyncMetadataRoot.Trim();
+            var settings = _integrationStatusService.GetSettings();
+            _integrationStatusService.SaveSettings(settings with
+            {
+                VaultSyncMetadataRoot = configuredRoot,
+            });
+            RefreshIntegrations();
+            IntegrationMessage = string.IsNullOrWhiteSpace(configuredRoot)
+                ? "VaultSync metadata link cleared."
+                : "VaultSync metadata link saved and checked read-only.";
+        }
+        catch (Exception exception)
+        {
+            IntegrationMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
     private void RefreshIntegrationStatuses()
     {
         try
@@ -2548,6 +2577,7 @@ public partial class MainWindowViewModel : ViewModelBase
         LocalGitRepositoryPath = string.Join(
             Environment.NewLine,
             settings.EffectiveLocalGitRepositoryPaths);
+        VaultSyncMetadataRoot = settings.VaultSyncMetadataRoot;
 
         Integrations.Clear();
         foreach (var integration in _integrationStatusService.GetIntegrationStatuses())

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -4,7 +4,7 @@
              xmlns:models="using:Blueprints.App.Models"
              x:Class="Blueprints.App.Views.Components.IntegrationsView"
              x:DataType="vm:MainWindowViewModel">
-  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="12">
+  <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12">
     <Border Background="#082941" BorderBrush="#2A698A" BorderThickness="1" CornerRadius="8" Padding="18">
       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="20">
         <StackPanel Spacing="6">
@@ -46,7 +46,23 @@
               Command="{Binding SaveLocalGitRepositoryPathCommand}" />
     </Grid>
 
-    <Grid Grid.Row="2" ColumnDefinitions="390,*" ColumnSpacing="12">
+    <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+      <Border Classes="card" Padding="12,8">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <TextBlock Text="VAULTSYNC" Classes="eyebrow" VerticalAlignment="Center" />
+          <TextBlock Text="read-only" Foreground="#277A67" FontSize="11" FontWeight="Bold" VerticalAlignment="Center" />
+        </StackPanel>
+      </Border>
+      <TextBox Grid.Column="1"
+               Text="{Binding VaultSyncMetadataRoot}"
+               PlaceholderText="Destination, .vaultsync, meta folder, or vaultsync.meta.db path" />
+      <Button Grid.Column="2"
+              Classes="secondary"
+              Content="Save health link"
+              Command="{Binding SaveVaultSyncMetadataRootCommand}" />
+    </Grid>
+
+    <Grid Grid.Row="3" ColumnDefinitions="390,*" ColumnSpacing="12">
       <Border Classes="card" Padding="0">
         <Grid RowDefinitions="Auto,Auto,*,Auto">
           <Border Padding="15,13" BorderBrush="#D1E4EE" BorderThickness="0,0,0,1">

--- a/Blueprints.Tests/FileSystemIntegrationSettingsStoreTests.cs
+++ b/Blueprints.Tests/FileSystemIntegrationSettingsStoreTests.cs
@@ -1,0 +1,78 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemIntegrationSettingsStoreTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Load_ReturnsEmptyWhenSettingsDoNotExist()
+    {
+        var store = CreateStore();
+
+        var settings = store.Load();
+
+        Assert.Equal(IntegrationSettings.Empty, settings);
+    }
+
+    [Fact]
+    public void Save_RoundTripsAllMachineLocalLinks()
+    {
+        var store = CreateStore();
+        var expected = new IntegrationSettings("/repo-a", "/backup")
+        {
+            LocalGitRepositoryPaths = ["/repo-a", "/repo-b"],
+        };
+
+        store.Save(expected);
+        var actual = store.Load();
+
+        Assert.Equal(expected.LocalGitRepositoryPath, actual.LocalGitRepositoryPath);
+        Assert.Equal(expected.VaultSyncMetadataRoot, actual.VaultSyncMetadataRoot);
+        Assert.Equal(expected.LocalGitRepositoryPaths, actual.LocalGitRepositoryPaths);
+        Assert.Empty(Directory.GetFiles(_root, "*.tmp"));
+    }
+
+    [Fact]
+    public void Load_ReturnsEmptyForMalformedJson()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(SettingsPath, """{"localGitRepositoryPath":""");
+        var store = CreateStore();
+
+        var settings = store.Load();
+
+        Assert.Equal(IntegrationSettings.Empty, settings);
+    }
+
+    [Fact]
+    public void Load_ReturnsEmptyForOversizedInput()
+    {
+        Directory.CreateDirectory(_root);
+        using (var stream = File.Create(SettingsPath))
+        {
+            stream.SetLength(FileSystemIntegrationSettingsStore.MaximumSettingsBytes + 1);
+        }
+
+        var settings = CreateStore().Load();
+
+        Assert.Equal(IntegrationSettings.Empty, settings);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private string SettingsPath => Path.Combine(_root, "integrations.json");
+
+    private FileSystemIntegrationSettingsStore CreateStore() => new(SettingsPath);
+}

--- a/Blueprints.Tests/FileSystemVaultSyncStatusReaderTests.cs
+++ b/Blueprints.Tests/FileSystemVaultSyncStatusReaderTests.cs
@@ -1,0 +1,170 @@
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemVaultSyncStatusReaderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Inspect_DetectsMetadataWithoutReadingSqlite()
+    {
+        var metadataPath = CreateMetadataStore();
+        File.WriteAllText(metadataPath, "not a SQLite database");
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(_root);
+
+        Assert.True(status.MetadataStoreFound);
+        Assert.Equal(metadataPath, status.MetadataStorePath);
+        Assert.Equal("Unknown", status.RestoreReadiness);
+        Assert.Contains(
+            "not available",
+            status.Warnings.Single(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Inspect_ReadsBoundedPassiveHealthDocument()
+    {
+        var metadataPath = CreateMetadataStore();
+        var statusPath = Path.Combine(
+            Path.GetDirectoryName(metadataPath)!,
+            FileSystemVaultSyncStatusReader.StatusFileName);
+        File.WriteAllText(
+            statusPath,
+            """
+            {
+              "schemaVersion": 1,
+              "projectExternalId": "project-42",
+              "projectName": "Blueprints",
+              "destinationAlias": "NAS",
+              "destinationReachable": true,
+              "latestSnapshotUtc": "2026-07-30T20:00:00Z",
+              "latestBackupUtc": "2026-07-30T21:00:00Z",
+              "latestVerificationUtc": "2026-07-30T22:00:00Z",
+              "backupIndexConsistent": true,
+              "restoreReadiness": "Ready",
+              "metadataConflictCount": 0,
+              "warnings": []
+            }
+            """);
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(_root);
+
+        Assert.True(status.MetadataStoreFound);
+        Assert.Equal("project-42", status.ProjectExternalId);
+        Assert.Equal("Blueprints", status.ProjectName);
+        Assert.Equal("NAS", status.DestinationAlias);
+        Assert.True(status.DestinationReachable);
+        Assert.True(status.BackupIndexConsistent);
+        Assert.Equal("Ready", status.RestoreReadiness);
+        Assert.Empty(status.Warnings);
+        Assert.Contains("latest backup", status.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("vaultsync")]
+    [InlineData("meta")]
+    [InlineData("database")]
+    public void Inspect_AcceptsEachDocumentedConfigurationLevel(string level)
+    {
+        var metadataPath = CreateMetadataStore();
+        var configuredPath = level switch
+        {
+            "vaultsync" => Path.Combine(_root, ".vaultsync"),
+            "meta" => Path.GetDirectoryName(metadataPath)!,
+            _ => metadataPath,
+        };
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(configuredPath);
+
+        Assert.True(status.MetadataStoreFound);
+        Assert.Equal(metadataPath, status.MetadataStorePath);
+    }
+
+    [Fact]
+    public void Inspect_RejectsUnsupportedOrMalformedHealthDocuments()
+    {
+        var metadataPath = CreateMetadataStore();
+        var statusPath = Path.Combine(
+            Path.GetDirectoryName(metadataPath)!,
+            FileSystemVaultSyncStatusReader.StatusFileName);
+        File.WriteAllText(statusPath, """{"schemaVersion":2,"restoreReadiness":"Ready"}""");
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(_root);
+
+        Assert.True(status.MetadataStoreFound);
+        Assert.Equal("Unavailable", status.RestoreReadiness);
+        Assert.Contains("schemaVersion 1", status.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Inspect_WarnsWhenRequiredHealthEvidenceIsMissing()
+    {
+        var metadataPath = CreateMetadataStore();
+        var statusPath = Path.Combine(
+            Path.GetDirectoryName(metadataPath)!,
+            FileSystemVaultSyncStatusReader.StatusFileName);
+        File.WriteAllText(
+            statusPath,
+            """{"schemaVersion":1,"restoreReadiness":"Ready"}""");
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(_root);
+
+        Assert.Contains(
+            status.Warnings,
+            warning => warning.Contains("destination", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            status.Warnings,
+            warning => warning.Contains("snapshot", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            status.Warnings,
+            warning => warning.Contains("backup", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            status.Warnings,
+            warning => warning.Contains("verification", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            status.Warnings,
+            warning => warning.Contains("index", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Inspect_RejectsOversizedHealthDocumentsBeforeParsing()
+    {
+        var metadataPath = CreateMetadataStore();
+        var statusPath = Path.Combine(
+            Path.GetDirectoryName(metadataPath)!,
+            FileSystemVaultSyncStatusReader.StatusFileName);
+        using (var stream = File.Create(statusPath))
+        {
+            stream.SetLength(FileSystemVaultSyncStatusReader.MaximumStatusDocumentBytes + 1);
+        }
+
+        var status = new FileSystemVaultSyncStatusReader().Inspect(_root);
+
+        Assert.Equal("Unavailable", status.RestoreReadiness);
+        Assert.Contains("read limit", status.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private string CreateMetadataStore()
+    {
+        var metadataDirectory = Path.Combine(_root, ".vaultsync", "meta");
+        Directory.CreateDirectory(metadataDirectory);
+        var metadataPath = Path.Combine(
+            metadataDirectory,
+            FileSystemVaultSyncStatusReader.MetadataFileName);
+        File.WriteAllBytes(metadataPath, []);
+        return metadataPath;
+    }
+}

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -106,6 +106,69 @@ public sealed class IntegrationStatusServiceTests
     }
 
     [Fact]
+    public void GetIntegrationStatuses_ReportsHealthyVaultSyncEvidence()
+    {
+        var vaultStatus = new VaultSyncStatusSummary(
+            true,
+            "/backup/.vaultsync/meta/vaultsync.meta.db",
+            "/backup/.vaultsync/meta/blueprints.status.json",
+            DateTimeOffset.Parse("2026-07-30T20:00:00Z"),
+            "project-42",
+            "Blueprints",
+            "NAS",
+            true,
+            DateTimeOffset.Parse("2026-07-30T20:00:00Z"),
+            DateTimeOffset.Parse("2026-07-30T21:00:00Z"),
+            DateTimeOffset.Parse("2026-07-30T22:00:00Z"),
+            true,
+            "Ready",
+            0,
+            [],
+            "Restore readiness: Ready.");
+        var service = CreateService(
+            new IntegrationSettings(string.Empty, "/backup"),
+            vaultStatus: vaultStatus);
+
+        var vaultSync = service.GetIntegrationStatuses()
+            .Single(status => status.Provider == IntegrationProviderType.VaultSync);
+
+        Assert.Equal(IntegrationConnectionState.Connected, vaultSync.State);
+        Assert.Contains("NAS", vaultSync.Target, StringComparison.Ordinal);
+        Assert.Contains("read-only", vaultSync.Guidance, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetIntegrationStatuses_WarnsForVaultSyncMetadataConflicts()
+    {
+        var vaultStatus = new VaultSyncStatusSummary(
+            true,
+            "/backup/.vaultsync/meta/vaultsync.meta.db",
+            "/backup/.vaultsync/meta/blueprints.status.json",
+            DateTimeOffset.Parse("2026-07-30T20:00:00Z"),
+            "project-42",
+            "Blueprints",
+            "NAS",
+            true,
+            null,
+            null,
+            null,
+            true,
+            "Risk",
+            2,
+            ["2 VaultSync metadata conflicts require review."],
+            "Restore readiness: Risk.");
+        var service = CreateService(
+            new IntegrationSettings(string.Empty, "/backup"),
+            vaultStatus: vaultStatus);
+
+        var vaultSync = service.GetIntegrationStatuses()
+            .Single(status => status.Provider == IntegrationProviderType.VaultSync);
+
+        Assert.Equal(IntegrationConnectionState.Warning, vaultSync.State);
+        Assert.Contains("conflicts", vaultSync.Guidance, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GetIntegrationStatuses_DetectsConfiguredCleanLocalGitRepository()
     {
         var service = CreateService(
@@ -195,11 +258,13 @@ public sealed class IntegrationStatusServiceTests
         IntegrationSettings settings,
         LocalGitRepositoryStatus? gitStatus = null,
         string? credential = null,
-        string? gitLabCredential = null) =>
+        string? gitLabCredential = null,
+        VaultSyncStatusSummary? vaultStatus = null) =>
         new(
             new TestIntegrationSettingsStore(settings),
             new TestLocalGitRepositoryInspector(gitStatus),
-            new TestProviderCredentialSource(credential, gitLabCredential));
+            new TestProviderCredentialSource(credential, gitLabCredential),
+            new TestVaultSyncStatusReader(vaultStatus));
 
     private sealed class TestProviderCredentialSource(
         string? credential,
@@ -246,5 +311,28 @@ public sealed class IntegrationStatusServiceTests
                     [],
                     "Configured path is not a Git repository.")
                 : _status with { RepositoryRoot = repositoryPath };
+    }
+
+    private sealed class TestVaultSyncStatusReader(VaultSyncStatusSummary? status)
+        : IVaultSyncStatusReader
+    {
+        public VaultSyncStatusSummary Inspect(string configuredRoot) =>
+            status ?? new VaultSyncStatusSummary(
+                false,
+                configuredRoot,
+                string.Empty,
+                null,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Unavailable",
+                0,
+                ["Metadata unavailable."],
+                "Metadata unavailable.");
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+### Added
+
+- Passive VaultSync health awareness with a machine-local metadata-root setting, bounded path detection, and clear healthy, warning, unavailable, and invalid states in the Integrations workspace.
+- A versioned `blueprints.status.json` interoperability contract for destination reachability, snapshot, backup, verification, restore-readiness, index-consistency, and metadata-conflict evidence.
+- An injectable VaultSync status-reader boundary and filesystem tests covering supported root forms, absent sidecars, malformed schemas, and oversized input.
+
+### Changed
+
+- Alpha 5 development builds identify themselves as `0.5.0-alpha.5-dev`.
+- The VaultSync exchange-root contract now reserves `<destination>/.blueprints/projects/<project-id>/` for an explicitly enabled future adapter while keeping the VaultSync project payload separate.
+- Machine-local integration settings now recover safely from malformed or oversized JSON and use atomic replacement on save.
+
+### Security
+
+- Blueprints never parses the VaultSync SQLite database, caps passive health documents at 1 MiB and 32 warnings, and keeps configured paths and all health evidence outside signed project truth.
+
 ## 0.4.0 — 2026-07-30
 
 Provider-neutral source-control awareness milestone. This release connects the signed release plan to local Git, GitHub, and GitLab evidence while keeping discovery read-only, credentials local, and every imported proposal subject to explicit review.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionSuffix>alpha.5-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Release notes often live in scattered issues, commit messages, and private docum
 - discover changelog, roadmap, GitHub issue, and Project signals as editable approval-first proposals;
 - validate signed project files and enter read-only mode when trust breaks;
 - exchange signed changes through a shared folder with explicit push, pull, and conflict resolution;
-- inspect membership, audit history, sync state, and integration boundaries in one desktop app.
+- inspect membership, audit history, sync state, and integration boundaries in one desktop app;
+- inspect passive VaultSync backup and restore-readiness evidence without coupling signed project truth to backup metadata.
 
 ## Current status
 
@@ -45,7 +46,8 @@ Release notes often live in scattered issues, commit messages, and private docum
 | Conflict and audit diagnostics | Document-aware, recoverable, and actionable |
 | Local Git awareness | Read-only integration available |
 | Changelog, roadmap, and GitHub issue discovery | Working, explicit approval required |
-| Full GitHub, GitLab, and VaultSync adapters | Planned |
+| GitHub and GitLab source discovery | Working, read-only and bounded |
+| VaultSync integration | Passive metadata and backup-health awareness |
 | Installers and supported releases | Not ready |
 
 The canonical delivery plan is [ROADMAP.md](Roadmap.md). Older planning files remain as design history and are not the active backlog.
@@ -94,6 +96,7 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 - [User guide](docs/user-guide.md)
 - [Canvas engine](docs/canvas-engine.md)
 - [Source Lens](docs/source-lens.md)
+- [VaultSync integration](docs/vaultsync-integration.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](docs/architecture.md)
 - [Workspace format](docs/workspace-format.md)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -84,12 +84,12 @@ Exit criteria:
 - provider credentials and settings never enter signed project truth;
 - no hosted provider is required for core release planning.
 
-## Later — v0.5: VaultSync integration
+## In progress — v0.5: VaultSync integration
 
 Goal: let VaultSync improve transport and recovery while each product keeps a clear responsibility.
 
-- [ ] Finalize the exchange-root contract.
-- [ ] Detect a VaultSync-managed location and report backup health.
+- [x] Finalize the exchange-root contract.
+- [x] Detect a VaultSync-managed location and report backup health.
 - [ ] Register Blueprints exchange roots through an explicit opt-in adapter.
 - [ ] Add a release safety gate based on verified backup state.
 - [ ] Test restore of both local and exchange workspaces.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use this directory as the canonical technical and user documentation.
 | Trying the app | [User guide](user-guide.md) |
 | Understanding the visual workspace | [Canvas engine](canvas-engine.md) |
 | Importing issues and planning files | [Source Lens](source-lens.md) |
+| Inspecting VaultSync backup health | [VaultSync integration](vaultsync-integration.md) |
 | Diagnosing a problem | [Troubleshooting](troubleshooting.md) |
 | Building or contributing | [Development guide](development.md) |
 | Understanding the code | [Architecture](architecture.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,17 @@ Discovery never mutates the repository, provider, or Blueprints workspace. Provi
 
 The hosted-provider operation policy allows discovery reads without a write approval. Future provider mutations must present a fresh approval matching one exact provider, repository, operation, and target; approval expires within ten minutes and is consumed once.
 
+### Passive VaultSync health
+
+1. Load the machine-local configured VaultSync destination or metadata path.
+2. Resolve only the documented `.vaultsync/meta/vaultsync.meta.db` path forms.
+3. Confirm the portable metadata store exists without opening or parsing its SQLite contents.
+4. Read the optional sibling `blueprints.status.json` through a schema-1, 1 MiB-bounded adapter.
+5. Project reachability, backup, verification, restore-readiness, index, conflict, and warning evidence into the Integrations workspace.
+6. Keep all evidence informational and outside signed project truth.
+
+The reader boundary is injectable so a future stable VaultSync CLI/API adapter can replace the file contract without changing integration presentation or Blueprints trust semantics.
+
 ### Push
 
 1. Build local and shared snapshots.
@@ -116,6 +127,7 @@ The hosted-provider operation policy allows discovery reads without a write appr
 - Local-only integration credentials and paths stay outside project files.
 - Canvas layout is shared signed presentation state; version and item documents remain authoritative content.
 - Source-discovery proposals are transient and untrusted; only reviewed, approved, signed Blueprints items become project truth.
+- VaultSync metadata enriches recovery diagnostics but cannot establish Blueprints workspace trust.
 
 ## Known structural debt
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -22,6 +22,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 | Project invitation | Out-of-band signed trust bootstrap targeted to one local identity |
 | Local project trust anchors | Machine-local accepted member keys; never sourced from unverified shared data |
 | Git/provider integration | Informational; not authoritative project truth |
+| VaultSync metadata and health sidecar | Untrusted, bounded, read-only recovery evidence; never Blueprints trust authority |
 | Source Lens proposals | Untrusted transient suggestions; no persistence before explicit approval |
 | UI input | Validated by application workflows before persistence |
 | Canvas layout | Signed shared node positions; entity references and coordinate bounds validated before rendering or saving |
@@ -61,6 +62,8 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - GitHub API credentials are accepted only through the process environment variable `BLUEPRINTS_GITHUB_TOKEN` and remain outside Blueprints workspaces and settings.
 - GitLab API credentials follow the same isolation rule through `BLUEPRINTS_GITLAB_TOKEN`.
 - Hosted-provider reads are allowed directly. Any future write must have a fresh, exact-target, single-use approval with a maximum ten-minute lifetime; credentials alone never authorize a write.
+- VaultSync passive awareness resolves only documented paths, does not parse the metadata SQLite database, and limits the optional health sidecar to 1 MiB, schema depth 16, and 32 distinct warnings.
+- VaultSync paths and health evidence are machine-local integration state. They do not enter signed workspaces, manifests, audit history, or release semantics.
 
 ## Important limitations
 
@@ -75,7 +78,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Conflict recovery copies are local, unsigned operational records; protect and back them up according to the sensitivity of project content.
 - Blueprints does not encrypt project content.
 - Duplicate detection is an exact normalized-title warning, not semantic identity proof.
-- GitHub Project discovery currently sees project-linked repository issues, not standalone Project draft items.
+- VaultSync health freshness is reported from supplied timestamps; passive awareness does not independently verify backup payloads or destination contents.
 
 ## Reviewing security changes
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -101,6 +101,14 @@ Public GitHub issues, pull requests, and releases are read directly without requ
 
 GitLab.com worktrees use the same flow for issues, merge requests, releases, and milestones. Public projects need no credential; private projects use a read-only `BLUEPRINTS_GITLAB_TOKEN` in the application environment. Nested GitLab group paths are supported.
 
+## Inspect VaultSync backup health
+
+Open **Source Lens**, then enter a VaultSync destination, `.vaultsync` directory, `meta` directory, or exact `vaultsync.meta.db` path in the VaultSync field and select **Save health link**.
+
+Blueprints confirms the portable metadata store exists without reading its SQLite schema. If VaultSync also supplies `.vaultsync/meta/blueprints.status.json`, the connection card reports destination reachability, latest snapshot, backup and verification times, restore readiness, backup-index consistency, and metadata conflicts. A missing health document is shown honestly as “metadata detected; detailed backup health unavailable.”
+
+This integration is passive and machine-local. Blueprints does not register projects, start a backup, verify payloads, or make VaultSync evidence authoritative. See [VaultSync integration](vaultsync-integration.md) for the exact contract and limits.
+
 ## Exchange changes
 
 The shared root is an exchange layer, not the editable workspace.

--- a/docs/vaultsync-integration.md
+++ b/docs/vaultsync-integration.md
@@ -1,0 +1,72 @@
+# VaultSync integration
+
+Blueprints treats VaultSync as an optional transport and recovery system. Blueprints continues to own release semantics, signed project documents, membership, manifests, audit continuity, and conflict decisions. Either application remains usable when the other is absent.
+
+## Passive health contract
+
+The VaultSync link is a machine-local path stored with other application integration settings. It is never written into the signed project or shared exchange root.
+
+Blueprints accepts any of these configured locations:
+
+- a destination containing `.vaultsync/meta/vaultsync.meta.db`;
+- the destination's `.vaultsync` directory;
+- the `.vaultsync/meta` directory;
+- the exact `vaultsync.meta.db` file.
+
+Detection is deliberately shallow and deterministic. Blueprints confirms the database exists but does not open or parse SQLite because that would couple this application to VaultSync's private storage schema.
+
+Detailed health is optional. A producer may place this file beside the database:
+
+```text
+<destination>/.vaultsync/meta/blueprints.status.json
+```
+
+Schema 1:
+
+```json
+{
+  "schemaVersion": 1,
+  "projectExternalId": "stable-vaultsync-project-id",
+  "projectName": "Example",
+  "destinationAlias": "Studio NAS",
+  "destinationReachable": true,
+  "latestSnapshotUtc": "2026-07-30T20:00:00Z",
+  "latestBackupUtc": "2026-07-30T21:00:00Z",
+  "latestVerificationUtc": "2026-07-30T22:00:00Z",
+  "backupIndexConsistent": true,
+  "restoreReadiness": "Ready",
+  "metadataConflictCount": 0,
+  "warnings": []
+}
+```
+
+The document is read-only input. Blueprints accepts at most 1 MiB, JSON depth 16, 32 distinct non-empty warnings, and 256 characters for displayed identity fields. Unsupported or malformed schemas become warnings and never affect workspace trust.
+
+Connection states:
+
+- **Connected:** metadata and a risk-free schema-1 health document are available.
+- **Warning:** metadata exists but detailed health is absent, reports risk, contains warnings or conflicts, or says the destination/index is unhealthy.
+- **Error:** the configured location does not contain a supported metadata store.
+- **Not configured:** no machine-local link is set.
+
+Timestamps and readiness values are evidence reported by the producer. Passive awareness does not independently inspect backup payloads or claim verification.
+
+## Exchange-root contract
+
+When explicit registration is implemented, a Blueprints exchange root managed beneath a VaultSync destination will use:
+
+```text
+<destination>/.blueprints/projects/<project-id>/
+```
+
+`<project-id>` is the lowercase canonical Blueprints project GUID. The directory contains the same signed documents, signatures, and manifest expected from any Blueprints shared root.
+
+The ownership boundary is:
+
+- Blueprints creates and validates content only under its project-specific directory after explicit opt-in.
+- VaultSync owns transport, destination reachability, backup, verification, and restore operations for the parent destination.
+- Blueprints never mixes exchange state into the backed-up project payload.
+- VaultSync metadata cannot make unsigned or invalid Blueprints documents trusted.
+- Registration and any future VaultSync command remain explicit and reversible; passive health detection never writes.
+
+The registration adapter, release safety gate, and end-to-end restore exercise remain v0.5 work.


### PR DESCRIPTION
## Summary
- begin the v0.5 milestone with a read-only VaultSync metadata and backup-health adapter
- add a machine-local VaultSync link and health state to the Integrations workspace
- define the bounded schema-1 health sidecar and future opt-in exchange-root ownership contract
- harden integration settings with bounded reads, malformed-input recovery, and atomic writes
- advance development versioning to `0.5.0-alpha.5-dev` and update roadmap, changelog, architecture, security, and user documentation

## Safety boundary
- Blueprints confirms `vaultsync.meta.db` exists but never parses SQLite
- health JSON is capped at 1 MiB, depth 16, and 32 warnings
- VaultSync evidence remains machine-local and cannot establish signed workspace trust
- passive detection performs no VaultSync or exchange-root writes

## Verification
- `./scripts/verify.sh` (Release build, 142 tests)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (none found)
- resolved package version: `0.5.0-alpha.5-dev`