### PR TITLE
Add explicit VaultSync exchange registration

### DIFF
--- a/Blueprints.App/Models/IntegrationSettings.cs
+++ b/Blueprints.App/Models/IntegrationSettings.cs
@@ -6,6 +6,8 @@ public sealed record IntegrationSettings(
 {
     public IReadOnlyList<string> LocalGitRepositoryPaths { get; init; } = [];
 
+    public string RegisteredVaultSyncExchangeRoot { get; init; } = string.Empty;
+
     public IReadOnlyList<string> EffectiveLocalGitRepositoryPaths =>
         LocalGitRepositoryPaths
             .Append(LocalGitRepositoryPath)

--- a/Blueprints.App/Models/VaultSyncExchangeRootApproval.cs
+++ b/Blueprints.App/Models/VaultSyncExchangeRootApproval.cs
@@ -1,0 +1,7 @@
+namespace Blueprints.App.Models;
+
+public sealed record VaultSyncExchangeRootApproval(
+    Guid ApprovalId,
+    VaultSyncExchangeRootIntent Intent,
+    DateTimeOffset ApprovedUtc,
+    DateTimeOffset ExpiresUtc);

--- a/Blueprints.App/Models/VaultSyncExchangeRootIntent.cs
+++ b/Blueprints.App/Models/VaultSyncExchangeRootIntent.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.App.Models;
+
+public sealed record VaultSyncExchangeRootIntent(
+    Guid ProjectId,
+    string DestinationRoot,
+    string ExchangeRoot);

--- a/Blueprints.App/Models/VaultSyncExchangeRootRegistration.cs
+++ b/Blueprints.App/Models/VaultSyncExchangeRootRegistration.cs
@@ -1,0 +1,6 @@
+namespace Blueprints.App.Models;
+
+public sealed record VaultSyncExchangeRootRegistration(
+    string ExchangeRoot,
+    string RegistrationMarkerPath,
+    bool AlreadyRegistered);

--- a/Blueprints.App/Services/FileSystemVaultSyncExchangeRootAdapter.cs
+++ b/Blueprints.App/Services/FileSystemVaultSyncExchangeRootAdapter.cs
@@ -1,0 +1,295 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public sealed class FileSystemVaultSyncExchangeRootAdapter : IVaultSyncExchangeRootAdapter
+{
+    public const string RegistrationMarkerFileName = ".blueprints-exchange.json";
+    public const long MaximumRegistrationMarkerBytes = 64 * 1024;
+    public static readonly TimeSpan MaximumApprovalLifetime = TimeSpan.FromMinutes(10);
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    private readonly IVaultSyncStatusReader _statusReader;
+    private readonly HashSet<Guid> _consumedApprovals = [];
+    private readonly Lock _approvalLock = new();
+
+    public FileSystemVaultSyncExchangeRootAdapter()
+        : this(new FileSystemVaultSyncStatusReader())
+    {
+    }
+
+    public FileSystemVaultSyncExchangeRootAdapter(IVaultSyncStatusReader statusReader)
+    {
+        _statusReader = statusReader;
+    }
+
+    public VaultSyncExchangeRootIntent PrepareIntent(
+        string configuredMetadataRoot,
+        Guid projectId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredMetadataRoot);
+        if (projectId == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                "A real Blueprints project is required before registering an exchange root.");
+        }
+
+        var status = _statusReader.Inspect(configuredMetadataRoot);
+        if (!status.MetadataStoreFound)
+        {
+            throw new InvalidOperationException(
+                "VaultSync metadata must be detected before registering an exchange root.");
+        }
+
+        var metadataFile = new FileInfo(Path.GetFullPath(status.MetadataStorePath));
+        var metadataDirectory = metadataFile.Directory;
+        var vaultSyncDirectory = metadataDirectory?.Parent;
+        var destinationDirectory = vaultSyncDirectory?.Parent;
+        if (metadataDirectory is null ||
+            vaultSyncDirectory is null ||
+            destinationDirectory is null ||
+            !metadataDirectory.Name.Equals("meta", StringComparison.OrdinalIgnoreCase) ||
+            !vaultSyncDirectory.Name.Equals(".vaultsync", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Exchange registration requires metadata at <destination>/.vaultsync/meta/vaultsync.meta.db.");
+        }
+
+        var destinationRoot = Path.GetFullPath(destinationDirectory.FullName);
+        var exchangeRoot = Path.GetFullPath(
+            Path.Combine(
+                destinationRoot,
+                ".blueprints",
+                "projects",
+                projectId.ToString("D").ToLowerInvariant()));
+        EnsureContained(destinationRoot, exchangeRoot);
+
+        return new VaultSyncExchangeRootIntent(
+            projectId,
+            destinationRoot,
+            exchangeRoot);
+    }
+
+    public VaultSyncExchangeRootApproval Approve(
+        VaultSyncExchangeRootIntent intent,
+        DateTimeOffset nowUtc)
+    {
+        ValidateIntent(intent);
+        return new VaultSyncExchangeRootApproval(
+            Guid.NewGuid(),
+            intent,
+            nowUtc,
+            nowUtc.Add(MaximumApprovalLifetime));
+    }
+
+    public VaultSyncExchangeRootRegistration Register(
+        VaultSyncExchangeRootIntent intent,
+        VaultSyncExchangeRootApproval approval,
+        DateTimeOffset nowUtc)
+    {
+        ValidateIntent(intent);
+        Authorize(intent, approval, nowUtc);
+
+        var blueprintsRoot = Path.Combine(intent.DestinationRoot, ".blueprints");
+        var projectsRoot = Path.Combine(blueprintsRoot, "projects");
+        RejectReparsePoint(blueprintsRoot);
+        RejectReparsePoint(projectsRoot);
+        RejectReparsePoint(intent.ExchangeRoot);
+
+        var markerPath = Path.Combine(
+            intent.ExchangeRoot,
+            RegistrationMarkerFileName);
+        if (File.Exists(markerPath))
+        {
+            ValidateExistingMarker(markerPath, intent);
+            return new VaultSyncExchangeRootRegistration(
+                intent.ExchangeRoot,
+                markerPath,
+                true);
+        }
+
+        if (Directory.Exists(intent.ExchangeRoot) &&
+            Directory.EnumerateFileSystemEntries(intent.ExchangeRoot).Any())
+        {
+            throw new InvalidOperationException(
+                "The intended VaultSync exchange root already contains unregistered content.");
+        }
+
+        var createdExchangeRoot = !Directory.Exists(intent.ExchangeRoot);
+        Directory.CreateDirectory(intent.ExchangeRoot);
+        try
+        {
+            WriteMarkerAtomically(
+                markerPath,
+                new RegistrationMarker(
+                    1,
+                    intent.ProjectId,
+                    nowUtc));
+        }
+        catch
+        {
+            if (createdExchangeRoot &&
+                Directory.Exists(intent.ExchangeRoot) &&
+                !Directory.EnumerateFileSystemEntries(intent.ExchangeRoot).Any())
+            {
+                Directory.Delete(intent.ExchangeRoot);
+            }
+
+            throw;
+        }
+
+        return new VaultSyncExchangeRootRegistration(
+            intent.ExchangeRoot,
+            markerPath,
+            false);
+    }
+
+    private void Authorize(
+        VaultSyncExchangeRootIntent intent,
+        VaultSyncExchangeRootApproval approval,
+        DateTimeOffset nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(approval);
+        if (approval.ApprovalId == Guid.Empty ||
+            approval.Intent != intent ||
+            approval.ApprovedUtc > nowUtc ||
+            approval.ExpiresUtc <= nowUtc ||
+            approval.ExpiresUtc - approval.ApprovedUtc > MaximumApprovalLifetime)
+        {
+            throw new InvalidOperationException(
+                "VaultSync exchange-root approval is invalid, expired, or does not match the exact project and destination.");
+        }
+
+        lock (_approvalLock)
+        {
+            if (!_consumedApprovals.Add(approval.ApprovalId))
+            {
+                throw new InvalidOperationException(
+                    "VaultSync exchange-root approval has already been consumed.");
+            }
+        }
+    }
+
+    private static void ValidateIntent(VaultSyncExchangeRootIntent intent)
+    {
+        ArgumentNullException.ThrowIfNull(intent);
+        if (intent.ProjectId == Guid.Empty ||
+            string.IsNullOrWhiteSpace(intent.DestinationRoot) ||
+            string.IsNullOrWhiteSpace(intent.ExchangeRoot))
+        {
+            throw new InvalidOperationException(
+                "VaultSync exchange registration requires an exact project, destination, and exchange root.");
+        }
+
+        var destinationRoot = Path.GetFullPath(intent.DestinationRoot);
+        var expectedExchangeRoot = Path.GetFullPath(
+            Path.Combine(
+                destinationRoot,
+                ".blueprints",
+                "projects",
+                intent.ProjectId.ToString("D").ToLowerInvariant()));
+        if (!string.Equals(
+                expectedExchangeRoot,
+                Path.GetFullPath(intent.ExchangeRoot),
+                PathComparison))
+        {
+            throw new InvalidOperationException(
+                "The VaultSync exchange root does not match the project-specific contract.");
+        }
+
+        EnsureContained(destinationRoot, expectedExchangeRoot);
+    }
+
+    private static void ValidateExistingMarker(
+        string markerPath,
+        VaultSyncExchangeRootIntent intent)
+    {
+        try
+        {
+            if (new FileInfo(markerPath).Length > MaximumRegistrationMarkerBytes)
+            {
+                throw new InvalidOperationException(
+                    "The existing VaultSync exchange marker exceeds the read limit.");
+            }
+
+            var marker = JsonSerializer.Deserialize<RegistrationMarker>(
+                File.ReadAllText(markerPath),
+                SerializerOptions);
+            if (marker is null ||
+                marker.SchemaVersion != 1 ||
+                marker.ProjectId != intent.ProjectId)
+            {
+                throw new InvalidOperationException(
+                    "The existing VaultSync exchange marker does not match this project.");
+            }
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                "The existing VaultSync exchange marker is malformed.",
+                exception);
+        }
+    }
+
+    private static void WriteMarkerAtomically(
+        string markerPath,
+        RegistrationMarker marker)
+    {
+        var temporaryPath = Path.Combine(
+            Path.GetDirectoryName(markerPath)!,
+            $".{Path.GetFileName(markerPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllText(
+                temporaryPath,
+                JsonSerializer.Serialize(marker, SerializerOptions));
+            File.Move(temporaryPath, markerPath);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+    }
+
+    private static void RejectReparsePoint(string path)
+    {
+        if (Directory.Exists(path) &&
+            File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint))
+        {
+            throw new InvalidOperationException(
+                $"VaultSync exchange registration refuses the linked directory: {path}");
+        }
+    }
+
+    private static void EnsureContained(string parentPath, string childPath)
+    {
+        var parentPrefix = Path.TrimEndingDirectorySeparator(
+            Path.GetFullPath(parentPath)) + Path.DirectorySeparatorChar;
+        if (!Path.GetFullPath(childPath).StartsWith(
+                parentPrefix,
+                PathComparison))
+        {
+            throw new InvalidOperationException(
+                "The VaultSync exchange root escapes the configured destination.");
+        }
+    }
+
+    private sealed record RegistrationMarker(
+        int SchemaVersion,
+        Guid ProjectId,
+        DateTimeOffset RegisteredUtc);
+}

--- a/Blueprints.App/Services/IVaultSyncExchangeRootAdapter.cs
+++ b/Blueprints.App/Services/IVaultSyncExchangeRootAdapter.cs
@@ -1,0 +1,19 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public interface IVaultSyncExchangeRootAdapter
+{
+    VaultSyncExchangeRootIntent PrepareIntent(
+        string configuredMetadataRoot,
+        Guid projectId);
+
+    VaultSyncExchangeRootApproval Approve(
+        VaultSyncExchangeRootIntent intent,
+        DateTimeOffset nowUtc);
+
+    VaultSyncExchangeRootRegistration Register(
+        VaultSyncExchangeRootIntent intent,
+        VaultSyncExchangeRootApproval approval,
+        DateTimeOffset nowUtc);
+}

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -139,6 +139,20 @@ public sealed class IntegrationStatusService
         var target = string.IsNullOrWhiteSpace(status.DestinationAlias)
             ? status.MetadataStorePath
             : $"{status.DestinationAlias} · {status.MetadataStorePath}";
+        var registeredRoot = settings.RegisteredVaultSyncExchangeRoot;
+        var registeredRootMissing =
+            !string.IsNullOrWhiteSpace(registeredRoot) &&
+            !Directory.Exists(registeredRoot);
+        hasRisk |= registeredRootMissing;
+        var guidance = status.Warnings.Count == 0
+            ? "Backup metadata is healthy. Blueprints used read-only evidence and did not modify VaultSync or signed project truth."
+            : string.Join(" ", status.Warnings);
+        if (!string.IsNullOrWhiteSpace(registeredRoot))
+        {
+            guidance += registeredRootMissing
+                ? $" The registered exchange root is unavailable: {registeredRoot}"
+                : $" Registered exchange root: {registeredRoot}";
+        }
 
         return new IntegrationStatusCard(
             IntegrationProviderType.VaultSync,
@@ -150,9 +164,7 @@ public sealed class IntegrationStatusService
                     : IntegrationConnectionState.Connected,
             target,
             status.Summary,
-            status.Warnings.Count == 0
-                ? "Backup metadata is healthy. Blueprints used read-only evidence and did not modify VaultSync or signed project truth."
-                : string.Join(" ", status.Warnings),
+            guidance,
             BlueprintsTrustBoundary(),
             checkedAtUtc,
             []);

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -22,6 +22,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IntegrationStatusService _integrationStatusService;
     private readonly ISourceDiscoveryService _sourceDiscoveryService;
     private readonly FileSystemCanvasViewStateStore _canvasViewStateStore;
+    private readonly IVaultSyncExchangeRootAdapter _vaultSyncExchangeRootAdapter;
     private LocalWorkspaceSession? _currentSession;
     private string _title = "Blueprints Setup";
     private ProjectSummary _currentProject = new(string.Empty, string.Empty, TrustState.Corrupt, string.Empty);
@@ -55,6 +56,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private WorkspaceItemCard? _selectedItem;
     private Guid? _pendingArchiveVersionId;
     private Guid? _pendingArchiveItemId;
+    private VaultSyncExchangeRootApproval? _pendingVaultSyncExchangeRootApproval;
     private string _newVersionName = "1.0.0";
     private string _versionEditorName = string.Empty;
     private string _versionEditorNotes = string.Empty;
@@ -128,6 +130,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _integrationStatusService = new IntegrationStatusService();
         _sourceDiscoveryService = new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
+        _vaultSyncExchangeRootAdapter = new FileSystemVaultSyncExchangeRootAdapter();
         SourceImportProposals = new ObservableCollection<SourceImportProposal>();
         ApplyDesignSession(CreateDesignSession());
         ApplyDesignSourceProposals();
@@ -137,12 +140,15 @@ public partial class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel(
         ProjectWorkspaceCoordinatorService coordinatorService,
         IntegrationStatusService integrationStatusService,
-        ISourceDiscoveryService? sourceDiscoveryService = null)
+        ISourceDiscoveryService? sourceDiscoveryService = null,
+        IVaultSyncExchangeRootAdapter? vaultSyncExchangeRootAdapter = null)
     {
         _coordinatorService = coordinatorService;
         _integrationStatusService = integrationStatusService;
         _sourceDiscoveryService = sourceDiscoveryService ?? new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
+        _vaultSyncExchangeRootAdapter =
+            vaultSyncExchangeRootAdapter ?? new FileSystemVaultSyncExchangeRootAdapter();
         Versions = new ObservableCollection<WorkspaceVersionCard>();
         AvailableItemTypes = new ObservableCollection<string>();
         AvailableCategories = new ObservableCollection<string>();
@@ -282,8 +288,21 @@ public partial class MainWindowViewModel : ViewModelBase
     public string VaultSyncMetadataRoot
     {
         get => _vaultSyncMetadataRoot;
-        set => SetProperty(ref _vaultSyncMetadataRoot, value);
+        set
+        {
+            if (SetProperty(ref _vaultSyncMetadataRoot, value))
+            {
+                _pendingVaultSyncExchangeRootApproval = null;
+                OnPropertyChanged(nameof(CanRegisterVaultSyncExchangeRoot));
+            }
+        }
     }
+
+    public bool CanRegisterVaultSyncExchangeRoot =>
+        HasActiveSession &&
+        CanMutateWorkspace &&
+        CurrentProject.ProjectId != Guid.Empty &&
+        !string.IsNullOrWhiteSpace(VaultSyncMetadataRoot);
 
     public string IntegrationMessage
     {
@@ -542,6 +561,7 @@ public partial class MainWindowViewModel : ViewModelBase
             if (SetProperty(ref _hasActiveSession, value))
             {
                 OnPropertyChanged(nameof(IsSetupMode));
+                OnPropertyChanged(nameof(CanRegisterVaultSyncExchangeRoot));
             }
         }
     }
@@ -1737,10 +1757,18 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var configuredRoot = VaultSyncMetadataRoot.Trim();
             var settings = _integrationStatusService.GetSettings();
+            var keepRegisteredRoot = string.Equals(
+                settings.VaultSyncMetadataRoot.Trim(),
+                configuredRoot,
+                StringComparison.Ordinal);
             _integrationStatusService.SaveSettings(settings with
             {
                 VaultSyncMetadataRoot = configuredRoot,
+                RegisteredVaultSyncExchangeRoot = keepRegisteredRoot
+                    ? settings.RegisteredVaultSyncExchangeRoot
+                    : string.Empty,
             });
+            _pendingVaultSyncExchangeRootApproval = null;
             RefreshIntegrations();
             IntegrationMessage = string.IsNullOrWhiteSpace(configuredRoot)
                 ? "VaultSync metadata link cleared."
@@ -1748,6 +1776,53 @@ public partial class MainWindowViewModel : ViewModelBase
         }
         catch (Exception exception)
         {
+            IntegrationMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void RegisterVaultSyncExchangeRoot()
+    {
+        if (!CanRegisterVaultSyncExchangeRoot)
+        {
+            IntegrationMessage =
+                "Open a trusted, conflict-free project and link VaultSync metadata before registering an exchange root.";
+            return;
+        }
+
+        try
+        {
+            var intent = _vaultSyncExchangeRootAdapter.PrepareIntent(
+                VaultSyncMetadataRoot,
+                CurrentProject.ProjectId);
+            if (_pendingVaultSyncExchangeRootApproval?.Intent != intent)
+            {
+                _pendingVaultSyncExchangeRootApproval =
+                    _vaultSyncExchangeRootAdapter.Approve(intent, DateTimeOffset.UtcNow);
+                IntegrationMessage =
+                    $"Register {intent.ExchangeRoot}? Select Register exchange again within ten minutes to confirm. " +
+                    "This creates a project-specific directory and registration marker but does not change the active shared root.";
+                return;
+            }
+
+            var registration = _vaultSyncExchangeRootAdapter.Register(
+                intent,
+                _pendingVaultSyncExchangeRootApproval,
+                DateTimeOffset.UtcNow);
+            var settings = _integrationStatusService.GetSettings();
+            _integrationStatusService.SaveSettings(settings with
+            {
+                RegisteredVaultSyncExchangeRoot = registration.ExchangeRoot,
+            });
+            _pendingVaultSyncExchangeRootApproval = null;
+            RefreshIntegrations();
+            IntegrationMessage = registration.AlreadyRegistered
+                ? $"VaultSync exchange root was already registered: {registration.ExchangeRoot}"
+                : $"VaultSync exchange root registered: {registration.ExchangeRoot}. Reopen the project with this shared root when you are ready to use it.";
+        }
+        catch (Exception exception)
+        {
+            _pendingVaultSyncExchangeRootApproval = null;
             IntegrationMessage = exception.Message;
         }
     }
@@ -2453,6 +2528,7 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsWorkspaceReadOnly));
         OnPropertyChanged(nameof(HasConflicts));
         OnPropertyChanged(nameof(CanMutateWorkspace));
+        OnPropertyChanged(nameof(CanRegisterVaultSyncExchangeRoot));
         OnPropertyChanged(nameof(CanArchiveSelectedVersion));
         OnPropertyChanged(nameof(CanArchiveSelectedItem));
         OnPropertyChanged(nameof(IsProjectVersionEmpty));
@@ -2472,6 +2548,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private void ApplySetupState(string message)
     {
         _currentSession = null;
+        _pendingVaultSyncExchangeRootApproval = null;
         Title = "Blueprints Setup";
         CurrentProject = new ProjectSummary(string.Empty, string.Empty, TrustState.Corrupt, string.Empty);
         TrustSummary = message;
@@ -2539,6 +2616,7 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsWorkspaceReadOnly));
         OnPropertyChanged(nameof(HasConflicts));
         OnPropertyChanged(nameof(CanMutateWorkspace));
+        OnPropertyChanged(nameof(CanRegisterVaultSyncExchangeRoot));
         OnPropertyChanged(nameof(WorkspaceModeSummary));
         OnPropertyChanged(nameof(CanResolveSelectedConflict));
         OnPropertyChanged(nameof(HasSyncDiagnostics));
@@ -2578,6 +2656,7 @@ public partial class MainWindowViewModel : ViewModelBase
             Environment.NewLine,
             settings.EffectiveLocalGitRepositoryPaths);
         VaultSyncMetadataRoot = settings.VaultSyncMetadataRoot;
+        OnPropertyChanged(nameof(CanRegisterVaultSyncExchangeRoot));
 
         Integrations.Clear();
         foreach (var integration in _integrationStatusService.GetIntegrationStatuses())

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -46,7 +46,7 @@
               Command="{Binding SaveLocalGitRepositoryPathCommand}" />
     </Grid>
 
-    <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+    <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="10">
       <Border Classes="card" Padding="12,8">
         <StackPanel Orientation="Horizontal" Spacing="8">
           <TextBlock Text="VAULTSYNC" Classes="eyebrow" VerticalAlignment="Center" />
@@ -60,6 +60,11 @@
               Classes="secondary"
               Content="Save health link"
               Command="{Binding SaveVaultSyncMetadataRootCommand}" />
+      <Button Grid.Column="3"
+              Classes="secondary"
+              Content="Register exchange"
+              Command="{Binding RegisterVaultSyncExchangeRootCommand}"
+              IsEnabled="{Binding CanRegisterVaultSyncExchangeRoot}" />
     </Grid>
 
     <Grid Grid.Row="3" ColumnDefinitions="390,*" ColumnSpacing="12">

--- a/Blueprints.Tests/FileSystemIntegrationSettingsStoreTests.cs
+++ b/Blueprints.Tests/FileSystemIntegrationSettingsStoreTests.cs
@@ -27,6 +27,7 @@ public sealed class FileSystemIntegrationSettingsStoreTests : IDisposable
         var expected = new IntegrationSettings("/repo-a", "/backup")
         {
             LocalGitRepositoryPaths = ["/repo-a", "/repo-b"],
+            RegisteredVaultSyncExchangeRoot = "/backup/.blueprints/projects/project-42",
         };
 
         store.Save(expected);
@@ -35,6 +36,9 @@ public sealed class FileSystemIntegrationSettingsStoreTests : IDisposable
         Assert.Equal(expected.LocalGitRepositoryPath, actual.LocalGitRepositoryPath);
         Assert.Equal(expected.VaultSyncMetadataRoot, actual.VaultSyncMetadataRoot);
         Assert.Equal(expected.LocalGitRepositoryPaths, actual.LocalGitRepositoryPaths);
+        Assert.Equal(
+            expected.RegisteredVaultSyncExchangeRoot,
+            actual.RegisteredVaultSyncExchangeRoot);
         Assert.Empty(Directory.GetFiles(_root, "*.tmp"));
     }
 

--- a/Blueprints.Tests/FileSystemVaultSyncExchangeRootAdapterTests.cs
+++ b/Blueprints.Tests/FileSystemVaultSyncExchangeRootAdapterTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemVaultSyncExchangeRootAdapterTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        Guid.NewGuid().ToString("N"));
+    private readonly Guid _projectId = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef");
+
+    [Fact]
+    public void PrepareIntent_DerivesTheProjectSpecificExchangeRoot()
+    {
+        CreateMetadataStore();
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+
+        var intent = adapter.PrepareIntent(_root, _projectId);
+
+        Assert.Equal(Path.GetFullPath(_root), intent.DestinationRoot);
+        Assert.Equal(
+            Path.Combine(
+                Path.GetFullPath(_root),
+                ".blueprints",
+                "projects",
+                _projectId.ToString("D")),
+            intent.ExchangeRoot);
+    }
+
+    [Fact]
+    public void Register_RequiresFreshExactSingleUseApproval()
+    {
+        CreateMetadataStore();
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var now = DateTimeOffset.UtcNow;
+        var intent = adapter.PrepareIntent(_root, _projectId);
+        var approval = adapter.Approve(intent, now);
+
+        Assert.Throws<InvalidOperationException>(
+            () => adapter.Register(
+                intent,
+                approval with
+                {
+                    Intent = intent with { ProjectId = Guid.NewGuid() },
+                },
+                now));
+        Assert.Throws<InvalidOperationException>(
+            () => adapter.Register(
+                intent,
+                approval with { ExpiresUtc = now },
+                now));
+
+        adapter.Register(intent, approval, now);
+
+        Assert.Throws<InvalidOperationException>(
+            () => adapter.Register(intent, approval, now));
+    }
+
+    [Fact]
+    public void Register_WritesBoundedProjectMarkerAndIsIdempotent()
+    {
+        CreateMetadataStore();
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var now = DateTimeOffset.Parse("2026-07-30T23:00:00Z");
+        var intent = adapter.PrepareIntent(_root, _projectId);
+
+        var created = adapter.Register(
+            intent,
+            adapter.Approve(intent, now),
+            now);
+
+        Assert.False(created.AlreadyRegistered);
+        Assert.True(File.Exists(created.RegistrationMarkerPath));
+        using (var marker = JsonDocument.Parse(
+                   File.ReadAllText(created.RegistrationMarkerPath)))
+        {
+            Assert.Equal(
+                1,
+                marker.RootElement.GetProperty("schemaVersion").GetInt32());
+            Assert.Equal(
+                _projectId,
+                marker.RootElement.GetProperty("projectId").GetGuid());
+        }
+
+        var existing = adapter.Register(
+            intent,
+            adapter.Approve(intent, now.AddMinutes(1)),
+            now.AddMinutes(1));
+
+        Assert.True(existing.AlreadyRegistered);
+        Assert.Equal(created.ExchangeRoot, existing.ExchangeRoot);
+    }
+
+    [Fact]
+    public void Register_RefusesToAdoptUnregisteredContent()
+    {
+        CreateMetadataStore();
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var now = DateTimeOffset.UtcNow;
+        var intent = adapter.PrepareIntent(_root, _projectId);
+        Directory.CreateDirectory(intent.ExchangeRoot);
+        File.WriteAllText(Path.Combine(intent.ExchangeRoot, "unexpected.txt"), "content");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => adapter.Register(
+                intent,
+                adapter.Approve(intent, now),
+                now));
+
+        Assert.Contains(
+            "unregistered content",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PrepareIntent_RejectsMetadataOutsideTheCanonicalLayout()
+    {
+        var metadataDirectory = Path.Combine(_root, "meta");
+        Directory.CreateDirectory(metadataDirectory);
+        File.WriteAllBytes(
+            Path.Combine(
+                metadataDirectory,
+                FileSystemVaultSyncStatusReader.MetadataFileName),
+            []);
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => adapter.PrepareIntent(_root, _projectId));
+
+        Assert.Contains(
+            "<destination>/.vaultsync/meta",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Register_RejectsOversizedExistingMarker()
+    {
+        CreateMetadataStore();
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var now = DateTimeOffset.UtcNow;
+        var intent = adapter.PrepareIntent(_root, _projectId);
+        Directory.CreateDirectory(intent.ExchangeRoot);
+        var markerPath = Path.Combine(
+            intent.ExchangeRoot,
+            FileSystemVaultSyncExchangeRootAdapter.RegistrationMarkerFileName);
+        using (var stream = File.Create(markerPath))
+        {
+            stream.SetLength(
+                FileSystemVaultSyncExchangeRootAdapter.MaximumRegistrationMarkerBytes + 1);
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => adapter.Register(
+                intent,
+                adapter.Approve(intent, now),
+                now));
+
+        Assert.Contains("read limit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private void CreateMetadataStore()
+    {
+        var metadataDirectory = Path.Combine(_root, ".vaultsync", "meta");
+        Directory.CreateDirectory(metadataDirectory);
+        File.WriteAllBytes(
+            Path.Combine(
+                metadataDirectory,
+                FileSystemVaultSyncStatusReader.MetadataFileName),
+            []);
+    }
+}

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -169,6 +169,44 @@ public sealed class IntegrationStatusServiceTests
     }
 
     [Fact]
+    public void GetIntegrationStatuses_WarnsWhenRegisteredExchangeRootDisappears()
+    {
+        var missingRoot = Path.Combine(
+            Path.GetTempPath(),
+            "Blueprints.Tests",
+            Guid.NewGuid().ToString("N"));
+        var settings = new IntegrationSettings(string.Empty, "/backup")
+        {
+            RegisteredVaultSyncExchangeRoot = missingRoot,
+        };
+        var vaultStatus = new VaultSyncStatusSummary(
+            true,
+            "/backup/.vaultsync/meta/vaultsync.meta.db",
+            "/backup/.vaultsync/meta/blueprints.status.json",
+            DateTimeOffset.Parse("2026-07-30T20:00:00Z"),
+            "project-42",
+            "Blueprints",
+            "NAS",
+            true,
+            DateTimeOffset.Parse("2026-07-30T20:00:00Z"),
+            DateTimeOffset.Parse("2026-07-30T21:00:00Z"),
+            DateTimeOffset.Parse("2026-07-30T22:00:00Z"),
+            true,
+            "Ready",
+            0,
+            [],
+            "Restore readiness: Ready.");
+        var service = CreateService(settings, vaultStatus: vaultStatus);
+
+        var vaultSync = service.GetIntegrationStatuses()
+            .Single(status => status.Provider == IntegrationProviderType.VaultSync);
+
+        Assert.Equal(IntegrationConnectionState.Warning, vaultSync.State);
+        Assert.Contains("unavailable", vaultSync.Guidance, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(missingRoot, vaultSync.Guidance, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GetIntegrationStatuses_DetectsConfiguredCleanLocalGitRepository()
     {
         var service = CreateService(

--- a/Blueprints.Tests/MainWindowWorkflowTests.cs
+++ b/Blueprints.Tests/MainWindowWorkflowTests.cs
@@ -1,3 +1,4 @@
+using Blueprints.App.Models;
 using Blueprints.App.Services;
 using Blueprints.App.ViewModels;
 using Blueprints.Collaboration.Services;
@@ -61,6 +62,65 @@ public sealed class MainWindowWorkflowTests : IDisposable
         Assert.Contains("Exported changelog", viewModel.WorkspaceMessage, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Commands_RegisterVaultSyncExchangeRootOnlyAfterSecondExplicitAction()
+    {
+        var destinationRoot = Path.Combine(_rootDirectory, "vaultsync-destination");
+        var metadataDirectory = Path.Combine(destinationRoot, ".vaultsync", "meta");
+        Directory.CreateDirectory(metadataDirectory);
+        File.WriteAllBytes(
+            Path.Combine(
+                metadataDirectory,
+                FileSystemVaultSyncStatusReader.MetadataFileName),
+            []);
+        var settingsStore = new FileSystemIntegrationSettingsStore(
+            Path.Combine(_rootDirectory, "integrations.json"));
+        var integrationService = new IntegrationStatusService(
+            settingsStore,
+            new TestLocalGitRepositoryInspector());
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var viewModel = new MainWindowViewModel(
+            CreateCoordinator(),
+            integrationService,
+            vaultSyncExchangeRootAdapter: adapter);
+        viewModel.IdentitySetupName = "Exchange Admin";
+        viewModel.CreateLocalIdentityCommand.Execute(null);
+        viewModel.CreateProjectName = "Blueprints";
+        viewModel.CreateProjectCode = "BP";
+        viewModel.CreateLocalWorkspaceRoot = Path.Combine(_rootDirectory, "local", "BP");
+        viewModel.CreateSharedWorkspaceRoot = Path.Combine(_rootDirectory, "shared", "BP");
+        viewModel.CreateProjectCommand.Execute(null);
+        viewModel.VaultSyncMetadataRoot = destinationRoot;
+        viewModel.SaveVaultSyncMetadataRootCommand.Execute(null);
+        var expectedRoot = adapter.PrepareIntent(
+            destinationRoot,
+            viewModel.CurrentProject.ProjectId).ExchangeRoot;
+
+        Assert.True(viewModel.CanRegisterVaultSyncExchangeRoot);
+        viewModel.RegisterVaultSyncExchangeRootCommand.Execute(null);
+
+        Assert.False(Directory.Exists(expectedRoot));
+        Assert.Contains("again", viewModel.IntegrationMessage, StringComparison.OrdinalIgnoreCase);
+
+        viewModel.RegisterVaultSyncExchangeRootCommand.Execute(null);
+
+        Assert.True(Directory.Exists(expectedRoot));
+        Assert.True(
+            File.Exists(
+                Path.Combine(
+                    expectedRoot,
+                    FileSystemVaultSyncExchangeRootAdapter.RegistrationMarkerFileName)));
+        Assert.Equal(
+            expectedRoot,
+            settingsStore.Load().RegisteredVaultSyncExchangeRoot);
+        Assert.NotEqual(expectedRoot, viewModel.SharedSyncPath);
+
+        viewModel.VaultSyncMetadataRoot = string.Empty;
+        viewModel.SaveVaultSyncMetadataRootCommand.Execute(null);
+
+        Assert.Empty(settingsStore.Load().RegisteredVaultSyncExchangeRoot);
+    }
+
     private ProjectWorkspaceCoordinatorService CreateCoordinator()
     {
         var identityRoot = Path.Combine(_rootDirectory, "identities");
@@ -113,5 +173,19 @@ public sealed class MainWindowWorkflowTests : IDisposable
 
         public byte[] Unprotect(ReadOnlySpan<byte> protectedBytes) =>
             protectedBytes.ToArray();
+    }
+
+    private sealed class TestLocalGitRepositoryInspector : ILocalGitRepositoryInspector
+    {
+        public LocalGitRepositoryStatus Inspect(string repositoryPath) =>
+            new(
+                false,
+                repositoryPath,
+                string.Empty,
+                string.Empty,
+                false,
+                string.Empty,
+                [],
+                "Not configured.");
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,20 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Passive VaultSync health awareness with a machine-local metadata-root setting, bounded path detection, and clear healthy, warning, unavailable, and invalid states in the Integrations workspace.
 - A versioned `blueprints.status.json` interoperability contract for destination reachability, snapshot, backup, verification, restore-readiness, index-consistency, and metadata-conflict evidence.
 - An injectable VaultSync status-reader boundary and filesystem tests covering supported root forms, absent sidecars, malformed schemas, and oversized input.
+- Explicit two-step registration for project-specific VaultSync exchange roots, backed by a fresh exact-target approval, an atomic bounded marker, canonical path containment, and refusal to adopt unexpected content.
 
 ### Changed
 
 - Alpha 5 development builds identify themselves as `0.5.0-alpha.5-dev`.
 - The VaultSync exchange-root contract now reserves `<destination>/.blueprints/projects/<project-id>/` for an explicitly enabled future adapter while keeping the VaultSync project payload separate.
 - Machine-local integration settings now recover safely from malformed or oversized JSON and use atomic replacement on save.
+- Registered VaultSync exchange roots remain separate from the active shared root until the project is deliberately reopened against the prepared location.
+- Changing or clearing the linked VaultSync metadata root also clears any stale registered exchange-root reference.
 
 ### Security
 
 - Blueprints never parses the VaultSync SQLite database, caps passive health documents at 1 MiB and 32 warnings, and keeps configured paths and all health evidence outside signed project truth.
+- VaultSync exchange registration approvals expire within ten minutes and are single-use; registration rejects mismatched projects, non-canonical layouts, internal directory links, oversized markers, and pre-existing unregistered content.
 
 ## 0.4.0 — 2026-07-30
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -90,7 +90,7 @@ Goal: let VaultSync improve transport and recovery while each product keeps a cl
 
 - [x] Finalize the exchange-root contract.
 - [x] Detect a VaultSync-managed location and report backup health.
-- [ ] Register Blueprints exchange roots through an explicit opt-in adapter.
+- [x] Register Blueprints exchange roots through an explicit opt-in adapter.
 - [ ] Add a release safety gate based on verified backup state.
 - [ ] Test restore of both local and exchange workspaces.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,8 @@ The hosted-provider operation policy allows discovery reads without a write appr
 
 The reader boundary is injectable so a future stable VaultSync CLI/API adapter can replace the file contract without changing integration presentation or Blueprints trust semantics.
 
+Exchange registration is a separate write adapter. It derives the canonical `<destination>/.blueprints/projects/<project-id>/` path from detected metadata, requires a fresh exact-target single-use approval, refuses ambiguous existing content, and writes one atomic registration marker. The adapter does not mutate the current session or its configured shared root.
+
 ### Push
 
 1. Build local and shared snapshots.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -64,6 +64,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Hosted-provider reads are allowed directly. Any future write must have a fresh, exact-target, single-use approval with a maximum ten-minute lifetime; credentials alone never authorize a write.
 - VaultSync passive awareness resolves only documented paths, does not parse the metadata SQLite database, and limits the optional health sidecar to 1 MiB, schema depth 16, and 32 distinct warnings.
 - VaultSync paths and health evidence are machine-local integration state. They do not enter signed workspaces, manifests, audit history, or release semantics.
+- VaultSync exchange registration requires a fresh exact-project and exact-destination approval with a maximum ten-minute lifetime. Approval is single-use; registration enforces the canonical contained path, rejects internal directory links and unexpected content, and atomically creates only a bounded marker.
 
 ## Important limitations
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -107,7 +107,9 @@ Open **Source Lens**, then enter a VaultSync destination, `.vaultsync` directory
 
 Blueprints confirms the portable metadata store exists without reading its SQLite schema. If VaultSync also supplies `.vaultsync/meta/blueprints.status.json`, the connection card reports destination reachability, latest snapshot, backup and verification times, restore readiness, backup-index consistency, and metadata conflicts. A missing health document is shown honestly as “metadata detected; detailed backup health unavailable.”
 
-This integration is passive and machine-local. Blueprints does not register projects, start a backup, verify payloads, or make VaultSync evidence authoritative. See [VaultSync integration](vaultsync-integration.md) for the exact contract and limits.
+This integration is passive and machine-local. Blueprints does not register or modify VaultSync projects, start a backup, verify payloads, or make VaultSync evidence authoritative. See [VaultSync integration](vaultsync-integration.md) for the exact contract and limits.
+
+To prepare the current trusted project for VaultSync transport, select **Register exchange** twice. The first selection previews the exact project-specific path; the second consumes a short-lived approval and creates the directory plus registration marker. Registration does not redirect the currently open project. Reopen it with the reported path as the shared root only when you intend to start using that exchange location.
 
 ## Exchange changes
 

--- a/docs/vaultsync-integration.md
+++ b/docs/vaultsync-integration.md
@@ -53,7 +53,7 @@ Timestamps and readiness values are evidence reported by the producer. Passive a
 
 ## Exchange-root contract
 
-When explicit registration is implemented, a Blueprints exchange root managed beneath a VaultSync destination will use:
+An explicitly registered Blueprints exchange root managed beneath a VaultSync destination uses:
 
 ```text
 <destination>/.blueprints/projects/<project-id>/
@@ -63,10 +63,13 @@ When explicit registration is implemented, a Blueprints exchange root managed be
 
 The ownership boundary is:
 
-- Blueprints creates and validates content only under its project-specific directory after explicit opt-in.
+- Blueprints creates and validates content only under its project-specific directory after the user selects **Register exchange** twice.
 - VaultSync owns transport, destination reachability, backup, verification, and restore operations for the parent destination.
 - Blueprints never mixes exchange state into the backed-up project payload.
 - VaultSync metadata cannot make unsigned or invalid Blueprints documents trusted.
-- Registration and any future VaultSync command remain explicit and reversible; passive health detection never writes.
+- Registration requires a fresh exact-project, exact-destination approval that expires within ten minutes and is consumed once.
+- Registration writes only an atomic, bounded `.blueprints-exchange.json` marker. It refuses non-canonical metadata layouts, linked internal directories, and existing unregistered content.
+- Registration does not switch the open project's shared root. Reopen the project with the prepared root when ready, so a confirmation can never silently redirect collaboration.
+- Future VaultSync commands remain explicit and reversible; passive health detection never writes.
 
-The registration adapter, release safety gate, and end-to-end restore exercise remain v0.5 work.
+The release safety gate and end-to-end restore exercise remain v0.5 work.

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -43,6 +43,8 @@ This document describes the current schema-1 layout. The format is pre-release a
 
 The collaboration layer also writes a signed manifest in the shared project root. Files under `.blueprints/` and `sync/` are local bookkeeping and are not signed project truth or exchange input.
 
+A VaultSync-prepared shared root also contains `.blueprints-exchange.json` at its top level. This bounded machine-local registration marker identifies the intended Blueprints project but is not signed project truth and is excluded from exchange snapshots. Project documents and the signed manifest retain exactly the same format as any other shared root.
+
 `trusted-project-keys.json` is the machine-local trust-anchor set established when a project is created or a signed project invitation is accepted. It lets documents and audit entries signed by different project members validate without placing trust in the shared folder itself. A verified membership revision may extend this set, but unverified shared membership data cannot.
 
 Before applying a whole-document conflict choice, Blueprints creates a conflict recovery directory. Its metadata records the selected path, choice, presence of each source file, and whether the operation was prepared, applied, or failed. Recovery data stays local and is excluded from exchange manifests.


### PR DESCRIPTION
## Summary
- add an explicit two-step adapter for project-specific VaultSync exchange-root registration
- derive the canonical destination-owned path from detected VaultSync metadata
- persist the prepared exchange link locally and surface unavailable registered roots as health warnings
- keep the active collaboration root unchanged until the project is deliberately reopened
- complete the v0.5 exchange-registration roadmap item and document ownership, format, and recovery boundaries

## Safety boundary
- fresh exact-project/exact-destination approvals expire within ten minutes and are consumed once
- registration rejects non-canonical layouts, linked internal directories, oversized or mismatched markers, and unregistered existing content
- the registration marker is bounded and written atomically
- no signed project data, VaultSync project metadata, backup payload, or current session path is mutated

## Verification
- `./scripts/verify.sh` (Release build, 150 tests)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (none found)