### PR TITLE
Add VaultSync release safety diagnostics

### DIFF
--- a/Blueprints.App/Models/IntegrationStatusCard.cs
+++ b/Blueprints.App/Models/IntegrationStatusCard.cs
@@ -11,6 +11,8 @@ public sealed record IntegrationStatusCard(
     DateTimeOffset CheckedAtUtc,
     IReadOnlyList<SourceChangeSummary> RecentChanges)
 {
+    public VaultSyncStatusSummary? VaultSyncStatus { get; init; }
+
     public string CheckedAtSummary => $"Checked {CheckedAtUtc:yyyy-MM-dd HH:mm} UTC";
 
     public string RecentChangeSummary =>

--- a/Blueprints.App/Services/IntegrationStatusService.cs
+++ b/Blueprints.App/Services/IntegrationStatusService.cs
@@ -167,7 +167,10 @@ public sealed class IntegrationStatusService
             guidance,
             BlueprintsTrustBoundary(),
             checkedAtUtc,
-            []);
+            [])
+        {
+            VaultSyncStatus = status,
+        };
     }
 
     private IReadOnlyList<IntegrationStatusCard> GetLocalGitStatuses(

--- a/Blueprints.App/Services/ReleaseReadinessDiagnosticBuilder.cs
+++ b/Blueprints.App/Services/ReleaseReadinessDiagnosticBuilder.cs
@@ -4,10 +4,15 @@ namespace Blueprints.App.Services;
 
 public static class ReleaseReadinessDiagnosticBuilder
 {
+    public static readonly TimeSpan MaximumVaultSyncEvidenceAge = TimeSpan.FromDays(7);
+    public static readonly TimeSpan MaximumFutureClockSkew = TimeSpan.FromMinutes(5);
+
     public static IReadOnlyList<ReleaseReadinessDiagnostic> Build(
         WorkspaceVersionCard? version,
         IntegrationStatusCard? localGit,
-        IReadOnlyList<VersionSourceChangeDiagnostic> sourceChanges)
+        IReadOnlyList<VersionSourceChangeDiagnostic> sourceChanges,
+        IntegrationStatusCard? vaultSync = null,
+        DateTimeOffset? nowUtc = null)
     {
         ArgumentNullException.ThrowIfNull(sourceChanges);
         var diagnostics = new List<ReleaseReadinessDiagnostic>();
@@ -24,6 +29,13 @@ public static class ReleaseReadinessDiagnosticBuilder
         }
 
         AddRepositoryDiagnostic(diagnostics, localGit);
+        if (vaultSync is not null)
+        {
+            AddVaultSyncDiagnostic(
+                diagnostics,
+                vaultSync,
+                nowUtc ?? DateTimeOffset.UtcNow);
+        }
 
         var incompleteItemCount = version.Items.Count(static item => !item.IsDone);
         if (incompleteItemCount > 0)
@@ -52,6 +64,96 @@ public static class ReleaseReadinessDiagnosticBuilder
         }
 
         return diagnostics;
+    }
+
+    private static void AddVaultSyncDiagnostic(
+        ICollection<ReleaseReadinessDiagnostic> diagnostics,
+        IntegrationStatusCard vaultSync,
+        DateTimeOffset nowUtc)
+    {
+        if (vaultSync.Provider != IntegrationProviderType.VaultSync)
+        {
+            throw new ArgumentException(
+                "VaultSync release readiness requires the VaultSync integration card.",
+                nameof(vaultSync));
+        }
+
+        if (vaultSync.State == IntegrationConnectionState.NotConfigured)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Backup health is not configured",
+                    "No VaultSync recovery evidence is available for this release.",
+                    "Link VaultSync health if backup verification should be part of release review. Core release planning remains available."));
+            return;
+        }
+
+        if (vaultSync.State is IntegrationConnectionState.Warning or IntegrationConnectionState.Error ||
+            vaultSync.VaultSyncStatus is not { } status)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Backup health needs review",
+                    vaultSync.Summary,
+                    vaultSync.Guidance));
+            return;
+        }
+
+        var evidenceTimes = new[]
+        {
+            ("snapshot", status.LatestSnapshotUtc),
+            ("backup", status.LatestBackupUtc),
+            ("verification", status.LatestVerificationUtc),
+        };
+        if (evidenceTimes.Any(static evidence => evidence.Item2 is null))
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Backup evidence is incomplete",
+                    "VaultSync did not report every required snapshot, backup, and verification timestamp.",
+                    "Refresh VaultSync health before relying on recovery readiness."));
+            return;
+        }
+
+        var futureEvidence = evidenceTimes
+            .FirstOrDefault(evidence =>
+                evidence.Item2 is DateTimeOffset timestamp &&
+                timestamp > nowUtc.Add(MaximumFutureClockSkew));
+        if (futureEvidence.Item2 is DateTimeOffset futureTimestamp)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Backup evidence is future-dated",
+                    $"The latest {futureEvidence.Item1} timestamp is {futureTimestamp:yyyy-MM-dd HH:mm} UTC, beyond the allowed clock skew.",
+                    "Check the producing machine clock and refresh VaultSync health before relying on this evidence."));
+            return;
+        }
+
+        var staleEvidence = evidenceTimes
+            .FirstOrDefault(evidence =>
+                evidence.Item2 is DateTimeOffset timestamp &&
+                nowUtc - timestamp > MaximumVaultSyncEvidenceAge);
+        if (staleEvidence.Item2 is DateTimeOffset staleTimestamp)
+        {
+            diagnostics.Add(
+                new ReleaseReadinessDiagnostic(
+                    ReleaseReadinessLevel.Attention,
+                    "Backup evidence is stale",
+                    $"The latest {staleEvidence.Item1} evidence is from {staleTimestamp:yyyy-MM-dd HH:mm} UTC.",
+                    $"Refresh snapshot, backup, and verification evidence within {MaximumVaultSyncEvidenceAge.TotalDays:0} days before relying on recovery readiness."));
+            return;
+        }
+
+        diagnostics.Add(
+            new ReleaseReadinessDiagnostic(
+                ReleaseReadinessLevel.Ready,
+                "VaultSync recovery evidence is ready",
+                status.Summary,
+                "The producer reports a reachable destination, consistent index, and recent snapshot, backup, and verification. This is advisory evidence, not a replacement for Blueprints signatures."));
     }
 
     private static void AddRepositoryDiagnostic(

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -1116,10 +1116,10 @@ public partial class MainWindowViewModel : ViewModelBase
             var attention = ReleaseReadinessDiagnostics.Count(
                 static diagnostic => diagnostic.Level == ReleaseReadinessLevel.Attention);
             return blocking > 0
-                ? $"{blocking} blocking source-control checks · {attention} need attention"
+                ? $"{blocking} blocking release checks · {attention} need attention"
                 : attention > 0
-                    ? $"No source-control blockers · {attention} checks need attention"
-                    : "Source-control checks are ready for human release review";
+                    ? $"No blocking release checks · {attention} checks need attention"
+                    : "Release checks are ready for human review";
         }
     }
 
@@ -2786,10 +2786,14 @@ public partial class MainWindowViewModel : ViewModelBase
 
         ReleaseReadinessDiagnostics.Clear();
         var localGit = GetLocalGitReadinessStatus();
+        var vaultSync = Integrations.FirstOrDefault(
+            static integration => integration.Provider == IntegrationProviderType.VaultSync);
         foreach (var diagnostic in ReleaseReadinessDiagnosticBuilder.Build(
                      SelectedVersion,
                      localGit,
-                     VersionSourceChangeDiagnostics))
+                     VersionSourceChangeDiagnostics,
+                     vaultSync,
+                     DateTimeOffset.UtcNow))
         {
             ReleaseReadinessDiagnostics.Add(diagnostic);
         }

--- a/Blueprints.Tests/IntegrationStatusServiceTests.cs
+++ b/Blueprints.Tests/IntegrationStatusServiceTests.cs
@@ -133,6 +133,7 @@ public sealed class IntegrationStatusServiceTests
             .Single(status => status.Provider == IntegrationProviderType.VaultSync);
 
         Assert.Equal(IntegrationConnectionState.Connected, vaultSync.State);
+        Assert.Equal(vaultStatus, vaultSync.VaultSyncStatus);
         Assert.Contains("NAS", vaultSync.Target, StringComparison.Ordinal);
         Assert.Contains("read-only", vaultSync.Guidance, StringComparison.OrdinalIgnoreCase);
     }

--- a/Blueprints.Tests/ReleaseReadinessDiagnosticBuilderTests.cs
+++ b/Blueprints.Tests/ReleaseReadinessDiagnosticBuilderTests.cs
@@ -68,6 +68,104 @@ public sealed class ReleaseReadinessDiagnosticBuilderTests
         Assert.Equal(ReleaseReadinessLevel.Ready, ready.Level);
     }
 
+    [Fact]
+    public void Build_AddsAdvisoryWhenVaultSyncIsNotConfigured()
+    {
+        var version = CreateVersion();
+
+        var diagnostics = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, []),
+            [],
+            CreateVaultSync(IntegrationConnectionState.NotConfigured));
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Level == ReleaseReadinessLevel.Attention &&
+                diagnostic.Title.Contains("not configured", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic => diagnostic.Level == ReleaseReadinessLevel.Blocking);
+    }
+
+    [Fact]
+    public void Build_ReportsRecentVerifiedVaultSyncEvidenceAsReady()
+    {
+        var now = DateTimeOffset.Parse("2026-07-31T00:00:00Z");
+        var version = CreateVersion();
+        var status = CreateVaultSync(
+            IntegrationConnectionState.Connected,
+            CreateVaultSyncSummary(now.AddHours(-2)));
+
+        var diagnostics = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, []),
+            [],
+            status,
+            now);
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Level == ReleaseReadinessLevel.Ready &&
+                diagnostic.Title.Contains("VaultSync", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_WarnsForStaleOrFutureDatedVaultSyncEvidence()
+    {
+        var now = DateTimeOffset.Parse("2026-07-31T00:00:00Z");
+        var version = CreateVersion();
+
+        var stale = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, []),
+            [],
+            CreateVaultSync(
+                IntegrationConnectionState.Connected,
+                CreateVaultSyncSummary(
+                    now - ReleaseReadinessDiagnosticBuilder.MaximumVaultSyncEvidenceAge - TimeSpan.FromMinutes(1))),
+            now);
+        var future = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, []),
+            [],
+            CreateVaultSync(
+                IntegrationConnectionState.Connected,
+                CreateVaultSyncSummary(
+                    now + ReleaseReadinessDiagnosticBuilder.MaximumFutureClockSkew + TimeSpan.FromMinutes(1))),
+            now);
+
+        Assert.Contains(
+            stale,
+            diagnostic => diagnostic.Title.Contains("stale", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            future,
+            diagnostic => diagnostic.Title.Contains("future", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_KeepsRiskyVaultSyncHealthAdvisoryByDefault()
+    {
+        var version = CreateVersion();
+
+        var diagnostics = ReleaseReadinessDiagnosticBuilder.Build(
+            version,
+            CreateLocalGit(IntegrationConnectionState.Connected, []),
+            [],
+            CreateVaultSync(IntegrationConnectionState.Warning));
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Level == ReleaseReadinessLevel.Attention &&
+                diagnostic.Title.Contains("needs review", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic => diagnostic.Level == ReleaseReadinessLevel.Blocking);
+    }
+
     private static WorkspaceVersionCard CreateVersion(params WorkspaceItemCard[] items) =>
         new(
             Guid.NewGuid(),
@@ -93,4 +191,41 @@ public sealed class ReleaseReadinessDiagnosticBuilderTests
             "Blueprints remains authoritative.",
             DateTimeOffset.UtcNow,
             changes);
+
+    private static IntegrationStatusCard CreateVaultSync(
+        IntegrationConnectionState state,
+        VaultSyncStatusSummary? status = null) =>
+        new(
+            IntegrationProviderType.VaultSync,
+            "VaultSync",
+            state,
+            "/backup/.vaultsync/meta/vaultsync.meta.db",
+            status?.Summary ?? "VaultSync health is unavailable.",
+            "Review VaultSync backup health.",
+            "Blueprints remains authoritative.",
+            DateTimeOffset.UtcNow,
+            [])
+        {
+            VaultSyncStatus = status,
+        };
+
+    private static VaultSyncStatusSummary CreateVaultSyncSummary(
+        DateTimeOffset evidenceUtc) =>
+        new(
+            true,
+            "/backup/.vaultsync/meta/vaultsync.meta.db",
+            "/backup/.vaultsync/meta/blueprints.status.json",
+            evidenceUtc,
+            "project-42",
+            "Blueprints",
+            "NAS",
+            true,
+            evidenceUtc,
+            evidenceUtc,
+            evidenceUtc,
+            true,
+            "Ready",
+            0,
+            [],
+            $"Restore readiness: Ready. Verified {evidenceUtc:O}.");
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - A versioned `blueprints.status.json` interoperability contract for destination reachability, snapshot, backup, verification, restore-readiness, index-consistency, and metadata-conflict evidence.
 - An injectable VaultSync status-reader boundary and filesystem tests covering supported root forms, absent sidecars, malformed schemas, and oversized input.
 - Explicit two-step registration for project-specific VaultSync exchange roots, backed by a fresh exact-target approval, an atomic bounded marker, canonical path containment, and refusal to adopt unexpected content.
+- Advisory release-readiness diagnostics for missing, risky, incomplete, stale, future-dated, or recent healthy VaultSync recovery evidence.
 
 ### Changed
 
@@ -18,6 +19,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - Machine-local integration settings now recover safely from malformed or oversized JSON and use atomic replacement on save.
 - Registered VaultSync exchange roots remain separate from the active shared root until the project is deliberately reopened against the prepared location.
 - Changing or clearing the linked VaultSync metadata root also clears any stale registered exchange-root reference.
+- VaultSync release evidence is considered recent within seven days and allows five minutes of producer clock skew; it informs release review without silently blocking the release action.
 
 ### Security
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -91,7 +91,7 @@ Goal: let VaultSync improve transport and recovery while each product keeps a cl
 - [x] Finalize the exchange-root contract.
 - [x] Detect a VaultSync-managed location and report backup health.
 - [x] Register Blueprints exchange roots through an explicit opt-in adapter.
-- [ ] Add a release safety gate based on verified backup state.
+- [x] Add a release safety gate based on verified backup state.
 - [ ] Test restore of both local and exchange workspaces.
 
 Exit criteria:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,8 @@ The reader boundary is injectable so a future stable VaultSync CLI/API adapter c
 
 Exchange registration is a separate write adapter. It derives the canonical `<destination>/.blueprints/projects/<project-id>/` path from detected metadata, requires a fresh exact-target single-use approval, refuses ambiguous existing content, and writes one atomic registration marker. The adapter does not mutate the current session or its configured shared root.
 
+The release-readiness builder consumes the structured passive-health result rather than parsing display text. It reports absent, risky, incomplete, stale, future-dated, and recent healthy evidence. The default policy is advisory: seven-day freshness and five-minute future clock skew inform the human decision but do not disable release.
+
 ### Push
 
 1. Build local and shared snapshots.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -65,6 +65,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - VaultSync passive awareness resolves only documented paths, does not parse the metadata SQLite database, and limits the optional health sidecar to 1 MiB, schema depth 16, and 32 distinct warnings.
 - VaultSync paths and health evidence are machine-local integration state. They do not enter signed workspaces, manifests, audit history, or release semantics.
 - VaultSync exchange registration requires a fresh exact-project and exact-destination approval with a maximum ten-minute lifetime. Approval is single-use; registration enforces the canonical contained path, rejects internal directory links and unexpected content, and atomically creates only a bounded marker.
+- VaultSync release readiness treats missing, stale, future-dated, and producer-reported risk as advisory attention. It does not infer that payloads were verified, elevate project trust, or silently block a release.
 
 ## Important limitations
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,8 +78,11 @@ Before freezing or releasing, review **Release readiness** in the release planne
 - incomplete items in the selected version;
 - missing post-tag history;
 - recent commits that do not reference a completed item key in the selected version.
+- missing, risky, incomplete, stale, future-dated, or recent healthy VaultSync recovery evidence.
 
 Repository errors and dirty state are blockers. Unmatched commits and incomplete items require attention because they may be intentionally out of scope; Blueprints explains them but does not silently change source history or the release plan.
+
+VaultSync recovery evidence is advisory by default. Snapshot, backup, and verification reports are considered recent for seven days, with five minutes allowed for producer clock skew. Blueprints does not disable release merely because VaultSync is absent or needs attention.
 
 ## Archive draft work
 

--- a/docs/vaultsync-integration.md
+++ b/docs/vaultsync-integration.md
@@ -51,6 +51,17 @@ Connection states:
 
 Timestamps and readiness values are evidence reported by the producer. Passive awareness does not independently inspect backup payloads or claim verification.
 
+## Release safety
+
+The release planner treats VaultSync health as an advisory safety gate:
+
+- no configured health link, unavailable metadata, reported risk, and incomplete evidence need attention;
+- snapshot, backup, and verification timestamps older than seven days are stale;
+- timestamps more than five minutes in the future require a producer clock check;
+- reachable, consistent, Ready/Healthy evidence with all three recent timestamps is shown as ready.
+
+These diagnostics do not silently disable the release action. Teams can still make an explicit release decision when VaultSync is absent or when older evidence is intentional. Blueprints reports what the producer claimed and never substitutes that claim for signed workspace validation or a real restore exercise.
+
 ## Exchange-root contract
 
 An explicitly registered Blueprints exchange root managed beneath a VaultSync destination uses:
@@ -72,4 +83,4 @@ The ownership boundary is:
 - Registration does not switch the open project's shared root. Reopen the project with the prepared root when ready, so a confirmation can never silently redirect collaboration.
 - Future VaultSync commands remain explicit and reversible; passive health detection never writes.
 
-The release safety gate and end-to-end restore exercise remain v0.5 work.
+The end-to-end restore exercise remains v0.5 work.


### PR DESCRIPTION
## Summary
- carry structured VaultSync health evidence into release readiness
- classify missing, risky, incomplete, stale, future-dated, and recent healthy recovery evidence
- use a documented seven-day freshness window and five-minute future clock-skew allowance
- keep VaultSync readiness advisory so core release planning remains independent
- complete the v0.5 release-safety roadmap item and update user, architecture, and security guidance

## Safety boundary
- diagnostics consume the bounded structured health result, never display text or SQLite
- producer claims do not elevate Blueprints trust or prove backup payload integrity
- VaultSync absence or risk never silently disables the explicit release action

## Verification
- `./scripts/verify.sh` (Release build, 154 tests)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (none found)