### PR TITLE
Add VaultSync restore recovery drill

### DIFF
--- a/Blueprints.Tests/VaultSyncRestoreDrillTests.cs
+++ b/Blueprints.Tests/VaultSyncRestoreDrillTests.cs
@@ -1,0 +1,220 @@
+using Blueprints.App.Services;
+using Blueprints.Collaboration.Services;
+using Blueprints.Core.Enums;
+using Blueprints.Security.Models;
+using Blueprints.Security.Services;
+using Blueprints.Storage.Models;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class VaultSyncRestoreDrillTests : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "VaultSyncRestoreDrill",
+        Guid.NewGuid().ToString("N"));
+    private readonly SignatureKeyMaterial _signingKey;
+    private readonly SignaturePublicKey _publicKey;
+    private readonly FileSystemProjectWorkspaceStore _workspaceStore;
+    private readonly FileSystemAuditLogService _auditLog;
+    private readonly FileSystemWorkspaceSyncService _syncService;
+
+    public VaultSyncRestoreDrillTests()
+    {
+        var keyPair = new Ed25519KeyPairGenerator().Generate("restore-admin");
+        _signingKey = new SignatureKeyMaterial(
+            keyPair.KeyId,
+            keyPair.PrivateKeyBytes);
+        _publicKey = new SignaturePublicKey(
+            keyPair.KeyId,
+            keyPair.PublicKeyBytes);
+        var signedStore = new FileSystemSignedDocumentStore(
+            new CanonicalJsonSerializer(),
+            new Ed25519SignatureService());
+        _workspaceStore = new FileSystemProjectWorkspaceStore(signedStore);
+        _auditLog = new FileSystemAuditLogService(signedStore);
+        var snapshotBuilder = new WorkspaceExchangeSnapshotBuilder();
+        _syncService = new FileSystemWorkspaceSyncService(
+            snapshotBuilder,
+            new WorkspaceSyncAnalyzer(snapshotBuilder),
+            new FileSystemSyncManifestStore(signedStore, snapshotBuilder),
+            new FileSystemSyncStateStore(),
+            new WorkspaceExchangeValidator(new Ed25519SignatureService()),
+            _auditLog);
+    }
+
+    [Fact]
+    public void LocalAndVaultSyncExchangeBackups_CanBeRelocatedAndContinued()
+    {
+        var workspace = TestWorkspaceFactory.CreateWorkspaceSnapshot();
+        var member = Assert.Single(workspace.Members.Members);
+        var localRoot = Path.Combine(_rootDirectory, "active", "local");
+        var destinationRoot = Path.Combine(_rootDirectory, "active", "destination");
+        CreateMetadataStore(destinationRoot);
+        var adapter = new FileSystemVaultSyncExchangeRootAdapter();
+        var intent = adapter.PrepareIntent(
+            destinationRoot,
+            workspace.Project.ProjectId);
+        var now = DateTimeOffset.Parse("2026-07-31T00:00:00Z");
+        var registration = adapter.Register(
+            intent,
+            adapter.Approve(intent, now),
+            now);
+
+        _workspaceStore.Save(localRoot, workspace, _signingKey);
+        _auditLog.Append(
+            localRoot,
+            workspace.Project.ProjectId,
+            "project.create",
+            "Created restore-drill project.",
+            member.UserId,
+            member.DisplayName,
+            workspace.Members.MembershipRevision,
+            _signingKey);
+        var initialPush = _syncService.Push(
+            new WorkspacePaths(localRoot, registration.ExchangeRoot),
+            workspace.Project.ProjectId,
+            _signingKey,
+            _publicKey);
+        Assert.True(initialPush.Success);
+
+        var localBackup = Path.Combine(_rootDirectory, "backup", "local");
+        var exchangeBackup = Path.Combine(_rootDirectory, "backup", "exchange");
+        CopyDirectory(localRoot, localBackup);
+        CopyDirectory(registration.ExchangeRoot, exchangeBackup);
+
+        var restoredLocalRoot = Path.Combine(_rootDirectory, "restored", "local");
+        CopyDirectory(localBackup, restoredLocalRoot);
+        var restoredLocal = _workspaceStore.Load(restoredLocalRoot, _publicKey);
+        Assert.Equal(TrustState.Trusted, restoredLocal.TrustReport.State);
+        Assert.Equal(
+            workspace.Project.ProjectId,
+            restoredLocal.Workspace.Project.ProjectId);
+
+        var restoredDestinationRoot = Path.Combine(
+            _rootDirectory,
+            "restored",
+            "destination");
+        CreateMetadataStore(restoredDestinationRoot);
+        var restoredIntent = adapter.PrepareIntent(
+            restoredDestinationRoot,
+            workspace.Project.ProjectId);
+        CopyDirectory(exchangeBackup, restoredIntent.ExchangeRoot);
+        var restoredRegistration = adapter.Register(
+            restoredIntent,
+            adapter.Approve(restoredIntent, now.AddMinutes(1)),
+            now.AddMinutes(1));
+        Assert.True(restoredRegistration.AlreadyRegistered);
+
+        var restoredPull = _syncService.Pull(
+            new WorkspacePaths(
+                restoredLocalRoot,
+                restoredRegistration.ExchangeRoot),
+            _publicKey);
+        Assert.True(restoredPull.Success);
+
+        SaveVersionNotes(
+            restoredLocalRoot,
+            "Continued after local and exchange restore.");
+        var continuedPush = _syncService.Push(
+            new WorkspacePaths(
+                restoredLocalRoot,
+                restoredRegistration.ExchangeRoot),
+            workspace.Project.ProjectId,
+            _signingKey,
+            _publicKey);
+
+        Assert.True(continuedPush.Success);
+        Assert.True(
+            File.Exists(
+                Path.Combine(
+                    restoredRegistration.ExchangeRoot,
+                    FileSystemVaultSyncExchangeRootAdapter.RegistrationMarkerFileName)));
+        var restoredExchange = _workspaceStore.Load(
+            restoredRegistration.ExchangeRoot,
+            _publicKey);
+        Assert.Equal(TrustState.Trusted, restoredExchange.TrustReport.State);
+        Assert.Equal(
+            "Continued after local and exchange restore.",
+            restoredExchange.Workspace.Versions.Single().Version.Notes);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+
+    private void SaveVersionNotes(string workspaceRoot, string notes)
+    {
+        var current = _workspaceStore.Load(workspaceRoot, _publicKey);
+        Assert.Equal(TrustState.Trusted, current.TrustReport.State);
+        var version = Assert.Single(current.Workspace.Versions);
+        var updated = current.Workspace with
+        {
+            Versions =
+            [
+                version with
+                {
+                    Version = version.Version with { Notes = notes },
+                },
+            ],
+        };
+        _workspaceStore.Save(workspaceRoot, updated, _signingKey);
+        var member = Assert.Single(updated.Members.Members);
+        _auditLog.Append(
+            workspaceRoot,
+            updated.Project.ProjectId,
+            "version.save",
+            "Continued the project after the restore drill.",
+            member.UserId,
+            member.DisplayName,
+            updated.Members.MembershipRevision,
+            _signingKey);
+    }
+
+    private static void CreateMetadataStore(string destinationRoot)
+    {
+        var metadataDirectory = Path.Combine(
+            destinationRoot,
+            ".vaultsync",
+            "meta");
+        Directory.CreateDirectory(metadataDirectory);
+        File.WriteAllBytes(
+            Path.Combine(
+                metadataDirectory,
+                FileSystemVaultSyncStatusReader.MetadataFileName),
+            []);
+    }
+
+    private static void CopyDirectory(string sourceRoot, string destinationRoot)
+    {
+        Directory.CreateDirectory(destinationRoot);
+        foreach (var directory in Directory.EnumerateDirectories(
+                     sourceRoot,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(
+                Path.Combine(
+                    destinationRoot,
+                    Path.GetRelativePath(sourceRoot, directory)));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(
+                     sourceRoot,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            var destinationPath = Path.Combine(
+                destinationRoot,
+                Path.GetRelativePath(sourceRoot, file));
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file, destinationPath);
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 - An injectable VaultSync status-reader boundary and filesystem tests covering supported root forms, absent sidecars, malformed schemas, and oversized input.
 - Explicit two-step registration for project-specific VaultSync exchange roots, backed by a fresh exact-target approval, an atomic bounded marker, canonical path containment, and refusal to adopt unexpected content.
 - Advisory release-readiness diagnostics for missing, risky, incomplete, stale, future-dated, or recent healthy VaultSync recovery evidence.
+- An end-to-end VaultSync recovery drill that independently relocates local and exchange backups, revalidates signed project trust and manifest continuity, and publishes a new signed change after restore.
 
 ### Changed
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -84,7 +84,7 @@ Exit criteria:
 - provider credentials and settings never enter signed project truth;
 - no hosted provider is required for core release planning.
 
-## In progress — v0.5: VaultSync integration
+## Completed — v0.5: VaultSync integration
 
 Goal: let VaultSync improve transport and recovery while each product keeps a clear responsibility.
 
@@ -92,7 +92,7 @@ Goal: let VaultSync improve transport and recovery while each product keeps a cl
 - [x] Detect a VaultSync-managed location and report backup health.
 - [x] Register Blueprints exchange roots through an explicit opt-in adapter.
 - [x] Add a release safety gate based on verified backup state.
-- [ ] Test restore of both local and exchange workspaces.
+- [x] Test restore of both local and exchange workspaces.
 
 Exit criteria:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,8 @@ Exchange registration is a separate write adapter. It derives the canonical `<de
 
 The release-readiness builder consumes the structured passive-health result rather than parsing display text. It reports absent, risky, incomplete, stale, future-dated, and recent healthy evidence. The default policy is advisory: seven-day freshness and five-minute future clock skew inform the human decision but do not disable release.
 
+The VaultSync recovery drill exercises the boundary without invoking VaultSync: local and registered exchange snapshots are copied independently, relocated, validated, pulled, and then used for another signed publication. This proves Blueprints path, marker, trust, manifest, and continuation behavior while leaving transport-level verification to VaultSync.
+
 ### Push
 
 1. Build local and shared snapshots.

--- a/docs/backup-recovery.md
+++ b/docs/backup-recovery.md
@@ -49,6 +49,16 @@ If the protected identity cannot be restored, follow [member key lifecycle](key-
 
 The `packs/` directories help diagnose individual publications, but they are not guaranteed to be complete project backups.
 
+### Restore a VaultSync-managed exchange
+
+1. Restore the complete project-specific directory, including `.blueprints-exchange.json`, under `<destination>/.blueprints/projects/<project-id>/`.
+2. Confirm the destination still exposes `.vaultsync/meta/vaultsync.meta.db`.
+3. Link the restored VaultSync destination in Source Lens and select **Register exchange** twice. A valid matching marker is accepted idempotently; a mismatched or malformed marker is rejected.
+4. Reopen the restored local project with the restored project-specific path as its shared root.
+5. Refresh and confirm project trust, audit continuity, the shared manifest version, and VaultSync health before pulling or pushing.
+
+The automated recovery drill relocates both backups independently, opens the local copy as trusted, accepts only the matching registered exchange, pulls the restored manifest, and successfully pushes a later signed change. This verifies the Blueprints workflow and file contracts; it does not claim that VaultSync payload verification itself ran.
+
 ## Recover from a conflict choice
 
 Before applying a conflict choice, Blueprints stores both available sides under:
@@ -72,3 +82,4 @@ Before relying on a backup policy, perform a drill on a disposable copy:
 - join a second disposable workspace through an invitation;
 - push and pull one signed change;
 - confirm a tampered copy is rejected.
+- for a VaultSync-managed exchange, relocate both backups and confirm a new signed change can be pushed after restore.

--- a/docs/vaultsync-integration.md
+++ b/docs/vaultsync-integration.md
@@ -83,4 +83,4 @@ The ownership boundary is:
 - Registration does not switch the open project's shared root. Reopen the project with the prepared root when ready, so a confirmation can never silently redirect collaboration.
 - Future VaultSync commands remain explicit and reversible; passive health detection never writes.
 
-The end-to-end restore exercise remains v0.5 work.
+The automated recovery drill backs up the local workspace and registered exchange independently, restores each to a new location, revalidates project trust and shared-manifest continuity, and publishes another signed change through the restored exchange.


### PR DESCRIPTION
## Summary
- add an end-to-end recovery drill for independently backed-up local and registered VaultSync exchange workspaces
- relocate both copies, revalidate project trust and manifest continuity, and publish another signed change after restore
- complete the final v0.5 roadmap item and document the exact recovery procedure and responsibility boundary

## Safety boundary
- the drill validates Blueprints signatures, marker identity, manifest continuity, and continuation behavior
- it does not claim or simulate VaultSync payload verification
- restored copies use new paths and never overwrite the backed-up evidence

## Verification
- `./scripts/verify.sh` (Release build, 155 tests)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (none found)