### PR TITLE
Prepare Blueprints 0.5.0 milestone release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+## 0.5.0 — 2026-07-31
+
+VaultSync recovery integration milestone. This release adds passive backup-health awareness, explicit project-specific exchange registration, advisory release-safety evidence, and a tested restore path while preserving Blueprints as the authority for signed release state.
+
 ### Added
 
 - Passive VaultSync health awareness with a machine-local metadata-root setting, bounded path detection, and clear healthy, warning, unavailable, and invalid states in the Integrations workspace.
@@ -15,7 +19,7 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ### Changed
 
-- Alpha 5 development builds identify themselves as `0.5.0-alpha.5-dev`.
+- Completed release builds identify themselves as `0.5.0`.
 - The VaultSync exchange-root contract now reserves `<destination>/.blueprints/projects/<project-id>/` for an explicitly enabled future adapter while keeping the VaultSync project payload separate.
 - Machine-local integration settings now recover safely from malformed or oversized JSON and use atomic replacement on save.
 - Registered VaultSync exchange roots remain separate from the active shared root until the project is deliberately reopened against the prepared location.
@@ -26,6 +30,20 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 - Blueprints never parses the VaultSync SQLite database, caps passive health documents at 1 MiB and 32 warnings, and keeps configured paths and all health evidence outside signed project truth.
 - VaultSync exchange registration approvals expire within ten minutes and are single-use; registration rejects mismatched projects, non-canonical layouts, internal directory links, oversized markers, and pre-existing unregistered content.
+
+### Workspace compatibility
+
+- Signed workspace schema remains version 1.
+- VaultSync paths, structured health evidence, and the registered exchange-root link are machine-local integration settings and never enter signed project documents.
+- A VaultSync-prepared shared root adds only the bounded `.blueprints-exchange.json` registration marker, which is excluded from signed exchange snapshots.
+- Projects remain fully usable without VaultSync and can continue using any supported plain shared-folder target.
+
+### Known limitations
+
+- This release contains no installers or application binaries.
+- Detailed health requires an external producer to write the documented schema-1 `blueprints.status.json` sidecar; Blueprints does not parse VaultSync SQLite or invoke a VaultSync CLI.
+- Exchange registration prepares and remembers the canonical root but deliberately requires the project to be reopened before that location becomes active.
+- Release-safety evidence is advisory and reports producer claims; Blueprints does not independently verify backup payloads or perform VaultSync restore operations.
 
 ## 0.4.0 — 2026-07-30
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>alpha.5-dev</VersionSuffix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -2,7 +2,7 @@
 
 This is the canonical product roadmap. It is organized by outcomes, not implementation layers, and should be updated when an issue changes scope or a milestone is completed.
 
-Last reviewed: 2026-07-30
+Last reviewed: 2026-07-31
 
 ## Product direction
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,7 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.5.0` | 2026-07-31 | VaultSync recovery integration | Passive bounded backup-health awareness, explicit project-specific exchange registration, advisory release-safety diagnostics, atomic local integration settings, and an end-to-end local/exchange restore drill |
 | `v0.4.0` | 2026-07-30 | Provider-neutral source-control awareness | Advanced canvas editing, signed typed relationships, multi-repository readiness analysis, provider-neutral references, direct bounded GitHub and GitLab discovery, isolated credentials, and an explicit approval boundary for future provider writes |
 | `v0.3.0` | 2026-07-30 | Understandable collaboration | Distinct signing identities, signed invitation onboarding, member-key-aware trust, staged and recoverable sync, semantic conflict comparison, manifest/audit evidence, recoverable archives, explicit identity setup, and disaster-recovery guidance |
 | `v0.2.0-alpha.2` | 2026-07-30 | Interactive workspace | Diagram-first canvas, signed shared layouts, machine-local viewport state, approval-first Source Lens, adaptive workflow navigation, .NET 10, Avalonia 12, and expanded security/user documentation |
@@ -16,7 +17,6 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 | Version | Milestone outcome |
 | --- | --- |
 | `v0.2.0` | Complete the coherent solo workflow with identity onboarding, editing history, archive/delete flows, and release polish |
-| `v0.5.0` | Explicit VaultSync transport and backup-health integration |
 | `v1.0.0` | A dependable, supported small-team release planner |
 
 ## Release record requirements


### PR DESCRIPTION
## Summary
- freeze the completed VaultSync recovery-integration milestone as Blueprints 0.5.0
- move the complete v0.5 record into the dated changelog
- record v0.5.0 in release history and close every v0.5 roadmap item
- document workspace compatibility, security boundaries, and remaining limitations

## Verification
- `./scripts/verify.sh` (Release build, 155 tests)
- `dotnet format Blueprints.sln --no-restore --verify-no-changes`
- `dotnet list Blueprints.sln package --vulnerable --include-transitive` (none found)
- resolved version: `0.5.0`