### PR TITLE
Complete Blueprints 0.6.0 foundations and desktop redesign

### DIFF
--- a/Blueprints.App/App.axaml
+++ b/Blueprints.App/App.axaml
@@ -7,14 +7,21 @@
     <local:ViewLocator />
   </Application.DataTemplates>
 
+  <!--
+    Blueprints' visual language is intentionally calm and familiar. Purple carries
+    actions, teal carries healthy state, and red is reserved for destructive work.
+    The old drafting-table metaphor remains in the canvas instead of leaking into
+    every form and navigation label.
+  -->
   <Application.Resources>
-    <Color x:Key="BlueprintInk">#102A43</Color>
-    <Color x:Key="BlueprintBlue">#0B4F8A</Color>
-    <Color x:Key="BlueprintBright">#168AD0</Color>
-    <Color x:Key="BlueprintCyan">#54C8E8</Color>
-    <Color x:Key="BlueprintPaper">#F2F8FC</Color>
-    <Color x:Key="BlueprintLine">#BED8E8</Color>
-    <Color x:Key="BlueprintMuted">#58758A</Color>
+    <Color x:Key="BlueprintInk">#191A2C</Color>
+    <Color x:Key="BlueprintBlue">#6254D9</Color>
+    <Color x:Key="BlueprintBright">#7767EA</Color>
+    <Color x:Key="BlueprintCyan">#35B5A5</Color>
+    <Color x:Key="BlueprintPaper">#F6F7FB</Color>
+    <Color x:Key="BlueprintLine">#E2E4EC</Color>
+    <Color x:Key="BlueprintMuted">#686B7B</Color>
+
     <SolidColorBrush x:Key="InkBrush" Color="{StaticResource BlueprintInk}" />
     <SolidColorBrush x:Key="BlueBrush" Color="{StaticResource BlueprintBlue}" />
     <SolidColorBrush x:Key="BrightBrush" Color="{StaticResource BlueprintBright}" />
@@ -34,56 +41,83 @@
       <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
     </Style>
     <Style Selector="TextBlock.eyebrow">
-      <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
       <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontWeight" Value="Bold" />
+      <Setter Property="FontWeight" Value="SemiBold" />
       <Setter Property="Foreground" Value="{StaticResource BrightBrush}" />
-      <Setter Property="LetterSpacing" Value="1.4" />
+      <Setter Property="LetterSpacing" Value="0.8" />
     </Style>
     <Style Selector="TextBlock.muted">
       <Setter Property="Foreground" Value="{StaticResource MutedBrush}" />
     </Style>
+    <Style Selector="TextBlock.page-title">
+      <Setter Property="FontSize" Value="30" />
+      <Setter Property="FontWeight" Value="Bold" />
+      <Setter Property="LetterSpacing" Value="-0.5" />
+    </Style>
+    <Style Selector="TextBlock.section-title">
+      <Setter Property="FontSize" Value="19" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
 
     <Style Selector="TextBox">
-      <Setter Property="CornerRadius" Value="4" />
-      <Setter Property="Padding" Value="11,9" />
-      <Setter Property="MinHeight" Value="40" />
-      <Setter Property="Background" Value="#F9FCFE" />
+      <Setter Property="CornerRadius" Value="9" />
+      <Setter Property="Padding" Value="12,9" />
+      <Setter Property="MinHeight" Value="42" />
+      <Setter Property="Background" Value="#FFFFFF" />
       <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
       <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="SelectionBrush" Value="#DCD8FA" />
+    </Style>
+    <Style Selector="TextBox:pointerover">
+      <Setter Property="BorderBrush" Value="#C8C5DC" />
     </Style>
     <Style Selector="TextBox:focus">
       <Setter Property="BorderBrush" Value="{StaticResource BrightBrush}" />
       <Setter Property="BorderThickness" Value="2" />
     </Style>
     <Style Selector="ComboBox">
-      <Setter Property="CornerRadius" Value="4" />
-      <Setter Property="MinHeight" Value="40" />
-      <Setter Property="Background" Value="#F9FCFE" />
+      <Setter Property="CornerRadius" Value="9" />
+      <Setter Property="MinHeight" Value="42" />
+      <Setter Property="Background" Value="#FFFFFF" />
       <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
     </Style>
+    <Style Selector="CheckBox">
+      <Setter Property="MinHeight" Value="32" />
+    </Style>
+
     <Style Selector="Button">
-      <Setter Property="CornerRadius" Value="4" />
-      <Setter Property="Padding" Value="14,9" />
+      <Setter Property="CornerRadius" Value="9" />
+      <Setter Property="Padding" Value="15,9" />
       <Setter Property="MinHeight" Value="40" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     <Style Selector="Button.primary">
       <Setter Property="Background" Value="{StaticResource BlueBrush}" />
       <Setter Property="Foreground" Value="White" />
+      <Setter Property="BorderBrush" Value="{StaticResource BlueBrush}" />
     </Style>
     <Style Selector="Button.primary:pointerover">
-      <Setter Property="Background" Value="#0D66A8" />
+      <Setter Property="Background" Value="#5145C7" />
+      <Setter Property="BorderBrush" Value="#5145C7" />
     </Style>
     <Style Selector="Button.secondary">
-      <Setter Property="Background" Value="#E5F2F9" />
-      <Setter Property="Foreground" Value="{StaticResource BlueprintBlue}" />
-      <Setter Property="BorderBrush" Value="{StaticResource BlueprintLine}" />
+      <Setter Property="Background" Value="#FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource BlueprintInk}" />
+      <Setter Property="BorderBrush" Value="#D9DAE4" />
       <Setter Property="BorderThickness" Value="1" />
     </Style>
+    <Style Selector="Button.secondary:pointerover">
+      <Setter Property="Background" Value="#F1F0FA" />
+      <Setter Property="BorderBrush" Value="#C6C1EC" />
+    </Style>
     <Style Selector="Button.danger">
-      <Setter Property="Background" Value="#A63D40" />
-      <Setter Property="Foreground" Value="White" />
+      <Setter Property="Background" Value="#FFF1F1" />
+      <Setter Property="Foreground" Value="#B02E36" />
+      <Setter Property="BorderBrush" Value="#F1C9CC" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="Button.danger:pointerover">
+      <Setter Property="Background" Value="#FFE2E3" />
     </Style>
     <Style Selector="Button.compact">
       <Setter Property="Padding" Value="10,6" />
@@ -93,88 +127,106 @@
     <Style Selector="Button.nav">
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Foreground" Value="#A9C8DC" />
+      <Setter Property="Foreground" Value="#B9BBCB" />
       <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="Padding" Value="12,9" />
-      <Setter Property="Margin" Value="0,0,0,4" />
+      <Setter Property="Padding" Value="12,10" />
+      <Setter Property="Margin" Value="0,0,0,3" />
+      <Setter Property="CornerRadius" Value="9" />
+      <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.nav:pointerover">
-      <Setter Property="Background" Value="#103B5D" />
+      <Setter Property="Background" Value="#282A43" />
+      <Setter Property="Foreground" Value="White" />
     </Style>
     <Style Selector="Button.nav.active">
-      <Setter Property="Background" Value="#0F4F7A" />
+      <Setter Property="Background" Value="#373455" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.nav TextBlock">
+      <Setter Property="Foreground" Value="#B9BBCB" />
+    </Style>
+    <Style Selector="Button.nav:pointerover TextBlock">
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.nav.active TextBlock">
       <Setter Property="Foreground" Value="White" />
     </Style>
     <Style Selector="Button.tool">
-      <Setter Property="Background" Value="#0B304D" />
-      <Setter Property="Foreground" Value="#C7E2EF" />
-      <Setter Property="BorderBrush" Value="#2A6485" />
+      <Setter Property="Background" Value="#FFFFFF" />
+      <Setter Property="Foreground" Value="#3E4050" />
+      <Setter Property="BorderBrush" Value="#DEDFE7" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="MinHeight" Value="32" />
-      <Setter Property="Padding" Value="10,5" />
+      <Setter Property="MinHeight" Value="34" />
+      <Setter Property="Padding" Value="10,6" />
       <Setter Property="FontSize" Value="12" />
+      <Setter Property="CornerRadius" Value="8" />
     </Style>
     <Style Selector="Button.tool:pointerover">
-      <Setter Property="Background" Value="#11496D" />
-      <Setter Property="BorderBrush" Value="#59BFDE" />
+      <Setter Property="Background" Value="#F0EEFA" />
+      <Setter Property="BorderBrush" Value="#C8C2EF" />
     </Style>
     <Style Selector="Button.tool.active">
-      <Setter Property="Background" Value="#146B9F" />
-      <Setter Property="Foreground" Value="White" />
-      <Setter Property="BorderBrush" Value="#6BD8F2" />
+      <Setter Property="Background" Value="#EAE7FF" />
+      <Setter Property="Foreground" Value="#5145C7" />
+      <Setter Property="BorderBrush" Value="#BFB7F4" />
     </Style>
     <Style Selector="Button.tool.square">
-      <Setter Property="Width" Value="32" />
+      <Setter Property="Width" Value="34" />
       <Setter Property="Padding" Value="0" />
     </Style>
-    <Style Selector="Button.rail">
-      <Setter Property="Width" Value="56" />
-      <Setter Property="Height" Value="48" />
-      <Setter Property="MinHeight" Value="48" />
-      <Setter Property="Padding" Value="0" />
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Foreground" Value="#8CB6CC" />
-      <Setter Property="BorderBrush" Value="Transparent" />
+    <Style Selector="Button.item-row">
+      <Setter Property="Background" Value="#FFFFFF" />
+      <Setter Property="BorderBrush" Value="#E4E5EC" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="FontFamily" Value="Cascadia Mono, SFMono-Regular, Consolas, monospace" />
-      <Setter Property="FontSize" Value="17" />
-      <Setter Property="FontWeight" Value="Bold" />
+      <Setter Property="Padding" Value="12" />
+      <Setter Property="CornerRadius" Value="9" />
     </Style>
-    <Style Selector="Button.rail:pointerover">
-      <Setter Property="Background" Value="#0C3858" />
-      <Setter Property="Foreground" Value="White" />
-      <Setter Property="BorderBrush" Value="#2C6D91" />
-    </Style>
-    <Style Selector="Button.rail.active">
-      <Setter Property="Background" Value="#12679A" />
-      <Setter Property="Foreground" Value="White" />
-      <Setter Property="BorderBrush" Value="#65D2EF" />
+    <Style Selector="Button.item-row:pointerover">
+      <Setter Property="Background" Value="#F5F3FF" />
+      <Setter Property="BorderBrush" Value="#C9C3F0" />
     </Style>
 
     <Style Selector="Border.card">
       <Setter Property="Background" Value="#FFFFFF" />
       <Setter Property="BorderBrush" Value="{StaticResource LineBrush}" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="6" />
-      <Setter Property="Padding" Value="18" />
+      <Setter Property="CornerRadius" Value="13" />
+      <Setter Property="Padding" Value="19" />
     </Style>
     <Style Selector="Border.blueprint-card">
-      <Setter Property="Background" Value="#F8FCFF" />
-      <Setter Property="BorderBrush" Value="#80B8D8" />
+      <Setter Property="Background" Value="#FAFAFD" />
+      <Setter Property="BorderBrush" Value="#E1E2EA" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="4" />
-      <Setter Property="Padding" Value="16" />
+      <Setter Property="CornerRadius" Value="10" />
+      <Setter Property="Padding" Value="14" />
     </Style>
     <Style Selector="Border.dark-card">
-      <Setter Property="Background" Value="#0B2D49" />
-      <Setter Property="BorderBrush" Value="#245A7D" />
+      <Setter Property="Background" Value="#202238" />
+      <Setter Property="BorderBrush" Value="#323550" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="5" />
-      <Setter Property="Padding" Value="16" />
+      <Setter Property="CornerRadius" Value="13" />
+      <Setter Property="Padding" Value="18" />
+    </Style>
+    <Style Selector="Border.callout">
+      <Setter Property="Background" Value="#F0EEFF" />
+      <Setter Property="BorderBrush" Value="#D5D0F6" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="10" />
+      <Setter Property="Padding" Value="13" />
+    </Style>
+    <Style Selector="Border.success">
+      <Setter Property="Background" Value="#EAF8F4" />
+      <Setter Property="BorderBrush" Value="#BDE8DC" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="10" />
+      <Setter Property="Padding" Value="12" />
     </Style>
     <Style Selector="ListBox">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="ListBoxItem">
+      <Setter Property="CornerRadius" Value="10" />
     </Style>
   </Application.Styles>
 </Application>

--- a/Blueprints.App/Models/SourceProviderCapabilities.cs
+++ b/Blueprints.App/Models/SourceProviderCapabilities.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.App.Models;
+
+[Flags]
+public enum SourceProviderCapabilities
+{
+    None = 0,
+    Issues = 1 << 0,
+    ChangeRequests = 1 << 1,
+    Releases = 1 << 2,
+    PlanningBoards = 1 << 3,
+}

--- a/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
+++ b/Blueprints.App/Services/GitHubRestSourceProviderReader.cs
@@ -18,6 +18,16 @@ public sealed class GitHubRestSourceProviderReader : IHostedSourceProviderReader
     private readonly HttpClient _httpClient;
     private readonly IProviderCredentialSource _credentialSource;
 
+    public int ContractVersion => HostedSourceProviderContract.CurrentVersion;
+
+    public SourceProviderKind Provider => SourceProviderKind.GitHub;
+
+    public SourceProviderCapabilities Capabilities =>
+        SourceProviderCapabilities.Issues
+        | SourceProviderCapabilities.ChangeRequests
+        | SourceProviderCapabilities.Releases
+        | SourceProviderCapabilities.PlanningBoards;
+
     public GitHubRestSourceProviderReader()
         : this(
             new HttpClient

--- a/Blueprints.App/Services/GitLabRestSourceProviderReader.cs
+++ b/Blueprints.App/Services/GitLabRestSourceProviderReader.cs
@@ -8,6 +8,16 @@ public sealed class GitLabRestSourceProviderReader : IHostedSourceProviderReader
     private readonly HttpClient _httpClient;
     private readonly IProviderCredentialSource _credentialSource;
 
+    public int ContractVersion => HostedSourceProviderContract.CurrentVersion;
+
+    public SourceProviderKind Provider => SourceProviderKind.GitLab;
+
+    public SourceProviderCapabilities Capabilities =>
+        SourceProviderCapabilities.Issues
+        | SourceProviderCapabilities.ChangeRequests
+        | SourceProviderCapabilities.Releases
+        | SourceProviderCapabilities.PlanningBoards;
+
     public GitLabRestSourceProviderReader()
         : this(
             new HttpClient

--- a/Blueprints.App/Services/HostedSourceProviderContract.cs
+++ b/Blueprints.App/Services/HostedSourceProviderContract.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.App.Services;
+
+public static class HostedSourceProviderContract
+{
+    public const int CurrentVersion = 1;
+    public const int MaximumCandidatesPerDiscovery = 500;
+    public const int MaximumWarningsPerDiscovery = 64;
+}

--- a/Blueprints.App/Services/HostedSourceProviderRouter.cs
+++ b/Blueprints.App/Services/HostedSourceProviderRouter.cs
@@ -6,6 +6,15 @@ public sealed class HostedSourceProviderRouter : IHostedSourceProviderReader
 {
     private readonly IReadOnlyDictionary<SourceProviderKind, IHostedSourceProviderReader> _readers;
 
+    public int ContractVersion => HostedSourceProviderContract.CurrentVersion;
+
+    public SourceProviderKind Provider => SourceProviderKind.Local;
+
+    public SourceProviderCapabilities Capabilities =>
+        _readers.Values.Aggregate(
+            SourceProviderCapabilities.None,
+            static (capabilities, reader) => capabilities | reader.Capabilities);
+
     public HostedSourceProviderRouter()
         : this(
             new GitHubRestSourceProviderReader(),
@@ -16,14 +25,34 @@ public sealed class HostedSourceProviderRouter : IHostedSourceProviderReader
     public HostedSourceProviderRouter(
         GitHubRestSourceProviderReader gitHubReader,
         GitLabRestSourceProviderReader gitLabReader)
+        : this([gitHubReader, gitLabReader])
     {
-        ArgumentNullException.ThrowIfNull(gitHubReader);
-        ArgumentNullException.ThrowIfNull(gitLabReader);
-        _readers = new Dictionary<SourceProviderKind, IHostedSourceProviderReader>
+    }
+
+    public HostedSourceProviderRouter(
+        IEnumerable<IHostedSourceProviderReader> readers)
+    {
+        ArgumentNullException.ThrowIfNull(readers);
+        var registeredReaders =
+            readers.ToArray();
+        foreach (var reader in registeredReaders)
         {
-            [SourceProviderKind.GitHub] = gitHubReader,
-            [SourceProviderKind.GitLab] = gitLabReader,
-        };
+            ArgumentNullException.ThrowIfNull(reader);
+            if (reader.ContractVersion != HostedSourceProviderContract.CurrentVersion)
+            {
+                throw new InvalidOperationException(
+                    $"Provider {reader.Provider} uses contract {reader.ContractVersion}; Blueprints requires contract {HostedSourceProviderContract.CurrentVersion}.");
+            }
+
+            if (reader.Provider == SourceProviderKind.Local
+                || reader.Capabilities == SourceProviderCapabilities.None)
+            {
+                throw new InvalidOperationException(
+                    "Hosted source providers must declare a hosted provider and at least one capability.");
+            }
+        }
+
+        _readers = registeredReaders.ToDictionary(static reader => reader.Provider);
     }
 
     public HostedSourceDiscoveryResult Read(
@@ -37,6 +66,14 @@ public sealed class HostedSourceProviderRouter : IHostedSourceProviderReader
                 $"No hosted-source reader supports {repository.Provider}.");
         }
 
-        return reader.Read(repositoryRoot, repository);
+        var result = reader.Read(repositoryRoot, repository);
+        if (result.Candidates.Count > HostedSourceProviderContract.MaximumCandidatesPerDiscovery
+            || result.Warnings.Count > HostedSourceProviderContract.MaximumWarningsPerDiscovery)
+        {
+            throw new InvalidOperationException(
+                $"Provider {reader.Provider} exceeded the bounded contract response limits.");
+        }
+
+        return result;
     }
 }

--- a/Blueprints.App/Services/IHostedSourceProviderReader.cs
+++ b/Blueprints.App/Services/IHostedSourceProviderReader.cs
@@ -4,6 +4,12 @@ namespace Blueprints.App.Services;
 
 public interface IHostedSourceProviderReader
 {
+    int ContractVersion { get; }
+
+    SourceProviderKind Provider { get; }
+
+    SourceProviderCapabilities Capabilities { get; }
+
     HostedSourceDiscoveryResult Read(
         string repositoryRoot,
         HostedRepositoryDescriptor repository);

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -727,76 +727,71 @@ public sealed class ProjectWorkspaceCoordinatorService
             ?? throw new InvalidOperationException("The selected version was not found.");
         EnsureArchivable(version.Version.Status, "version");
 
-        var archiveDirectory = CreateArchiveDirectory(
+        var archiveId = CreateArchiveId("version", versionId);
+        var archiveDirectory = Path.Combine(
             localWorkspaceRoot,
-            "version",
-            versionId);
-        var versionDirectory = Path.Combine(
-            localWorkspaceRoot,
-            "versions",
-            versionId.ToString("N"));
-        var archivedVersionDirectory = Path.Combine(
-            archiveDirectory,
-            "versions",
-            versionId.ToString("N"));
-        CopyDirectory(versionDirectory, archivedVersionDirectory);
-        WriteArchiveRecord(
-            archiveDirectory,
-            new WorkspaceArchiveRecord(
-                CurrentSchemaVersion,
-                Path.GetFileName(archiveDirectory),
-                "version",
-                versionId,
-                version.Version.Name,
-                DateTimeOffset.UtcNow,
-                identity.Profile.UserId,
-                identity.Profile.DisplayName,
-                "Prepared"));
-
-        Directory.Delete(versionDirectory, recursive: true);
-        try
+            ".blueprints",
+            "archive",
+            archiveId);
+        var removedEntityIds = version.Items
+            .Select(static item => item.ItemId)
+            .Append(versionId)
+            .ToHashSet();
+        var updatedWorkspace = workspace with
         {
-            var removedEntityIds = version.Items
-                .Select(static item => item.ItemId)
-                .Append(versionId)
-                .ToHashSet();
-            var updatedWorkspace = workspace with
-            {
-                Versions = workspace.Versions
-                    .Where(entry => entry.Version.VersionId != versionId)
-                    .ToArray(),
-                CanvasLayout = RemoveArchivedLayoutNodes(
-                    workspace.CanvasLayout,
-                    removedEntityIds,
-                    identity),
-                Relationships = RemoveArchivedRelationships(
-                    workspace.Relationships,
-                    removedEntityIds,
-                    identity),
-            };
-            var updatedSession = SaveWorkspace(
-                localWorkspaceRoot,
-                sharedWorkspaceRoot,
+            Versions = workspace.Versions
+                .Where(entry => entry.Version.VersionId != versionId)
+                .ToArray(),
+            CanvasLayout = RemoveArchivedLayoutNodes(
+                workspace.CanvasLayout,
+                removedEntityIds,
+                identity),
+            Relationships = RemoveArchivedRelationships(
+                workspace.Relationships,
+                removedEntityIds,
+                identity),
+        };
+        _workspaceTransactionService.Execute(localWorkspaceRoot, stagedRoot =>
+        {
+            var versionDirectory = Path.Combine(
+                stagedRoot,
+                "versions",
+                versionId.ToString("N"));
+            var stagedArchiveDirectory = Path.Combine(
+                stagedRoot,
+                ".blueprints",
+                "archive",
+                archiveId);
+            var archivedVersionDirectory = Path.Combine(
+                stagedArchiveDirectory,
+                "versions",
+                versionId.ToString("N"));
+            CopyDirectory(versionDirectory, archivedVersionDirectory);
+            WriteArchiveRecord(
+                stagedArchiveDirectory,
+                new WorkspaceArchiveRecord(
+                    CurrentSchemaVersion,
+                    archiveId,
+                    "version",
+                    versionId,
+                    version.Version.Name,
+                    DateTimeOffset.UtcNow,
+                    identity.Profile.UserId,
+                    identity.Profile.DisplayName,
+                    "Applied"));
+            Directory.Delete(versionDirectory, recursive: true);
+            _workspaceStore.Save(stagedRoot, updatedWorkspace, identity.SigningKey);
+            AppendAuditEntry(
+                stagedRoot,
                 identity,
                 updatedWorkspace,
                 "version.archive",
                 $"Archived draft version {version.Version.Name}.");
-            UpdateArchiveStatus(archiveDirectory, "Applied");
-            return new WorkspaceArchiveResult(
-                updatedSession,
-                archiveDirectory,
-                $"Archived version {version.Version.Name}. Recovery copy: {archiveDirectory}");
-        }
-        catch
-        {
-            if (!Directory.Exists(versionDirectory))
-            {
-                CopyDirectory(archivedVersionDirectory, versionDirectory);
-            }
-
-            UpdateArchiveStatus(archiveDirectory, "Failed and restored");
-            throw;
-        }
+        });
+        return new WorkspaceArchiveResult(
+            OpenProject(localWorkspaceRoot, sharedWorkspaceRoot),
+            archiveDirectory,
+            $"Archived version {version.Version.Name}. Recovery copy: {archiveDirectory}");
     }
 
     public WorkspaceArchiveResult ArchiveItem(
@@ -826,79 +821,76 @@ public sealed class ProjectWorkspaceCoordinatorService
             ?? throw new InvalidOperationException("The selected item was not found.");
         var relativeDocumentPath =
             $"versions/{versionId:N}/items/{itemId:N}.json";
-        var archiveDirectory = CreateArchiveDirectory(
+        var archiveId = CreateArchiveId("item", itemId);
+        var archiveDirectory = Path.Combine(
             localWorkspaceRoot,
-            "item",
-            itemId);
-        CopyDocumentPair(
-            localWorkspaceRoot,
-            archiveDirectory,
-            relativeDocumentPath);
-        WriteArchiveRecord(
-            archiveDirectory,
-            new WorkspaceArchiveRecord(
-                CurrentSchemaVersion,
-                Path.GetFileName(archiveDirectory),
-                "item",
-                itemId,
-                item.ItemKey,
-                DateTimeOffset.UtcNow,
-                identity.Profile.UserId,
-                identity.Profile.DisplayName,
-                "Prepared"));
-        DeleteFileIfPresent(localWorkspaceRoot, relativeDocumentPath);
-        DeleteFileIfPresent(
-            localWorkspaceRoot,
-            Path.ChangeExtension(relativeDocumentPath, ".sig"));
-
-        try
+            ".blueprints",
+            "archive",
+            archiveId);
+        var versions = workspace.Versions.ToArray();
+        versions[versionIndex.index] = versionIndex.entry with
         {
-            var versions = workspace.Versions.ToArray();
-            versions[versionIndex.index] = versionIndex.entry with
+            Version = versionIndex.entry.Version with
             {
-                Version = versionIndex.entry.Version with
-                {
-                    ManualOrder = versionIndex.entry.Version.ManualOrder
-                        .Where(id => id != itemId)
-                        .ToArray(),
-                },
-                Items = versionIndex.entry.Items
-                    .Where(candidate => candidate.ItemId != itemId)
+                ManualOrder = versionIndex.entry.Version.ManualOrder
+                    .Where(id => id != itemId)
                     .ToArray(),
-            };
-            var updatedSession = SaveWorkspace(
-                localWorkspaceRoot,
-                sharedWorkspaceRoot,
+            },
+            Items = versionIndex.entry.Items
+                .Where(candidate => candidate.ItemId != itemId)
+                .ToArray(),
+        };
+        var updatedWorkspace = workspace with
+        {
+            Versions = versions,
+            CanvasLayout = RemoveArchivedLayoutNodes(
+                workspace.CanvasLayout,
+                new HashSet<Guid> { itemId },
+                identity),
+            Relationships = RemoveArchivedRelationships(
+                workspace.Relationships,
+                new HashSet<Guid> { itemId },
+                identity),
+        };
+        _workspaceTransactionService.Execute(localWorkspaceRoot, stagedRoot =>
+        {
+            var stagedArchiveDirectory = Path.Combine(
+                stagedRoot,
+                ".blueprints",
+                "archive",
+                archiveId);
+            CopyDocumentPair(
+                stagedRoot,
+                stagedArchiveDirectory,
+                relativeDocumentPath);
+            WriteArchiveRecord(
+                stagedArchiveDirectory,
+                new WorkspaceArchiveRecord(
+                    CurrentSchemaVersion,
+                    archiveId,
+                    "item",
+                    itemId,
+                    item.ItemKey,
+                    DateTimeOffset.UtcNow,
+                    identity.Profile.UserId,
+                    identity.Profile.DisplayName,
+                    "Applied"));
+            DeleteFileIfPresent(stagedRoot, relativeDocumentPath);
+            DeleteFileIfPresent(
+                stagedRoot,
+                Path.ChangeExtension(relativeDocumentPath, ".sig"));
+            _workspaceStore.Save(stagedRoot, updatedWorkspace, identity.SigningKey);
+            AppendAuditEntry(
+                stagedRoot,
                 identity,
-                workspace with
-                {
-                    Versions = versions,
-                    CanvasLayout = RemoveArchivedLayoutNodes(
-                        workspace.CanvasLayout,
-                        new HashSet<Guid> { itemId },
-                        identity),
-                    Relationships = RemoveArchivedRelationships(
-                        workspace.Relationships,
-                        new HashSet<Guid> { itemId },
-                        identity),
-                },
+                updatedWorkspace,
                 "item.archive",
                 $"Archived item {item.ItemKey}.");
-            UpdateArchiveStatus(archiveDirectory, "Applied");
-            return new WorkspaceArchiveResult(
-                updatedSession,
-                archiveDirectory,
-                $"Archived item {item.ItemKey}. Recovery copy: {archiveDirectory}");
-        }
-        catch
-        {
-            CopyDocumentPair(
-                archiveDirectory,
-                localWorkspaceRoot,
-                relativeDocumentPath);
-            UpdateArchiveStatus(archiveDirectory, "Failed and restored");
-            throw;
-        }
+        });
+        return new WorkspaceArchiveResult(
+            OpenProject(localWorkspaceRoot, sharedWorkspaceRoot),
+            archiveDirectory,
+            $"Archived item {item.ItemKey}. Recovery copy: {archiveDirectory}");
     }
 
     public ChangelogExportResult ExportVersionChangelog(
@@ -1876,35 +1868,10 @@ public sealed class ProjectWorkspaceCoordinatorService
         return recoveryDirectory;
     }
 
-    private static string CreateArchiveDirectory(
-        string localWorkspaceRoot,
+    private static string CreateArchiveId(
         string entityType,
         Guid entityId)
-    {
-        var archiveId =
-            $"{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{entityType}-{entityId:N}-{Guid.NewGuid():N}";
-        var archiveDirectory = Path.Combine(
-            localWorkspaceRoot,
-            ".blueprints",
-            "archive",
-            archiveId);
-        Directory.CreateDirectory(archiveDirectory);
-        return archiveDirectory;
-    }
-
-    private static void UpdateArchiveStatus(
-        string archiveDirectory,
-        string status)
-    {
-        var recordPath = Path.Combine(archiveDirectory, "archive.json");
-        var record = JsonSerializer.Deserialize<WorkspaceArchiveRecord>(
-            File.ReadAllText(recordPath),
-            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
-            ?? throw new InvalidOperationException("Archive metadata could not be read.");
-        WriteArchiveRecord(
-            archiveDirectory,
-            record with { Status = status });
-    }
+        => $"{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{entityType}-{entityId:N}-{Guid.NewGuid():N}";
 
     private static void WriteArchiveRecord(
         string archiveDirectory,

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -26,6 +26,8 @@ public sealed class ProjectWorkspaceCoordinatorService
     private readonly RecentProjectsStore _recentProjectsStore;
     private readonly FileSystemAuditLogService _auditLogService;
     private readonly SharedFolderSafetyInspector _sharedFolderSafetyInspector;
+    private readonly IWorkspaceTransactionService _workspaceTransactionService;
+    private readonly WorkspaceMigrationService _workspaceMigrationService;
     private readonly FileSystemProjectTrustStore _projectTrustStore = new();
     private readonly IdentityInvitationService _identityInvitationService =
         new(new Ed25519SignatureService());
@@ -40,7 +42,9 @@ public sealed class ProjectWorkspaceCoordinatorService
         FileSystemWorkspaceSyncService workspaceSyncService,
         RecentProjectsStore recentProjectsStore,
         FileSystemAuditLogService auditLogService,
-        SharedFolderSafetyInspector sharedFolderSafetyInspector)
+        SharedFolderSafetyInspector sharedFolderSafetyInspector,
+        IWorkspaceTransactionService? workspaceTransactionService = null,
+        WorkspaceMigrationService? workspaceMigrationService = null)
     {
         _identityService = identityService;
         _workspaceStore = workspaceStore;
@@ -50,6 +54,10 @@ public sealed class ProjectWorkspaceCoordinatorService
         _recentProjectsStore = recentProjectsStore;
         _auditLogService = auditLogService;
         _sharedFolderSafetyInspector = sharedFolderSafetyInspector;
+        _workspaceTransactionService =
+            workspaceTransactionService ?? new FileSystemWorkspaceTransactionService();
+        _workspaceMigrationService =
+            workspaceMigrationService ?? new WorkspaceMigrationService(_workspaceTransactionService);
     }
 
     public IReadOnlyList<RecentProjectReference> GetRecentProjects() =>
@@ -79,6 +87,24 @@ public sealed class ProjectWorkspaceCoordinatorService
         return _identityInvitationService.Write(filePath, identity);
     }
 
+    public string ExportIdentityBackup(string filePath, string passphrase) =>
+        _identityService.ExportBackup(filePath, passphrase);
+
+    public IdentitySummary ImportIdentityBackup(string filePath, string passphrase)
+    {
+        if (HasLocalIdentity)
+        {
+            throw new InvalidOperationException(
+                "A signing identity is already configured on this device.");
+        }
+
+        var identity = _identityService.ImportBackup(filePath, passphrase);
+        return new IdentitySummary(
+            identity.Profile.DisplayName,
+            identity.Profile.UserId.ToString(),
+            identity.Profile.KeyStorageProvider);
+    }
+
     public MemberInviteRequest ReadIdentityInvitation(string filePath)
     {
         var invitation = _identityInvitationService.Read(filePath);
@@ -105,21 +131,29 @@ public sealed class ProjectWorkspaceCoordinatorService
         }
 
         var snapshot = CreateProjectSnapshot(identity, request);
-        _workspaceStore.Save(localRoot, snapshot, identity.SigningKey);
-        _projectTrustStore.Initialize(
-            localRoot,
-            snapshot.Project.ProjectId,
-            [
-                new TrustedProjectKey(
-                    identity.Profile.UserId,
-                    identity.Profile.DisplayName,
-                    identity.Profile.KeyId,
-                    identity.Profile.PublicKeyBase64,
-                    DateTimeOffset.UtcNow,
-                    MemberRole.Admin,
-                    true),
-            ]);
-        AppendAuditEntry(localRoot, identity, snapshot, "project.create", $"Created project {snapshot.Project.Name}.");
+        _workspaceTransactionService.Execute(localRoot, stagedRoot =>
+        {
+            _workspaceStore.Save(stagedRoot, snapshot, identity.SigningKey);
+            _projectTrustStore.Initialize(
+                stagedRoot,
+                snapshot.Project.ProjectId,
+                [
+                    new TrustedProjectKey(
+                        identity.Profile.UserId,
+                        identity.Profile.DisplayName,
+                        identity.Profile.KeyId,
+                        identity.Profile.PublicKeyBase64,
+                        DateTimeOffset.UtcNow,
+                        MemberRole.Admin,
+                        true),
+                ]);
+            AppendAuditEntry(
+                stagedRoot,
+                identity,
+                snapshot,
+                "project.create",
+                $"Created project {snapshot.Project.Name}.");
+        });
         Directory.CreateDirectory(sharedRoot);
 
         var session = OpenProject(localRoot, sharedRoot);
@@ -131,7 +165,11 @@ public sealed class ProjectWorkspaceCoordinatorService
         ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
         ArgumentException.ThrowIfNullOrWhiteSpace(sharedWorkspaceRoot);
 
+        _workspaceTransactionService.Recover(localWorkspaceRoot);
         var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        _workspaceMigrationService.MigrateIfNeeded(
+            localWorkspaceRoot,
+            identity.SigningKey);
         var paths = WorkspacePathResolver.Create(localWorkspaceRoot, sharedWorkspaceRoot);
         Directory.CreateDirectory(paths.SharedProjectRoot);
         var safetyReport = _sharedFolderSafetyInspector.Inspect(paths.SharedProjectRoot, paths.LocalWorkspaceRoot);
@@ -483,13 +521,16 @@ public sealed class ProjectWorkspaceCoordinatorService
                 .Select(static item => item.ItemId)
                 .ToHashSet());
 
-        _workspaceStore.SaveCanvasLayout(localWorkspaceRoot, layout, identity.SigningKey);
-        AppendAuditEntry(
-            localWorkspaceRoot,
-            identity,
-            workspace,
-            "canvas.layout.save",
-            $"Saved canvas layout revision {layout.Revision} with {layout.Nodes.Count} nodes.");
+        _workspaceTransactionService.Execute(localWorkspaceRoot, stagedRoot =>
+        {
+            _workspaceStore.SaveCanvasLayout(stagedRoot, layout, identity.SigningKey);
+            AppendAuditEntry(
+                stagedRoot,
+                identity,
+                workspace,
+                "canvas.layout.save",
+                $"Saved canvas layout revision {layout.Revision} with {layout.Nodes.Count} nodes.");
+        });
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
     }
 
@@ -534,11 +575,11 @@ public sealed class ProjectWorkspaceCoordinatorService
             identity,
             types,
             workspace.Relationships?.Relationships ?? []);
-        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
-        AppendAuditEntry(
+        SaveRelationshipDocument(
             localWorkspaceRoot,
             identity,
-            workspace with { Relationships = document },
+            workspace,
+            document,
             existing is null ? "relationship.type.create" : "relationship.type.update",
             $"{(existing is null ? "Created" : "Updated")} relationship type {document.Types.First(type => type.TypeId == typeId).Name}.");
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
@@ -583,11 +624,11 @@ public sealed class ProjectWorkspaceCoordinatorService
             identity,
             relationships.Types,
             edges);
-        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
-        AppendAuditEntry(
+        SaveRelationshipDocument(
             localWorkspaceRoot,
             identity,
-            workspace with { Relationships = document },
+            workspace,
+            document,
             request.RelationshipId is null ? "relationship.create" : "relationship.update",
             $"{(request.RelationshipId is null ? "Created" : "Updated")} relationship {relationshipId:N}.");
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
@@ -619,11 +660,11 @@ public sealed class ProjectWorkspaceCoordinatorService
             relationships.Relationships
                 .Where(edge => edge.RelationshipId != relationshipId)
                 .ToArray());
-        SaveRelationshipDocument(localWorkspaceRoot, identity, workspace, document);
-        AppendAuditEntry(
+        SaveRelationshipDocument(
             localWorkspaceRoot,
             identity,
-            workspace with { Relationships = document },
+            workspace,
+            document,
             "relationship.remove",
             $"Removed relationship {relationshipId:N}.");
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
@@ -1370,8 +1411,11 @@ public sealed class ProjectWorkspaceCoordinatorService
         string operation,
         string summary)
     {
-        _workspaceStore.Save(localWorkspaceRoot, workspace, identity.SigningKey);
-        AppendAuditEntry(localWorkspaceRoot, identity, workspace, operation, summary);
+        _workspaceTransactionService.Execute(localWorkspaceRoot, stagedRoot =>
+        {
+            _workspaceStore.Save(stagedRoot, workspace, identity.SigningKey);
+            AppendAuditEntry(stagedRoot, identity, workspace, operation, summary);
+        });
         return OpenProject(localWorkspaceRoot, sharedWorkspaceRoot);
     }
 
@@ -1554,7 +1598,9 @@ public sealed class ProjectWorkspaceCoordinatorService
         string localWorkspaceRoot,
         Security.Models.StoredIdentity identity,
         ProjectWorkspaceSnapshot workspace,
-        RelationshipDocument document)
+        RelationshipDocument document,
+        string operation,
+        string summary)
     {
         RelationshipDocumentValidator.Validate(document, workspace.Project.ProjectId);
         RelationshipDocumentValidator.ValidateEntityReferences(
@@ -1565,7 +1611,16 @@ public sealed class ProjectWorkspaceCoordinatorService
                 .SelectMany(static version => version.Items)
                 .Select(static item => item.ItemId)
                 .ToHashSet());
-        _workspaceStore.SaveRelationships(localWorkspaceRoot, document, identity.SigningKey);
+        _workspaceTransactionService.Execute(localWorkspaceRoot, stagedRoot =>
+        {
+            _workspaceStore.SaveRelationships(stagedRoot, document, identity.SigningKey);
+            AppendAuditEntry(
+                stagedRoot,
+                identity,
+                workspace with { Relationships = document },
+                operation,
+                summary);
+        });
     }
 
     private static RelationshipDocument CreateRelationshipDocument(

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -39,6 +39,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private bool _hasActiveSession;
     private bool _hasLocalIdentity;
     private string _identitySetupName = string.Empty;
+    private string _identityBackupPassphrase = string.Empty;
     private string _setupMessage = string.Empty;
     private string _workspaceMessage = string.Empty;
     private string _createProjectName = "Blueprints";
@@ -589,6 +590,12 @@ public partial class MainWindowViewModel : ViewModelBase
         set => SetProperty(ref _identitySetupName, value);
     }
 
+    public string IdentityBackupPassphrase
+    {
+        get => _identityBackupPassphrase;
+        set => SetProperty(ref _identityBackupPassphrase, value);
+    }
+
     public string LocalIdentitySetupSummary =>
         HasLocalIdentity
             ? "A protected local signing identity is ready."
@@ -597,8 +604,16 @@ public partial class MainWindowViewModel : ViewModelBase
     public string SetupMessage
     {
         get => _setupMessage;
-        private set => SetProperty(ref _setupMessage, value);
+        private set
+        {
+            if (SetProperty(ref _setupMessage, value))
+            {
+                OnPropertyChanged(nameof(HasSetupMessage));
+            }
+        }
     }
+
+    public bool HasSetupMessage => !string.IsNullOrWhiteSpace(SetupMessage);
 
     public string WorkspaceMessage
     {
@@ -643,24 +658,24 @@ public partial class MainWindowViewModel : ViewModelBase
     public string SelectedWorkspaceSectionTitle =>
         SelectedWorkspaceSection switch
         {
-            WorkspaceSection.Overview => "Project overview",
-            WorkspaceSection.Releases => "Release drafting board",
-            WorkspaceSection.Team => "Team and signing identities",
-            WorkspaceSection.Sync => "Workspace exchange",
-            WorkspaceSection.Trust => "Trust and audit",
-            WorkspaceSection.Integrations => "Source Lens",
-            _ => "Project overview",
+            WorkspaceSection.Overview => "Home",
+            WorkspaceSection.Releases => "Plan releases",
+            WorkspaceSection.Team => "People",
+            WorkspaceSection.Sync => "Share changes",
+            WorkspaceSection.Trust => "Safety check",
+            WorkspaceSection.Integrations => "Find work",
+            _ => "Home",
         };
 
     public string SelectedWorkspaceSectionDescription =>
         SelectedWorkspaceSection switch
         {
-            WorkspaceSection.Overview => "Read the project map, spot blockers, and choose the next action.",
-            WorkspaceSection.Releases => "Plan versions, connect work items, preview notes, and mark milestones complete.",
-            WorkspaceSection.Team => "Review signed membership and manage the people allowed to contribute.",
-            WorkspaceSection.Sync => "Compare local and shared state before moving signed changes.",
-            WorkspaceSection.Trust => "Inspect validation results, conflicts, and the audit boundary.",
-            WorkspaceSection.Integrations => "Discover project signals, shape editable proposals, and approve exactly what enters the signed blueprint.",
+            WorkspaceSection.Overview => "See the plan, spot what needs attention, and choose your next step.",
+            WorkspaceSection.Releases => "Organize versions and accomplishments, then turn them into clear release notes.",
+            WorkspaceSection.Team => "Invite teammates and manage who can view or change this project.",
+            WorkspaceSection.Sync => "Review incoming and outgoing work before sharing it with your team.",
+            WorkspaceSection.Trust => "Confirm that project files and history are valid, with guidance when something needs attention.",
+            WorkspaceSection.Integrations => "Bring in useful work from Git, GitHub, and GitLab only after you review it.",
             _ => string.Empty,
         };
 
@@ -1470,6 +1485,71 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var exportedPath = _coordinatorService.ExportIdentityInvitation(filePath);
             SetupMessage = $"Exported signed identity invitation to {exportedPath}.";
+        }
+        catch (Exception exception)
+        {
+            SetupMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ExportIdentityBackup(string? filePath)
+    {
+        if (_coordinatorService is null
+            || !HasLocalIdentity
+            || string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var exportedPath = _coordinatorService.ExportIdentityBackup(
+                filePath,
+                IdentityBackupPassphrase);
+            IdentityBackupPassphrase = string.Empty;
+            var message = $"Created encrypted identity backup at {exportedPath}. Keep its passphrase separately.";
+            if (HasActiveSession)
+            {
+                WorkspaceMessage = message;
+            }
+            else
+            {
+                SetupMessage = message;
+            }
+        }
+        catch (Exception exception)
+        {
+            if (HasActiveSession)
+            {
+                WorkspaceMessage = exception.Message;
+            }
+            else
+            {
+                SetupMessage = exception.Message;
+            }
+        }
+    }
+
+    [RelayCommand]
+    private void ImportIdentityBackup(string? filePath)
+    {
+        if (_coordinatorService is null
+            || HasLocalIdentity
+            || string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var identity = _coordinatorService.ImportIdentityBackup(
+                filePath,
+                IdentityBackupPassphrase);
+            HasLocalIdentity = true;
+            IdentityBackupPassphrase = string.Empty;
+            SetupMessage =
+                $"Restored {identity.DisplayName}'s signing identity under this device's local key protection.";
         }
         catch (Exception exception)
         {

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
@@ -2,10 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Blueprints.App.Views.Components.BlueprintCanvasSurface"
              Focusable="True">
-  <Border Background="#072A46"
-          BorderBrush="#2C6E96"
+  <Border Background="#24243A"
+          BorderBrush="#383A55"
           BorderThickness="1"
-          CornerRadius="4"
+          CornerRadius="12"
           ClipToBounds="True">
     <Grid>
       <ScrollViewer x:Name="Viewport"
@@ -19,7 +19,7 @@
           <Canvas x:Name="Surface"
                   Width="1500"
                   Height="960"
-                  Background="#082F50" />
+                  Background="#25263D" />
         </Viewbox>
       </ScrollViewer>
 
@@ -29,18 +29,18 @@
               Height="132"
               Margin="0,0,18,18"
               Padding="7"
-              Background="#E6071F34"
-              BorderBrush="#659FC0"
+              Background="#E6222337"
+              BorderBrush="#64627F"
               BorderThickness="1"
-              CornerRadius="5"
+              CornerRadius="9"
               IsHitTestVisible="False">
         <Grid RowDefinitions="Auto,*" RowSpacing="4">
-          <TextBlock Text="MINIMAP" Foreground="#8BDCF0" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
+          <TextBlock Text="OVERVIEW" Foreground="#B8B2F4" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
           <Canvas x:Name="MiniMapSurface"
                   Grid.Row="1"
                   Width="174"
                   Height="106"
-                  Background="#B9082F50" />
+                  Background="#B925263D" />
         </Grid>
       </Border>
     </Grid>

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -253,21 +253,21 @@ public partial class BlueprintCanvasSurface : UserControl
                 };
             border.Background = Brush.Parse(
                 selected
-                    ? "#12669A"
+                    ? "#6658DA"
                     : tag.Type switch
                     {
-                        "project" => "#0A2035",
-                        "version" => "#0B3D62",
-                        _ => "#0A3656",
+                        "project" => "#202238",
+                        "version" => "#34304F",
+                        _ => "#2B2D48",
                     });
             border.BorderBrush = Brush.Parse(
                 selected
                     ? "#FFFFFF"
                     : tag.Type switch
                     {
-                        "project" => "#65D2EF",
-                        "version" => "#4EA9CC",
-                        _ => "#397F9F",
+                        "project" => "#B8B2F4",
+                        "version" => "#9187E8",
+                        _ => "#6F6A9E",
                     });
         }
     }
@@ -310,7 +310,7 @@ public partial class BlueprintCanvasSurface : UserControl
             Place(versionNode, versionPoint);
             Surface.Children.Add(versionNode);
             RegisterNode(versionNode);
-            AddConnection(projectNode, versionNode, "#52C7E8", 2);
+            AddConnection(projectNode, versionNode, "#9D93EF", 2);
 
             foreach (var item in version.Items)
             {
@@ -321,7 +321,7 @@ public partial class BlueprintCanvasSurface : UserControl
                 Place(itemNode, itemPoint);
                 Surface.Children.Add(itemNode);
                 RegisterNode(itemNode);
-                AddConnection(versionNode, itemNode, item.IsDone ? "#5DD6B2" : "#73AFCF", item.IsDone ? 2 : 1.25);
+                AddConnection(versionNode, itemNode, item.IsDone ? "#55C8B5" : "#79769A", item.IsDone ? 2 : 1.25);
                 globalItemIndex++;
             }
         }
@@ -372,7 +372,7 @@ public partial class BlueprintCanvasSurface : UserControl
                 FontFamily = FontFamily.Parse("Cascadia Mono, SFMono-Regular, Consolas, monospace"),
                 FontSize = 16,
                 FontWeight = FontWeight.Bold,
-                Foreground = Brush.Parse("#76CDE8"),
+                Foreground = Brush.Parse("#A9A2EC"),
             };
             Place(empty, new Point(360, 330));
             Surface.Children.Add(empty);
@@ -422,7 +422,7 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             StartPoint = start,
             EndPoint = end,
-            Stroke = Brush.Parse(major ? "#1A587A" : "#10415F"),
+            Stroke = Brush.Parse(major ? "#454560" : "#34354F"),
             StrokeThickness = major ? 1 : 0.5,
             IsHitTestVisible = false,
             Tag = "grid",
@@ -431,21 +431,21 @@ public partial class BlueprintCanvasSurface : UserControl
     private Control CreateProjectNode()
     {
         var content = new StackPanel { Spacing = 7 };
-        content.Children.Add(CreateLabel("PROJECT ORIGIN", "#65D2EF"));
+        content.Children.Add(CreateLabel("PROJECT", "#B8B2F4"));
         content.Children.Add(CreateTitle(_viewModel?.CurrentProject.Name ?? "Project", 22));
         content.Children.Add(CreateLabel(
             $"{_viewModel?.CurrentProject.Code}  /  {_viewModel?.VersioningScheme}",
-            "#A7CEE0"));
+            "#B9BBCB"));
         content.Children.Add(CreateLabel(
             $"{_viewModel?.VersionCount ?? 0} versions  ·  {_viewModel?.ItemCount ?? 0} items",
-            "#A7CEE0"));
+            "#B9BBCB"));
 
         var node = CreateNodeShell(
             content,
             250,
             140,
-            "#0A2035",
-            "#65D2EF",
+            "#202238",
+            "#B8B2F4",
             "project",
             _viewModel?.CurrentProject.ProjectId);
         if (_viewModel?.CurrentProject.ProjectId is Guid projectId && projectId != Guid.Empty)
@@ -460,18 +460,18 @@ public partial class BlueprintCanvasSurface : UserControl
     {
         var selected = _viewModel?.SelectedVersion?.VersionId == version.VersionId;
         var content = new StackPanel { Spacing = 6 };
-        content.Children.Add(CreateLabel($"VERSION  /  {version.Status}", selected ? "#FFFFFF" : "#65D2EF"));
+        content.Children.Add(CreateLabel($"VERSION  /  {version.Status}", selected ? "#FFFFFF" : "#B8B2F4"));
         content.Children.Add(CreateTitle(version.Name, 20));
         content.Children.Add(CreateLabel(
             $"{version.CompletedItemCount}/{version.ItemCount} complete",
-            version.CompletedItemCount == version.ItemCount && version.ItemCount > 0 ? "#64DBB6" : "#A7CEE0"));
+            version.CompletedItemCount == version.ItemCount && version.ItemCount > 0 ? "#62D3BC" : "#B9BBCB"));
 
         var node = CreateNodeShell(
             content,
             NodeWidth,
             VersionNodeHeight,
-            selected ? "#12669A" : "#0B3D62",
-            selected ? "#FFFFFF" : "#4EA9CC",
+            selected ? "#6658DA" : "#34304F",
+            selected ? "#FFFFFF" : "#9187E8",
             "version",
             version.VersionId);
         node.AddHandler(
@@ -487,20 +487,20 @@ public partial class BlueprintCanvasSurface : UserControl
         var selected = _viewModel?.SelectedItem?.ItemId == item.ItemId;
         var content = new StackPanel { Spacing = 4 };
         var heading = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
-        heading.Children.Add(CreateLabel(item.ItemKey, selected ? "#FFFFFF" : "#6ED1ED"));
-        var state = CreateLabel(item.IsDone ? "DONE" : "OPEN", item.IsDone ? "#64DBB6" : "#F2C66D");
+        heading.Children.Add(CreateLabel(item.ItemKey, selected ? "#FFFFFF" : "#B8B2F4"));
+        var state = CreateLabel(item.IsDone ? "DONE" : "OPEN", item.IsDone ? "#62D3BC" : "#F1C96A");
         Grid.SetColumn(state, 1);
         heading.Children.Add(state);
         content.Children.Add(heading);
         content.Children.Add(CreateTitle(item.Title, 15));
-        content.Children.Add(CreateLabel($"{item.ItemTypeId}  /  {item.CategoryId}", "#9FC5D8"));
+        content.Children.Add(CreateLabel($"{item.ItemTypeId}  /  {item.CategoryId}", "#A9ABBA"));
 
         var node = CreateNodeShell(
             content,
             NodeWidth,
             ItemNodeHeight,
-            selected ? "#12669A" : "#0A3656",
-            selected ? "#FFFFFF" : item.IsDone ? "#4BB99B" : "#397F9F",
+            selected ? "#6658DA" : "#2B2D48",
+            selected ? "#FFFFFF" : item.IsDone ? "#4DB7A5" : "#6F6A9E",
             "item",
             item.ItemId);
         node.AddHandler(
@@ -786,8 +786,8 @@ public partial class BlueprintCanvasSurface : UserControl
         _boxSelectionStart = eventArgs.GetPosition(Surface);
         _boxSelectionVisual = new Rectangle
         {
-            Fill = Brush.Parse("#3365D2EF"),
-            Stroke = Brush.Parse("#8BE6F7"),
+            Fill = Brush.Parse("#336B5CE7"),
+            Stroke = Brush.Parse("#A9A2EC"),
             StrokeThickness = 1.5,
             IsHitTestVisible = false,
         };
@@ -997,7 +997,7 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             StartPoint = start,
             EndPoint = end,
-            Stroke = Brush.Parse("#F2C66D"),
+            Stroke = Brush.Parse("#F1C96A"),
             StrokeThickness = 1,
             StrokeDashArray = [5, 4],
             IsHitTestVisible = false,
@@ -1044,12 +1044,12 @@ public partial class BlueprintCanvasSurface : UserControl
                 Height = Math.Max(2, node.Height * scale),
                 Fill = Brush.Parse(
                     _selectedNodeIds.Contains(id)
-                        ? "#F2C66D"
+                        ? "#F1C96A"
                         : tag?.Type switch
                         {
-                            "project" => "#65D2EF",
-                            "version" => "#4EA9CC",
-                            _ => "#5DD6B2",
+                            "project" => "#B8B2F4",
+                            "version" => "#9187E8",
+                            _ => "#55C8B5",
                         }),
                 IsHitTestVisible = false,
             };

--- a/Blueprints.App/Views/Components/IntegrationsView.axaml
+++ b/Blueprints.App/Views/Components/IntegrationsView.axaml
@@ -5,7 +5,7 @@
              x:Class="Blueprints.App.Views.Components.IntegrationsView"
              x:DataType="vm:MainWindowViewModel">
   <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12">
-    <Border Background="#082941" BorderBrush="#2A698A" BorderThickness="1" CornerRadius="8" Padding="18">
+    <Border Background="#202238" BorderBrush="#343650" BorderThickness="1" CornerRadius="13" Padding="18">
       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="20">
         <StackPanel Spacing="6">
           <TextBlock Text="SOURCE LENS" Foreground="#68D5EF" FontSize="11" FontWeight="Bold" LetterSpacing="1.6" />
@@ -75,7 +75,7 @@
               <Grid ColumnDefinitions="*,Auto">
                 <TextBlock Text="Proposal inbox" FontSize="17" FontWeight="Bold" />
                 <Border Grid.Column="1" Background="#E1F2F8" CornerRadius="10" Padding="8,3">
-                  <TextBlock Text="{Binding SourceImportProposals.Count}" Foreground="#0B5D8B" FontWeight="Bold" FontSize="11" />
+                  <TextBlock Text="{Binding SourceImportProposals.Count}" Foreground="#5A4ECC" FontWeight="Bold" FontSize="11" />
                 </Border>
               </Grid>
               <TextBlock Text="{Binding SourceDiscoverySummary}" Classes="muted" FontSize="11" TextWrapping="Wrap" />
@@ -94,7 +94,7 @@
           <ListBox Grid.Row="2"
                    ItemsSource="{Binding SourceImportProposals}"
                    SelectedItem="{Binding SelectedSourceProposal}"
-                   Background="#F7FBFD">
+                   Background="#FAFAFD">
             <ListBox.ItemTemplate>
               <DataTemplate x:DataType="models:SourceImportProposal">
                 <Border Background="White"
@@ -221,7 +221,7 @@
                     <DataTemplate x:DataType="models:IntegrationStatusCard">
                       <Grid ColumnDefinitions="120,110,*" ColumnSpacing="10" Margin="0,3">
                         <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
-                        <TextBlock Grid.Column="1" Text="{Binding State}" Foreground="#0B5D8B" />
+                        <TextBlock Grid.Column="1" Text="{Binding State}" Foreground="#5A4ECC" />
                         <TextBlock Grid.Column="2" Text="{Binding Summary}" Classes="muted" TextTrimming="CharacterEllipsis" />
                       </Grid>
                     </DataTemplate>
@@ -231,7 +231,7 @@
             </StackPanel>
           </ScrollViewer>
 
-          <Border Grid.Row="2" Background="#082941" Padding="14,10">
+          <Border Grid.Row="2" Background="#202238" Padding="14,10">
             <TextBlock Text="{Binding IntegrationMessage}" Foreground="#C9E4EF" TextWrapping="Wrap" />
           </Border>
         </Grid>

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -6,8 +6,8 @@
              xmlns:views="using:Blueprints.App.Views.Components"
              x:Class="Blueprints.App.Views.Components.OverviewView"
              x:DataType="vm:MainWindowViewModel">
-  <Grid RowDefinitions="58,*">
-    <Border Background="#071F34" BorderBrush="#285E7D" BorderThickness="0,0,0,1" Padding="14,9">
+  <Grid RowDefinitions="64,*">
+    <Border Background="#FFFFFF" BorderBrush="#E2E4EC" BorderThickness="0,0,0,1" Padding="16,11">
       <Grid ColumnDefinitions="Auto,18,Auto,*,Auto" ColumnSpacing="8">
         <StackPanel Orientation="Horizontal" Spacing="7">
           <Button Classes="tool active" Content="↖ Select" />
@@ -22,7 +22,7 @@
           <Button Classes="tool" Content="⌁ Work item" Command="{Binding BeginNewItemCommand}" IsEnabled="{Binding CanEditItems}" />
         </StackPanel>
 
-        <Border Grid.Column="1" Width="1" Background="#285E7D" Margin="8,0" />
+        <Border Grid.Column="1" Width="1" Background="#E2E4EC" Margin="8,0" />
 
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
           <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl+Z)" />
@@ -36,11 +36,11 @@
         </StackPanel>
 
         <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-          <Border Background="#0C3859" BorderBrush="#2E6A8D" BorderThickness="1" CornerRadius="6" Padding="10,4"
+          <Border Background="#F0EEFF" BorderBrush="#D5D0F6" BorderThickness="1" CornerRadius="9" Padding="10,5"
                   ToolTip.Tip="{Binding AdaptiveGuidanceDetail}">
             <StackPanel MaxWidth="300">
-              <TextBlock Text="NEXT BEST ACTION" Foreground="#60D1ED" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
-              <TextBlock Text="{Binding AdaptiveGuidanceTitle}" Foreground="#E4F3F8" FontSize="11" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
+              <TextBlock Text="NEXT STEP" Foreground="#6B5CE7" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
+              <TextBlock Text="{Binding AdaptiveGuidanceTitle}" Foreground="#37324E" FontSize="11" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
             </StackPanel>
           </Border>
           <Button Classes="tool" Content="↻ Refresh" Command="{Binding RefreshWorkspaceCommand}" />
@@ -52,11 +52,11 @@
       <views:BlueprintCanvasSurface x:Name="BlueprintSurface" />
 
       <Border Grid.Column="1"
-              Background="#F7FBFD"
-              BorderBrush="#9FC5D8"
+              Background="#FFFFFF"
+              BorderBrush="#E2E4EC"
               BorderThickness="1,0,0,0">
         <Grid RowDefinitions="Auto,*,Auto">
-          <Border Background="#E8F3F8" BorderBrush="#B8D5E3" BorderThickness="0,0,0,1" Padding="16,12">
+          <Border Background="#FAFAFD" BorderBrush="#E2E4EC" BorderThickness="0,0,0,1" Padding="16,12">
             <StackPanel Spacing="3">
               <TextBlock Classes="eyebrow" Text="NODE INSPECTOR" />
               <TextBlock Text="{Binding InspectorSelectionSummary}" Classes="mono" FontWeight="Bold" FontSize="12" />
@@ -239,16 +239,16 @@
             </StackPanel>
           </ScrollViewer>
 
-          <Border Grid.Row="2" Background="#0A2C47" Padding="14,11">
+          <Border Grid.Row="2" Background="#202238" Padding="14,11">
             <StackPanel Spacing="4">
               <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
-              <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#6DD6EF" FontSize="10" />
+              <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#B8B2F4" FontSize="10" />
               <TextBlock x:Name="CanvasSelectionSummary"
-                         Foreground="#D7EEF7"
+                         Foreground="#F1F0FF"
                          FontSize="10"
                          FontWeight="Bold" />
               <TextBlock Text="Drag empty space to box-select · Ctrl/Shift-click adds nodes · arrows move · Shift+arrows move 10px · Ctrl+A selects all · Esc clears"
-                         Foreground="#8FBAD0"
+                         Foreground="#A6A8BA"
                          FontSize="10"
                          TextWrapping="Wrap" />
             </StackPanel>

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -4,6 +4,7 @@
              xmlns:models="using:Blueprints.App.Models"
              xmlns:core="using:Blueprints.Core.Models"
              xmlns:views="using:Blueprints.App.Views.Components"
+             xmlns:automation="using:Avalonia.Automation"
              x:Class="Blueprints.App.Views.Components.OverviewView"
              x:DataType="vm:MainWindowViewModel">
   <Grid RowDefinitions="64,*">
@@ -25,10 +26,10 @@
         <Border Grid.Column="1" Width="1" Background="#E2E4EC" Margin="8,0" />
 
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
-          <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl+Z)" />
-          <Button x:Name="RedoButton" Classes="tool square" Content="↷" Click="RedoClick" ToolTip.Tip="Redo layout change (Ctrl+Shift+Z or Ctrl+Y)" />
-          <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" />
-          <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" />
+          <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl+Z)" automation:AutomationProperties.Name="Undo layout change" />
+          <Button x:Name="RedoButton" Classes="tool square" Content="↷" Click="RedoClick" ToolTip.Tip="Redo layout change (Ctrl+Shift+Z or Ctrl+Y)" automation:AutomationProperties.Name="Redo layout change" />
+          <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" automation:AutomationProperties.Name="Zoom out" />
+          <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" automation:AutomationProperties.Name="Zoom in" />
           <Button Classes="tool" Content="Fit view" Click="FitViewClick" />
           <Button Classes="tool" Content="Auto arrange" Click="AutoArrangeClick" IsEnabled="{Binding CanMutateWorkspace}" />
           <Button Classes="tool" Content="Save layout" Click="SaveLayoutClick" IsEnabled="{Binding CanMutateWorkspace}" />

--- a/Blueprints.App/Views/Components/ReleasePlannerView.axaml
+++ b/Blueprints.App/Views/Components/ReleasePlannerView.axaml
@@ -22,8 +22,8 @@
                 <StackPanel Spacing="6">
                   <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Classes="mono" Text="{Binding Name}" FontSize="17" FontWeight="Bold" />
-                    <Border Grid.Column="1" Background="#DDEFF8" CornerRadius="10" Padding="8,3">
-                      <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#0B4F8A" />
+                    <Border Grid.Column="1" Background="#EAE7FF" CornerRadius="10" Padding="8,3">
+                      <TextBlock Text="{Binding Status}" FontSize="11" Foreground="#5A4ECC" />
                     </Border>
                   </Grid>
                   <TextBlock Text="{Binding Notes}" Classes="muted" TextWrapping="Wrap" MaxHeight="44" />
@@ -112,7 +112,7 @@
               </Border>
             </Grid>
 
-            <Border Grid.Row="2" Background="#F3F9FC" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="12">
+            <Border Grid.Row="2" Background="#FAFAFD" BorderBrush="#E2E4EC" BorderThickness="1" CornerRadius="10" Padding="12">
               <StackPanel Spacing="6">
                 <TextBlock Classes="eyebrow" Text="SOURCE TRACE" />
                 <TextBlock Text="{Binding VersionSourceChangeSummary}" Classes="muted" TextWrapping="Wrap" />
@@ -147,17 +147,17 @@
             <ItemsControl ItemsSource="{Binding ReleaseReadinessDiagnostics}">
               <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="models:ReleaseReadinessDiagnostic">
-                  <Border Background="#F3F9FC"
-                          BorderBrush="#BED8E8"
+                  <Border Background="#FAFAFD"
+                          BorderBrush="#E2E4EC"
                           BorderThickness="1"
-                          CornerRadius="4"
+                          CornerRadius="10"
                           Padding="11"
                           Margin="0,0,0,6">
                     <Grid ColumnDefinitions="90,220,*,*" ColumnSpacing="10">
                       <TextBlock Text="{Binding Level}" Classes="eyebrow" VerticalAlignment="Top" />
                       <TextBlock Grid.Column="1" Text="{Binding Title}" FontWeight="Bold" TextWrapping="Wrap" />
                       <TextBlock Grid.Column="2" Text="{Binding Detail}" Classes="muted" TextWrapping="Wrap" />
-                      <TextBlock Grid.Column="3" Text="{Binding Guidance}" Foreground="#0B5D8B" TextWrapping="Wrap" />
+                      <TextBlock Grid.Column="3" Text="{Binding Guidance}" Foreground="#5A4ECC" TextWrapping="Wrap" />
                     </Grid>
                   </Border>
                 </DataTemplate>
@@ -225,7 +225,7 @@
                                       HorizontalContentAlignment="Stretch"
                                       Margin="0,0,0,6">
                                 <Grid ColumnDefinitions="92,*,Auto" ColumnSpacing="10">
-                                  <TextBlock Classes="mono" Text="{Binding ItemKey}" FontWeight="Bold" Foreground="#0B4F8A" />
+                                  <TextBlock Classes="mono" Text="{Binding ItemKey}" FontWeight="Bold" Foreground="#5A4ECC" />
                                   <StackPanel Grid.Column="1" Spacing="2">
                                     <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
                                     <TextBlock Text="{Binding Description}" Classes="muted" FontSize="11" TextTrimming="CharacterEllipsis" />

--- a/Blueprints.App/Views/Components/SetupView.axaml
+++ b/Blueprints.App/Views/Components/SetupView.axaml
@@ -4,248 +4,315 @@
              xmlns:models="using:Blueprints.App.Models"
              x:Class="Blueprints.App.Views.Components.SetupView"
              x:DataType="vm:MainWindowViewModel">
-  <ScrollViewer>
-    <Grid Margin="32" RowDefinitions="Auto,Auto,*" RowSpacing="24">
-      <Grid ColumnDefinitions="1.15*,0.85*" ColumnSpacing="28">
-        <StackPanel Spacing="10" VerticalAlignment="Center">
-          <TextBlock Classes="eyebrow" Text="BLUEPRINT  /  PROJECT ORIGIN" />
-          <TextBlock Text="Turn release intent into a trusted plan."
-                     FontSize="38"
-                     FontWeight="Black"
-                     MaxWidth="720"
-                     TextWrapping="Wrap" />
-          <TextBlock Text="Start with a local source of truth, connect a separate exchange location, then move through the project map one explicit step at a time."
-                     Classes="muted"
-                     FontSize="16"
-                     MaxWidth="720"
-                     TextWrapping="Wrap" />
-          <Border Background="#E2F2FA" BorderBrush="#8BC4DF" BorderThickness="1,0,0,0" Padding="14,10" Margin="0,8,0,0">
-            <TextBlock Text="{Binding SetupMessage}" TextWrapping="Wrap" Foreground="#214A64" />
+  <Grid ColumnDefinitions="360,*" Background="#F6F7FB">
+    <Border Background="#191A2C" Padding="36">
+      <Grid RowDefinitions="Auto,*,Auto">
+        <StackPanel Orientation="Horizontal" Spacing="12">
+          <Border Width="44" Height="44" CornerRadius="13" Background="#6B5CE7">
+            <TextBlock Text="B" Foreground="White" FontSize="21" FontWeight="Bold"
+                       HorizontalAlignment="Center" VerticalAlignment="Center" />
           </Border>
+          <StackPanel VerticalAlignment="Center" Spacing="1">
+            <TextBlock Text="Blueprints" Foreground="White" FontSize="19" FontWeight="Bold" />
+            <TextBlock Text="Plan releases with confidence" Foreground="#9295A8" FontSize="11" />
+          </StackPanel>
         </StackPanel>
 
-        <Border Grid.Column="1" Classes="dark-card">
-          <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="16">
-            <TextBlock Classes="eyebrow" Text="HOW THE MAP WORKS" Foreground="#62D3F0" />
-            <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto,*,Auto" VerticalAlignment="Center">
-              <Border Width="40" Height="40" CornerRadius="20" Background="#168AD0">
-                <TextBlock Text="01" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
+        <StackPanel Grid.Row="1" VerticalAlignment="Center" Spacing="18">
+          <TextBlock Text="From rough ideas to clear release notes."
+                     Foreground="White"
+                     FontSize="35"
+                     FontWeight="Bold"
+                     LetterSpacing="-0.7"
+                     TextWrapping="Wrap" />
+          <TextBlock Text="Keep every version, task, and decision together—without needing an account or learning a complicated system."
+                     Foreground="#B7B9C8"
+                     FontSize="15"
+                     LineHeight="23"
+                     TextWrapping="Wrap" />
+
+          <StackPanel Spacing="14" Margin="0,14,0,0">
+            <Grid ColumnDefinitions="34,*">
+              <Border Width="26" Height="26" CornerRadius="13" Background="#373455">
+                <TextBlock Text="1" Foreground="#DCD8FF" FontWeight="Bold" FontSize="11"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" />
               </Border>
-              <Border Grid.Column="1" Height="1" Background="#39779D" Margin="8,0" />
-              <Border Grid.Column="2" Width="40" Height="40" CornerRadius="20" Background="#168AD0">
-                <TextBlock Text="02" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
-              </Border>
-              <Border Grid.Column="3" Height="1" Background="#39779D" Margin="8,0" />
-              <Border Grid.Column="4" Width="40" Height="40" CornerRadius="20" Background="#168AD0">
-                <TextBlock Text="03" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
-              </Border>
-            </Grid>
-            <Grid Grid.Row="2" ColumnDefinitions="*,*,*" ColumnSpacing="12">
-              <StackPanel Spacing="3">
-                <TextBlock Text="Draft" Foreground="White" FontWeight="Bold" />
-                <TextBlock Text="Plan versions and work." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
-              </StackPanel>
-              <StackPanel Grid.Column="1" Spacing="3">
-                <TextBlock Text="Verify" Foreground="White" FontWeight="Bold" />
-                <TextBlock Text="Review trust and source." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
-              </StackPanel>
-              <StackPanel Grid.Column="2" Spacing="3">
-                <TextBlock Text="Record" Foreground="White" FontWeight="Bold" />
-                <TextBlock Text="Freeze accomplishments." Foreground="#A9C8DC" FontSize="12" TextWrapping="Wrap" />
+              <StackPanel Grid.Column="1" Spacing="2">
+                <TextBlock Text="Create or open a project" Foreground="White" FontWeight="SemiBold" />
+                <TextBlock Text="Everything stays in folders you control." Foreground="#9295A8" FontSize="11" />
               </StackPanel>
             </Grid>
-          </Grid>
-        </Border>
-      </Grid>
-
-      <Grid Grid.Row="1" ColumnDefinitions="1.1*,0.9*" RowDefinitions="Auto,Auto" ColumnSpacing="20" RowSpacing="20">
-        <Border Grid.ColumnSpan="2" Classes="card">
-          <Grid ColumnDefinitions="1.2*,1*,Auto,Auto" ColumnSpacing="12">
-            <StackPanel Spacing="3">
-              <TextBlock Classes="eyebrow" Text="LOCAL SIGNING IDENTITY" />
-              <TextBlock Text="{Binding LocalIdentitySetupSummary}" Classes="muted" TextWrapping="Wrap" />
-            </StackPanel>
-            <TextBox Grid.Column="1"
-                     PlaceholderText="Display name for signed changes"
-                     Text="{Binding IdentitySetupName}"
-                     IsEnabled="{Binding IsIdentitySetupRequired}" />
-            <Button Grid.Column="2"
-                    Classes="primary"
-                    Content="Create identity"
-                    Command="{Binding CreateLocalIdentityCommand}"
-                    IsEnabled="{Binding IsIdentitySetupRequired}" />
-            <Button Grid.Column="3"
-                    Classes="secondary"
-                    Content="Export identity invite…"
-                    Click="ExportSetupIdentityInvitation_Click"
-                    IsEnabled="{Binding HasLocalIdentity}" />
-          </Grid>
-        </Border>
-
-        <Border Grid.Row="1" Classes="card">
-          <StackPanel Spacing="14">
-            <StackPanel Spacing="3">
-              <TextBlock Classes="eyebrow" Text="NEW PROJECT" />
-              <TextBlock Text="Draw a fresh blueprint" FontSize="22" FontWeight="Bold" />
-              <TextBlock Text="The local workspace is editable. The exchange folder is treated as untrusted input until validation succeeds."
-                         Classes="muted"
-                         TextWrapping="Wrap" />
-            </StackPanel>
-
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
-              <StackPanel Spacing="5">
-                <TextBlock Text="Project name" FontWeight="SemiBold" />
-                <TextBox Text="{Binding CreateProjectName}" />
-              </StackPanel>
-              <StackPanel Grid.Column="1" Spacing="5">
-                <TextBlock Text="Project code" FontWeight="SemiBold" />
-                <TextBox Text="{Binding CreateProjectCode}" />
+            <Grid ColumnDefinitions="34,*">
+              <Border Width="26" Height="26" CornerRadius="13" Background="#373455">
+                <TextBlock Text="2" Foreground="#DCD8FF" FontWeight="Bold" FontSize="11"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+              </Border>
+              <StackPanel Grid.Column="1" Spacing="2">
+                <TextBlock Text="Plan what ships next" Foreground="White" FontWeight="SemiBold" />
+                <TextBlock Text="Turn work into readable release notes." Foreground="#9295A8" FontSize="11" />
               </StackPanel>
             </Grid>
-
-            <StackPanel Spacing="5">
-              <TextBlock Text="Versioning scheme" FontWeight="SemiBold" />
-              <TextBox Text="{Binding CreateVersioningScheme}" />
-            </StackPanel>
-
-            <StackPanel Spacing="5">
-              <TextBlock Text="Local workspace · editable source" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding CreateLocalWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateLocal_Click" />
-              </Grid>
-            </StackPanel>
-
-            <StackPanel Spacing="5">
-              <TextBlock Text="Shared exchange · team handoff" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding CreateSharedWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateShared_Click" />
-              </Grid>
-            </StackPanel>
-
-            <Button Classes="primary"
-                    Content="Create signed project  →"
-                    Command="{Binding CreateProjectCommand}"
-                    HorizontalAlignment="Left" />
+            <Grid ColumnDefinitions="34,*">
+              <Border Width="26" Height="26" CornerRadius="13" Background="#373455">
+                <TextBlock Text="3" Foreground="#DCD8FF" FontWeight="Bold" FontSize="11"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+              </Border>
+              <StackPanel Grid.Column="1" Spacing="2">
+                <TextBlock Text="Share safely when ready" Foreground="White" FontWeight="SemiBold" />
+                <TextBlock Text="Every incoming change is checked first." Foreground="#9295A8" FontSize="11" />
+              </StackPanel>
+            </Grid>
           </StackPanel>
-        </Border>
+        </StackPanel>
 
-        <Border Grid.Row="1" Grid.Column="1" Classes="card">
-          <StackPanel Spacing="14">
-            <StackPanel Spacing="3">
-              <TextBlock Classes="eyebrow" Text="EXISTING PROJECT" />
-              <TextBlock Text="Continue from a known workspace" FontSize="22" FontWeight="Bold" />
-              <TextBlock Text="Both locations are shown before opening so the trust boundary stays visible."
-                         Classes="muted"
-                         TextWrapping="Wrap" />
-            </StackPanel>
+        <TextBlock Grid.Row="2"
+                   Text="Local-first  •  No hosted account required"
+                   Foreground="#747789"
+                   FontSize="11" />
+      </Grid>
+    </Border>
 
-            <StackPanel Spacing="5">
-              <TextBlock Text="Local workspace" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding OpenLocalWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenLocal_Click" />
-              </Grid>
-            </StackPanel>
+    <ScrollViewer Grid.Column="1">
+      <StackPanel Margin="40,32" Spacing="22" MaxWidth="930" HorizontalAlignment="Center">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+          <StackPanel Spacing="4">
+            <TextBlock Text="Welcome" Classes="page-title" />
+            <TextBlock Text="Choose what you want to do. Blueprints will validate the details before opening anything."
+                       Classes="muted"
+                       FontSize="14"
+                       TextWrapping="Wrap" />
+          </StackPanel>
+          <Border Grid.Column="1"
+                  Classes="success"
+                  VerticalAlignment="Center"
+                  IsVisible="{Binding HasSetupMessage}">
+            <TextBlock Text="{Binding SetupMessage}" Foreground="#216D60" FontSize="11" TextWrapping="Wrap" MaxWidth="310" />
+          </Border>
+        </Grid>
 
-            <StackPanel Spacing="5">
-              <TextBlock Text="Shared exchange" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding OpenSharedWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenShared_Click" />
-              </Grid>
-            </StackPanel>
-
-            <Button Classes="primary"
-                    Content="Open and validate  →"
-                    Command="{Binding OpenProjectCommand}"
-                    HorizontalAlignment="Left" />
-
-            <Border Background="#F5FAFD" BorderBrush="#BED8E8" BorderThickness="1" CornerRadius="4" Padding="12">
-              <StackPanel Spacing="4">
-                <TextBlock Text="Validation gate" FontWeight="Bold" />
-                <TextBlock Text="Signed content is checked before editing is enabled. Invalid or incomplete state opens read-only."
-                           Classes="muted"
-                           TextWrapping="Wrap" />
-              </StackPanel>
+        <Border Classes="card">
+          <Grid ColumnDefinitions="Auto,*,220,Auto" ColumnSpacing="14">
+            <Border Width="42" Height="42" CornerRadius="21" Background="#EAE7FF" VerticalAlignment="Center">
+              <TextBlock Text="ID" Foreground="#5A4ECC" FontSize="10" FontWeight="Bold"
+                         HorizontalAlignment="Center" VerticalAlignment="Center" />
             </Border>
-
-            <Border Height="1" Background="#BED8E8" Margin="0,4" />
-            <StackPanel Spacing="3">
-              <TextBlock Classes="eyebrow" Text="JOIN A TEAM PROJECT" />
-              <TextBlock Text="Use a signed project invitation" FontSize="18" FontWeight="Bold" />
-              <TextBlock Text="The invitation anchors the administrator and member keys before any shared content enters the local workspace."
-                         Classes="muted"
-                         TextWrapping="Wrap" />
+            <StackPanel Grid.Column="1" Spacing="3" VerticalAlignment="Center">
+              <TextBlock Text="Your signing identity" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding LocalIdentitySetupSummary}" Classes="muted" FontSize="12" TextWrapping="Wrap" />
             </StackPanel>
-            <StackPanel Spacing="5">
-              <TextBlock Text="Project invitation" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding JoinInvitationFilePath}" IsReadOnly="True" />
-                <Button Grid.Column="1" Classes="secondary" Content="Choose…" Click="BrowseJoinInvitation_Click" />
-              </Grid>
+            <Grid Grid.Column="2">
+              <TextBox PlaceholderText="Your display name"
+                       Text="{Binding IdentitySetupName}"
+                       IsVisible="{Binding IsIdentitySetupRequired}" />
+              <TextBox PlaceholderText="Backup passphrase (12+ characters)"
+                       Text="{Binding IdentityBackupPassphrase}"
+                       PasswordChar="●"
+                       IsVisible="{Binding HasLocalIdentity}" />
+            </Grid>
+            <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8">
+              <Button Classes="primary"
+                      Content="Create identity"
+                      Command="{Binding CreateLocalIdentityCommand}"
+                      IsEnabled="{Binding IsIdentitySetupRequired}" />
+              <Button Classes="secondary compact"
+                      Content="Back up…"
+                      Click="ExportIdentityBackup_Click"
+                      IsVisible="{Binding HasLocalIdentity}" />
+              <Button Classes="secondary compact"
+                      Content="Restore backup…"
+                      Click="ImportIdentityBackup_Click"
+                      IsVisible="{Binding IsIdentitySetupRequired}" />
             </StackPanel>
-            <StackPanel Spacing="5">
-              <TextBlock Text="New empty local workspace" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding JoinLocalWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinLocal_Click" />
-              </Grid>
-            </StackPanel>
-            <StackPanel Spacing="5">
-              <TextBlock Text="Shared exchange override (optional)" FontWeight="SemiBold" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBox Text="{Binding JoinSharedWorkspaceRoot}" />
-                <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinShared_Click" />
-              </Grid>
-            </StackPanel>
-            <Button Classes="primary"
-                    Content="Validate invitation and join  →"
-                    Command="{Binding JoinProjectCommand}"
-                    HorizontalAlignment="Left" />
-          </StackPanel>
-        </Border>
-      </Grid>
-
-      <Border Grid.Row="2" Classes="card">
-        <Grid RowDefinitions="Auto,*" RowSpacing="12">
-          <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Classes="eyebrow" Text="RECENT WORKSPACES" />
-              <TextBlock Text="Resume a saved project map" FontSize="20" FontWeight="Bold" />
-            </StackPanel>
-            <Button Grid.Column="1"
-                    Classes="primary"
-                    Content="Open selected"
-                    Command="{Binding OpenSelectedRecentProjectCommand}" />
           </Grid>
-          <ListBox Grid.Row="1"
-                   ItemsSource="{Binding RecentProjects}"
-                   SelectedItem="{Binding SelectedRecentProject}"
-                   MaxHeight="220">
-            <ListBox.ItemsPanel>
-              <ItemsPanelTemplate>
-                <WrapPanel />
-              </ItemsPanelTemplate>
-            </ListBox.ItemsPanel>
-            <ListBox.ItemTemplate>
-              <DataTemplate x:DataType="models:RecentProjectReference">
-                <Border Classes="blueprint-card" Width="300" Margin="0,0,10,10">
+        </Border>
+
+        <TabControl>
+          <TabItem Header="Start a new project">
+            <Border Classes="card" Margin="0,12,0,0">
+              <Grid ColumnDefinitions="1.15*,0.85*" ColumnSpacing="28">
+                <StackPanel Spacing="14">
+                  <StackPanel Spacing="4">
+                    <TextBlock Text="Start something new" Classes="section-title" />
+                    <TextBlock Text="Give the project a friendly name. Short codes keep release item IDs easy to scan."
+                               Classes="muted" TextWrapping="Wrap" />
+                  </StackPanel>
+                  <Grid ColumnDefinitions="1.4*,0.6*" ColumnSpacing="10">
+                    <StackPanel Spacing="5">
+                      <TextBlock Text="Project name" FontWeight="SemiBold" />
+                      <TextBox Text="{Binding CreateProjectName}" PlaceholderText="Mobile app" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Spacing="5">
+                      <TextBlock Text="Short code" FontWeight="SemiBold" />
+                      <TextBox Text="{Binding CreateProjectCode}" PlaceholderText="APP" />
+                    </StackPanel>
+                  </Grid>
                   <StackPanel Spacing="5">
-                    <Grid ColumnDefinitions="*,Auto">
-                      <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="16" />
-                      <TextBlock Grid.Column="1" Classes="mono" Text="{Binding ProjectCode}" Foreground="#168AD0" />
+                    <TextBlock Text="How do you name releases?" FontWeight="SemiBold" />
+                    <TextBox Text="{Binding CreateVersioningScheme}" PlaceholderText="Semantic versions, e.g. 1.2.0" />
+                  </StackPanel>
+                  <Button Classes="primary"
+                          Content="Create project  →"
+                          Command="{Binding CreateProjectCommand}"
+                          HorizontalAlignment="Left"
+                          IsEnabled="{Binding HasLocalIdentity}" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Spacing="14">
+                  <Border Classes="callout">
+                    <StackPanel Spacing="4">
+                      <TextBlock Text="Where your files live" FontWeight="SemiBold" Foreground="#5145C7" />
+                      <TextBlock Text="The local folder is your editable copy. The shared folder is only for exchanging changes with teammates."
+                                 Foreground="#656079" FontSize="12" TextWrapping="Wrap" />
+                    </StackPanel>
+                  </Border>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Local project folder" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding CreateLocalWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateLocal_Click" />
                     </Grid>
-                    <TextBlock Text="{Binding LocalWorkspaceRoot}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
-                    <TextBlock Text="{Binding LastOpenedUtc, StringFormat='Last opened {0:g}'}" Classes="muted" FontSize="11" />
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Shared folder" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding CreateSharedWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseCreateShared_Click" />
+                    </Grid>
+                  </StackPanel>
+                </StackPanel>
+              </Grid>
+            </Border>
+          </TabItem>
+
+          <TabItem Header="Open a project">
+            <Border Classes="card" Margin="0,12,0,0">
+              <Grid ColumnDefinitions="1.05*,0.95*" ColumnSpacing="28">
+                <StackPanel Spacing="14">
+                  <StackPanel Spacing="4">
+                    <TextBlock Text="Open an existing project" Classes="section-title" />
+                    <TextBlock Text="Choose your editable project folder and its matching shared folder."
+                               Classes="muted" TextWrapping="Wrap" />
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Local project folder" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding OpenLocalWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenLocal_Click" />
+                    </Grid>
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Shared folder" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding OpenSharedWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseOpenShared_Click" />
+                    </Grid>
+                  </StackPanel>
+                  <Button Classes="primary"
+                          Content="Validate and open  →"
+                          Command="{Binding OpenProjectCommand}"
+                          HorizontalAlignment="Left"
+                          IsEnabled="{Binding HasLocalIdentity}" />
+                </StackPanel>
+                <Border Grid.Column="1" Classes="callout" VerticalAlignment="Top">
+                  <StackPanel Spacing="8">
+                    <TextBlock Text="Your project is checked before it opens" FontWeight="SemiBold" Foreground="#5145C7" />
+                    <TextBlock Text="Blueprints verifies the project files, signatures, membership, and change history. If something looks wrong, the project opens safely in read-only mode."
+                               Foreground="#656079" FontSize="12" TextWrapping="Wrap" />
                   </StackPanel>
                 </Border>
-              </DataTemplate>
-            </ListBox.ItemTemplate>
-          </ListBox>
-        </Grid>
-      </Border>
-    </Grid>
-  </ScrollViewer>
+              </Grid>
+            </Border>
+          </TabItem>
+
+          <TabItem Header="Join a team">
+            <Border Classes="card" Margin="0,12,0,0">
+              <Grid ColumnDefinitions="1.05*,0.95*" ColumnSpacing="28">
+                <StackPanel Spacing="14">
+                  <StackPanel Spacing="4">
+                    <TextBlock Text="Join with an invitation" Classes="section-title" />
+                    <TextBlock Text="Ask a project administrator for a Blueprints invitation file, then choose an empty folder for your local copy."
+                               Classes="muted" TextWrapping="Wrap" />
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Invitation file" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding JoinInvitationFilePath}" IsReadOnly="True" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Choose…" Click="BrowseJoinInvitation_Click" />
+                    </Grid>
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="New local project folder" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding JoinLocalWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinLocal_Click" />
+                    </Grid>
+                  </StackPanel>
+                  <StackPanel Spacing="5">
+                    <TextBlock Text="Different shared folder (optional)" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                      <TextBox Text="{Binding JoinSharedWorkspaceRoot}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Browse…" Click="BrowseJoinShared_Click" />
+                    </Grid>
+                  </StackPanel>
+                  <Button Classes="primary"
+                          Content="Check invitation and join  →"
+                          Command="{Binding JoinProjectCommand}"
+                          HorizontalAlignment="Left"
+                          IsEnabled="{Binding HasLocalIdentity}" />
+                </StackPanel>
+                <Border Grid.Column="1" Classes="callout" VerticalAlignment="Top">
+                  <StackPanel Spacing="8">
+                    <TextBlock Text="Why an invitation file?" FontWeight="SemiBold" Foreground="#5145C7" />
+                    <TextBlock Text="It lets Blueprints recognize the correct project and administrator before reading anything from the shared folder."
+                               Foreground="#656079" FontSize="12" TextWrapping="Wrap" />
+                  </StackPanel>
+                </Border>
+              </Grid>
+            </Border>
+          </TabItem>
+        </TabControl>
+
+        <Border Classes="card">
+          <Grid RowDefinitions="Auto,*" RowSpacing="12">
+            <Grid ColumnDefinitions="*,Auto">
+              <StackPanel Spacing="3">
+                <TextBlock Text="Recent projects" Classes="section-title" />
+                <TextBlock Text="Pick up where you left off." Classes="muted" />
+              </StackPanel>
+              <Button Grid.Column="1"
+                      Classes="primary"
+                      Content="Open selected"
+                      Command="{Binding OpenSelectedRecentProjectCommand}" />
+            </Grid>
+            <ListBox Grid.Row="1"
+                     ItemsSource="{Binding RecentProjects}"
+                     SelectedItem="{Binding SelectedRecentProject}"
+                     MaxHeight="210">
+              <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <WrapPanel />
+                </ItemsPanelTemplate>
+              </ListBox.ItemsPanel>
+              <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="models:RecentProjectReference">
+                  <Border Classes="blueprint-card" Width="275" Margin="0,0,10,10">
+                    <StackPanel Spacing="6">
+                      <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="15" />
+                        <Border Grid.Column="1" Background="#EAE7FF" CornerRadius="8" Padding="7,2">
+                          <TextBlock Classes="mono" Text="{Binding ProjectCode}" Foreground="#5A4ECC" FontSize="10" />
+                        </Border>
+                      </Grid>
+                      <TextBlock Text="{Binding LocalWorkspaceRoot}" Classes="mono muted" FontSize="10" TextTrimming="CharacterEllipsis" />
+                      <TextBlock Text="{Binding LastOpenedUtc, StringFormat='Last opened {0:g}'}" Classes="muted" FontSize="10" />
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Border>
+      </StackPanel>
+    </ScrollViewer>
+  </Grid>
 </UserControl>

--- a/Blueprints.App/Views/Components/SetupView.axaml.cs
+++ b/Blueprints.App/Views/Components/SetupView.axaml.cs
@@ -106,6 +106,74 @@ public partial class SetupView : UserControl
         }
     }
 
+    private async void ExportIdentityBackup_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = "Create encrypted identity backup",
+                SuggestedFileName = "identity.blueprints-backup.json",
+                FileTypeChoices =
+                [
+                    new FilePickerFileType("Blueprints encrypted identity backup")
+                    {
+                        Patterns = ["*.blueprints-backup.json"],
+                    },
+                ],
+            });
+        if (file?.TryGetLocalPath() is { } path)
+        {
+            viewModel.ExportIdentityBackupCommand.Execute(path);
+        }
+    }
+
+    private async void ImportIdentityBackup_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = "Restore encrypted identity backup",
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    new FilePickerFileType("Blueprints encrypted identity backup")
+                    {
+                        Patterns = ["*.blueprints-backup.json"],
+                    },
+                ],
+            });
+        if (files.FirstOrDefault()?.TryGetLocalPath() is { } path)
+        {
+            viewModel.ImportIdentityBackupCommand.Execute(path);
+        }
+    }
+
     private async Task<string?> PickInvitationAsync()
     {
         var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;

--- a/Blueprints.App/Views/Components/SyncView.axaml
+++ b/Blueprints.App/Views/Components/SyncView.axaml
@@ -8,27 +8,27 @@
     <StackPanel Spacing="16">
       <Border Classes="dark-card">
         <StackPanel Spacing="12">
-          <TextBlock Classes="eyebrow" Text="EXCHANGE CIRCUIT" Foreground="#62D3F0" />
+          <TextBlock Classes="eyebrow" Text="SHARED CHANGES" Foreground="#B8B2F4" />
           <TextBlock Text="{Binding SyncStatus}" FontSize="21" FontWeight="Bold" Foreground="White" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding SyncEvidenceSummary}" Foreground="#A9C8DC" FontSize="11" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#B9BBCB" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SyncEvidenceSummary}" Foreground="#B9BBCB" FontSize="11" TextWrapping="Wrap" />
 
           <Grid ColumnDefinitions="*,48,*" VerticalAlignment="Center" Margin="0,8">
-            <Border Background="#0F4F7A" BorderBrush="#3C88B5" BorderThickness="1" CornerRadius="4" Padding="10">
+            <Border Background="#2B2D48" BorderBrush="#464864" BorderThickness="1" CornerRadius="9" Padding="10">
               <StackPanel Spacing="3">
-                <TextBlock Text="LOCAL" Classes="eyebrow" Foreground="#62D3F0" />
+                <TextBlock Text="ON THIS DEVICE" Classes="eyebrow" Foreground="#B8B2F4" />
                 <TextBlock Text="{Binding Sync.PendingOutgoingChanges}" FontSize="28" FontWeight="Black" Foreground="White" />
-                <TextBlock Text="outgoing" Foreground="#A9C8DC" FontSize="11" />
+                <TextBlock Text="changes to share" Foreground="#B9BBCB" FontSize="11" />
               </StackPanel>
             </Border>
             <StackPanel Grid.Column="1" VerticalAlignment="Center">
-              <TextBlock Text="⇄" Foreground="#62D3F0" FontSize="26" HorizontalAlignment="Center" />
+              <TextBlock Text="⇄" Foreground="#B8B2F4" FontSize="26" HorizontalAlignment="Center" />
             </StackPanel>
-            <Border Grid.Column="2" Background="#0F4F7A" BorderBrush="#3C88B5" BorderThickness="1" CornerRadius="4" Padding="10">
+            <Border Grid.Column="2" Background="#2B2D48" BorderBrush="#464864" BorderThickness="1" CornerRadius="9" Padding="10">
               <StackPanel Spacing="3">
-                <TextBlock Text="SHARED" Classes="eyebrow" Foreground="#62D3F0" />
+                <TextBlock Text="FROM THE TEAM" Classes="eyebrow" Foreground="#B8B2F4" />
                 <TextBlock Text="{Binding Sync.PendingIncomingChanges}" FontSize="28" FontWeight="Black" Foreground="White" />
-                <TextBlock Text="incoming" Foreground="#A9C8DC" FontSize="11" />
+                <TextBlock Text="changes to review" Foreground="#B9BBCB" FontSize="11" />
               </StackPanel>
             </Border>
           </Grid>
@@ -94,7 +94,7 @@
           </ListBox.ItemTemplate>
         </ListBox>
 
-        <Border Grid.Row="2" Background="#E7F3F9" BorderBrush="#9AC7DE" BorderThickness="1" CornerRadius="4" Padding="12">
+        <Border Grid.Row="2" Background="#F0EEFF" BorderBrush="#D5D0F6" BorderThickness="1" CornerRadius="10" Padding="12">
           <StackPanel Spacing="8">
             <TextBlock Text="{Binding SelectedConflictSemanticSummary}" TextWrapping="Wrap" FontWeight="Bold" Foreground="#214A64" />
             <ItemsControl ItemsSource="{Binding ConflictFieldComparisons}">
@@ -116,7 +116,7 @@
           <StackPanel Spacing="6">
             <Grid ColumnDefinitions="Auto,*">
               <TextBlock Classes="eyebrow" Text="LOCAL COPY" />
-              <Border Grid.Column="1" Height="1" Background="#BED8E8" Margin="10,0,0,0" VerticalAlignment="Center" />
+              <Border Grid.Column="1" Height="1" Background="#E2E4EC" Margin="10,0,0,0" VerticalAlignment="Center" />
             </Grid>
             <TextBox Text="{Binding SelectedConflictLocalPreview}"
                      AcceptsReturn="True"
@@ -128,7 +128,7 @@
           <StackPanel Grid.Column="1" Spacing="6">
             <Grid ColumnDefinitions="Auto,*">
               <TextBlock Classes="eyebrow" Text="SHARED COPY" />
-              <Border Grid.Column="1" Height="1" Background="#BED8E8" Margin="10,0,0,0" VerticalAlignment="Center" />
+              <Border Grid.Column="1" Height="1" Background="#E2E4EC" Margin="10,0,0,0" VerticalAlignment="Center" />
             </Grid>
             <TextBox Text="{Binding SelectedConflictSharedPreview}"
                      AcceptsReturn="True"

--- a/Blueprints.App/Views/Components/TeamView.axaml
+++ b/Blueprints.App/Views/Components/TeamView.axaml
@@ -22,6 +22,19 @@
                     Content="Export identity invitation…"
                     Click="ExportIdentityInvitation_Click"
                     HorizontalAlignment="Left" />
+            <Border Height="1" Background="#3A3C55" Margin="0,5" />
+            <TextBlock Text="Recovery backup" Foreground="White" FontWeight="SemiBold" />
+            <TextBlock Text="Encrypt your signing key for disaster recovery. Store the passphrase somewhere else."
+                       Foreground="#B7B9C8"
+                       TextWrapping="Wrap"
+                       FontSize="12" />
+            <TextBox PlaceholderText="Backup passphrase (12+ characters)"
+                     Text="{Binding IdentityBackupPassphrase}"
+                     PasswordChar="●" />
+            <Button Classes="primary"
+                    Content="Create encrypted backup…"
+                    Click="ExportIdentityBackup_Click"
+                    HorizontalAlignment="Left" />
           </StackPanel>
         </Border>
 

--- a/Blueprints.App/Views/Components/TeamView.axaml.cs
+++ b/Blueprints.App/Views/Components/TeamView.axaml.cs
@@ -40,6 +40,21 @@ public partial class TeamView : UserControl
         }
     }
 
+    private async void ExportIdentityBackup_Click(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel viewModel &&
+            await PickSavePathAsync(
+                "Create encrypted identity backup",
+                "identity.blueprints-backup.json",
+                "Blueprints encrypted identity backup",
+                "*.blueprints-backup.json") is { } path)
+        {
+            viewModel.ExportIdentityBackupCommand.Execute(path);
+        }
+    }
+
     private async void ExportProjectInvitation_Click(
         object? sender,
         Avalonia.Interactivity.RoutedEventArgs e)

--- a/Blueprints.App/Views/Components/TrustView.axaml
+++ b/Blueprints.App/Views/Components/TrustView.axaml
@@ -8,13 +8,13 @@
     <StackPanel Spacing="16">
       <Border Classes="dark-card">
         <StackPanel Spacing="10">
-          <TextBlock Classes="eyebrow" Text="TRUST GATE" Foreground="#62D3F0" />
-          <Border Width="72" Height="72" CornerRadius="36" Background="#0F5E76" BorderBrush="#62D3F0" BorderThickness="2" HorizontalAlignment="Left">
+          <TextBlock Classes="eyebrow" Text="PROJECT SAFETY" Foreground="#B8B2F4" />
+          <Border Width="72" Height="72" CornerRadius="36" Background="#2D6F66" BorderBrush="#62D3BC" BorderThickness="2" HorizontalAlignment="Left">
             <TextBlock Text="✓" FontSize="32" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" />
           </Border>
           <TextBlock Text="{Binding TrustBadge}" FontSize="25" FontWeight="Black" Foreground="White" />
-          <TextBlock Text="{Binding TrustSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#A9C8DC" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding TrustSummary}" Foreground="#B9BBCB" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#B9BBCB" TextWrapping="Wrap" />
           <Button Classes="primary" Content="Run validation again" Command="{Binding RefreshWorkspaceCommand}" HorizontalAlignment="Left" />
         </StackPanel>
       </Border>
@@ -26,7 +26,7 @@
             <TextBlock Text="Editable local workspace" FontWeight="Bold" />
             <TextBlock Text="{Binding WorkspacePath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
           </StackPanel>
-          <Border Height="1" Background="#D5E6F0" />
+          <Border Height="1" Background="#E2E4EC" />
           <StackPanel Spacing="3">
             <TextBlock Text="Untrusted shared exchange" FontWeight="Bold" />
             <TextBlock Text="{Binding SharedSyncPath}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
@@ -49,11 +49,11 @@
             <DataTemplate x:DataType="models:TrustDiagnosticCard">
               <Border Classes="blueprint-card" Margin="0,0,0,9">
                 <Grid ColumnDefinitions="48,130,*" ColumnSpacing="12">
-                  <Border Width="34" Height="34" CornerRadius="17" Background="#DDEFF8" VerticalAlignment="Top">
-                    <TextBlock Text="◆" Foreground="#168AD0" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                  <Border Width="34" Height="34" CornerRadius="17" Background="#EAE7FF" VerticalAlignment="Top">
+                    <TextBlock Text="✓" Foreground="#5A4ECC" HorizontalAlignment="Center" VerticalAlignment="Center" />
                   </Border>
                   <StackPanel Grid.Column="1" Spacing="3">
-                    <TextBlock Text="{Binding Severity}" FontWeight="Bold" Foreground="#0B4F8A" />
+                    <TextBlock Text="{Binding Severity}" FontWeight="Bold" Foreground="#5A4ECC" />
                     <TextBlock Text="{Binding Area}" Classes="mono muted" FontSize="11" TextWrapping="Wrap" />
                   </StackPanel>
                   <StackPanel Grid.Column="2" Spacing="5">

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Blueprints.App.ViewModels"
         xmlns:views="using:Blueprints.App.Views.Components"
+        xmlns:automation="using:Avalonia.Automation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
@@ -67,7 +68,11 @@
 
         <StackPanel Grid.Row="2" Spacing="2">
           <TextBlock Text="WORKSPACE" Foreground="#747789" FontSize="10" FontWeight="SemiBold" Margin="12,0,0,7" />
-          <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Command="{Binding NavigateToOverviewCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsOverviewSelected}"
+                  Command="{Binding NavigateToOverviewCommand}"
+                  ToolTip.Tip="Home (Ctrl/Command+1)"
+                  automation:AutomationProperties.Name="Home">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="⌂" FontSize="16" VerticalAlignment="Center" />
               <StackPanel Grid.Column="1" Spacing="1">
@@ -76,7 +81,11 @@
               </StackPanel>
             </Grid>
           </Button>
-          <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Command="{Binding NavigateToReleasesCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsReleasesSelected}"
+                  Command="{Binding NavigateToReleasesCommand}"
+                  ToolTip.Tip="Plan releases (Ctrl/Command+2)"
+                  automation:AutomationProperties.Name="Plan releases">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="◫" FontSize="15" VerticalAlignment="Center" />
               <StackPanel Grid.Column="1" Spacing="1">
@@ -85,7 +94,11 @@
               </StackPanel>
             </Grid>
           </Button>
-          <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Command="{Binding NavigateToIntegrationsCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsIntegrationsSelected}"
+                  Command="{Binding NavigateToIntegrationsCommand}"
+                  ToolTip.Tip="Find work (Ctrl/Command+3)"
+                  automation:AutomationProperties.Name="Find work">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="⌕" FontSize="17" VerticalAlignment="Center" />
               <StackPanel Grid.Column="1" Spacing="1">
@@ -96,19 +109,31 @@
           </Button>
 
           <TextBlock Text="COLLABORATE" Foreground="#747789" FontSize="10" FontWeight="SemiBold" Margin="12,17,0,7" />
-          <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Command="{Binding NavigateToTeamCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsTeamSelected}"
+                  Command="{Binding NavigateToTeamCommand}"
+                  ToolTip.Tip="People (Ctrl/Command+4)"
+                  automation:AutomationProperties.Name="People">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="♙" FontSize="16" VerticalAlignment="Center" />
               <TextBlock Grid.Column="1" Text="People" FontWeight="SemiBold" VerticalAlignment="Center" />
             </Grid>
           </Button>
-          <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Command="{Binding NavigateToSyncCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsSyncSelected}"
+                  Command="{Binding NavigateToSyncCommand}"
+                  ToolTip.Tip="Share changes (Ctrl/Command+5)"
+                  automation:AutomationProperties.Name="Share changes">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="↕" FontSize="17" VerticalAlignment="Center" />
               <TextBlock Grid.Column="1" Text="Share changes" FontWeight="SemiBold" VerticalAlignment="Center" />
             </Grid>
           </Button>
-          <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Command="{Binding NavigateToTrustCommand}">
+          <Button Classes="nav"
+                  Classes.active="{Binding IsTrustSelected}"
+                  Command="{Binding NavigateToTrustCommand}"
+                  ToolTip.Tip="Safety check (Ctrl/Command+6)"
+                  automation:AutomationProperties.Name="Safety check">
             <Grid ColumnDefinitions="28,*">
               <TextBlock Text="✓" FontSize="15" VerticalAlignment="Center" />
               <TextBlock Grid.Column="1" Text="Safety check" FontWeight="SemiBold" VerticalAlignment="Center" />

--- a/Blueprints.App/Views/MainWindow.axaml
+++ b/Blueprints.App/Views/MainWindow.axaml
@@ -2,7 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Blueprints.App.ViewModels"
         xmlns:views="using:Blueprints.App.Views.Components"
-        xmlns:shapes="using:Avalonia.Controls.Shapes"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
@@ -14,119 +13,155 @@
         Icon="/Assets/blueprints.ico"
         Width="1440"
         Height="920"
-        MinWidth="1040"
-        MinHeight="700"
-        Background="#F2F8FC">
+        MinWidth="1080"
+        MinHeight="720"
+        Background="#F6F7FB">
   <Design.DataContext>
     <vm:MainWindowViewModel />
   </Design.DataContext>
 
-  <Grid RowDefinitions="72,*">
-    <Border Grid.Row="0" Background="#06192B" BorderBrush="#1C4A6A" BorderThickness="0,0,0,1" Padding="22,0">
-      <Grid ColumnDefinitions="Auto,20,*,Auto,Auto" VerticalAlignment="Center">
-        <Grid Width="42" Height="42">
-          <Border Background="#0F4F7A" BorderBrush="#62D3F0" BorderThickness="1" CornerRadius="4" />
-          <Canvas IsHitTestVisible="False">
-            <shapes:Line StartPoint="7,12" EndPoint="35,12" Stroke="#62D3F0" StrokeThickness="1" />
-            <shapes:Line StartPoint="7,21" EndPoint="35,21" Stroke="#62D3F0" StrokeThickness="1" />
-            <shapes:Line StartPoint="7,30" EndPoint="27,30" Stroke="#62D3F0" StrokeThickness="1" />
-            <shapes:Line StartPoint="12,7" EndPoint="12,35" Stroke="#62D3F0" StrokeThickness="1" />
-          </Canvas>
+  <Grid>
+    <views:SetupView IsVisible="{Binding IsSetupMode}" />
+
+    <Grid ColumnDefinitions="232,*" IsVisible="{Binding HasActiveSession}">
+    <Border Background="#191A2C" Padding="14,18">
+      <Grid RowDefinitions="Auto,Auto,*,Auto">
+        <Grid ColumnDefinitions="42,*" ColumnSpacing="11" Margin="7,0,7,24">
+          <Border Width="42" Height="42" CornerRadius="12" Background="#6B5CE7">
+            <TextBlock Text="B"
+                       Foreground="White"
+                       FontSize="20"
+                       FontWeight="Bold"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+          </Border>
+          <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+            <TextBlock Text="Blueprints" Foreground="White" FontSize="17" FontWeight="Bold" />
+            <TextBlock Text="Release planning" Foreground="#9295A8" FontSize="11" />
+          </StackPanel>
         </Grid>
 
-        <StackPanel Grid.Column="2" Spacing="1" VerticalAlignment="Center">
-          <TextBlock Text="BLUEPRINTS" FontSize="19" FontWeight="Black" Foreground="White" LetterSpacing="1.5" />
-          <TextBlock Text="{Binding Title}" FontSize="12" Foreground="#8FB5CC" />
-        </StackPanel>
-
-        <StackPanel Grid.Column="3"
-                    Orientation="Horizontal"
-                    Spacing="8"
-                    Margin="0,0,18,0"
-                    IsVisible="{Binding HasActiveSession}">
-          <Border Background="#0F4F7A" BorderBrush="#2F799F" BorderThickness="1" CornerRadius="12" Padding="10,5">
-            <StackPanel Orientation="Horizontal" Spacing="6">
-              <TextBlock Text="◆" Foreground="#62D3F0" FontSize="10" VerticalAlignment="Center" />
-              <TextBlock Text="{Binding TrustBadge}" Foreground="White" FontWeight="Bold" FontSize="12" />
-            </StackPanel>
-          </Border>
-          <Border Background="#133C58" BorderBrush="#2F6888" BorderThickness="1" CornerRadius="12" Padding="10,5">
-            <TextBlock Text="{Binding SyncStatus}" Foreground="#C5DCE9" FontWeight="SemiBold" FontSize="12" />
-          </Border>
-        </StackPanel>
-
-        <Border Grid.Column="4"
-                Background="#0B2D49"
-                BorderBrush="#245A7D"
+        <Border Grid.Row="1"
+                Background="#24263D"
+                BorderBrush="#343650"
                 BorderThickness="1"
-                CornerRadius="4"
-                Padding="12,7"
-                MinWidth="190"
-                IsVisible="{Binding HasActiveSession}">
-          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-            <StackPanel Spacing="1">
-              <TextBlock Text="{Binding Identity.DisplayName}" Foreground="White" FontWeight="Bold" FontSize="12" />
-              <TextBlock Text="{Binding Identity.KeyStorageProvider}" Foreground="#8FB5CC" FontSize="10" />
-            </StackPanel>
-            <Border Grid.Column="1" Width="28" Height="28" CornerRadius="14" Background="#168AD0">
-              <TextBlock Text="ID" Foreground="White" FontSize="9" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
-            </Border>
-          </Grid>
+                CornerRadius="11"
+                Padding="12"
+                Margin="0,0,0,18">
+          <StackPanel Spacing="4">
+            <TextBlock Text="{Binding CurrentProject.Name}"
+                       Foreground="White"
+                       FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis" />
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock Text="{Binding CurrentProject.Code}"
+                         Foreground="#A9ABBA"
+                         FontSize="11"
+                         Classes="mono" />
+              <Border Grid.Column="1" Background="#373455" CornerRadius="8" Padding="7,2">
+                <TextBlock Text="{Binding TrustBadge}" Foreground="#DCD8FF" FontSize="9" FontWeight="SemiBold" />
+              </Border>
+            </Grid>
+          </StackPanel>
         </Border>
+
+        <StackPanel Grid.Row="2" Spacing="2">
+          <TextBlock Text="WORKSPACE" Foreground="#747789" FontSize="10" FontWeight="SemiBold" Margin="12,0,0,7" />
+          <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Command="{Binding NavigateToOverviewCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="⌂" FontSize="16" VerticalAlignment="Center" />
+              <StackPanel Grid.Column="1" Spacing="1">
+                <TextBlock Text="Home" FontWeight="SemiBold" />
+                <TextBlock Text="Your project at a glance" Foreground="#9295A8" FontSize="10" />
+              </StackPanel>
+            </Grid>
+          </Button>
+          <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Command="{Binding NavigateToReleasesCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="◫" FontSize="15" VerticalAlignment="Center" />
+              <StackPanel Grid.Column="1" Spacing="1">
+                <TextBlock Text="Plan releases" FontWeight="SemiBold" />
+                <TextBlock Text="Versions and release notes" Foreground="#9295A8" FontSize="10" />
+              </StackPanel>
+            </Grid>
+          </Button>
+          <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Command="{Binding NavigateToIntegrationsCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="⌕" FontSize="17" VerticalAlignment="Center" />
+              <StackPanel Grid.Column="1" Spacing="1">
+                <TextBlock Text="Find work" FontWeight="SemiBold" />
+                <TextBlock Text="GitHub, GitLab and Git" Foreground="#9295A8" FontSize="10" />
+              </StackPanel>
+            </Grid>
+          </Button>
+
+          <TextBlock Text="COLLABORATE" Foreground="#747789" FontSize="10" FontWeight="SemiBold" Margin="12,17,0,7" />
+          <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Command="{Binding NavigateToTeamCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="♙" FontSize="16" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="People" FontWeight="SemiBold" VerticalAlignment="Center" />
+            </Grid>
+          </Button>
+          <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Command="{Binding NavigateToSyncCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="↕" FontSize="17" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="Share changes" FontWeight="SemiBold" VerticalAlignment="Center" />
+            </Grid>
+          </Button>
+          <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Command="{Binding NavigateToTrustCommand}">
+            <Grid ColumnDefinitions="28,*">
+              <TextBlock Text="✓" FontSize="15" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="Safety check" FontWeight="SemiBold" VerticalAlignment="Center" />
+            </Grid>
+          </Button>
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Spacing="10">
+          <Border Height="1" Background="#303249" />
+          <Grid ColumnDefinitions="36,*" Margin="6,0">
+            <Border Width="32" Height="32" CornerRadius="16" Background="#353750">
+              <TextBlock Text="ID" Foreground="#D6D2FF" FontSize="9" FontWeight="Bold"
+                         HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <StackPanel Grid.Column="1" Spacing="1" VerticalAlignment="Center">
+              <TextBlock Text="{Binding Identity.DisplayName}" Foreground="White" FontSize="11" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding SyncStatus}" Foreground="#9295A8" FontSize="9" TextTrimming="CharacterEllipsis" />
+            </StackPanel>
+          </Grid>
+          <Button Classes="nav" Content="←  Switch project" Command="{Binding ReturnToProjectSetupCommand}" />
+        </StackPanel>
       </Grid>
     </Border>
 
-    <views:SetupView Grid.Row="1" IsVisible="{Binding IsSetupMode}" />
+    <Grid Grid.Column="1" Background="#F6F7FB">
+      <views:OverviewView IsVisible="{Binding IsOverviewSelected}" />
 
-    <Grid Grid.Row="1" ColumnDefinitions="184,*" IsVisible="{Binding HasActiveSession}">
-      <Border Background="#061C30" BorderBrush="#285A78" BorderThickness="0,0,1,0">
-        <Grid RowDefinitions="Auto,*,Auto">
-          <Border Margin="12" Padding="12,10" Background="#0D4166" BorderBrush="#5CCBE8" BorderThickness="1" CornerRadius="6">
-            <StackPanel>
-              <TextBlock Text="{Binding CurrentProject.Code}" Classes="mono" Foreground="White" FontWeight="Black" />
-              <TextBlock Text="{Binding CurrentProject.Name}" Foreground="#A9D4E5" FontSize="10" TextTrimming="CharacterEllipsis" />
-            </StackPanel>
-          </Border>
-
-          <StackPanel Grid.Row="1" Spacing="3" Margin="10,8">
-            <Button Classes="nav" Classes.active="{Binding IsOverviewSelected}" Content="⌘  Blueprint map" Command="{Binding NavigateToOverviewCommand}" />
-            <Button Classes="nav" Classes.active="{Binding IsIntegrationsSelected}" Content="⌁  Source lens" Command="{Binding NavigateToIntegrationsCommand}" />
-            <Button Classes="nav" Classes.active="{Binding IsReleasesSelected}" Content="V  Releases" Command="{Binding NavigateToReleasesCommand}" />
-            <Button Classes="nav" Classes.active="{Binding IsTeamSelected}" Content="P  People" Command="{Binding NavigateToTeamCommand}" />
-            <Button Classes="nav" Classes.active="{Binding IsSyncSelected}" Content="⇄  Sync" Command="{Binding NavigateToSyncCommand}" />
-            <Button Classes="nav" Classes.active="{Binding IsTrustSelected}" Content="◇  Trust" Command="{Binding NavigateToTrustCommand}" />
-          </StackPanel>
-
-          <Button Grid.Row="2"
-                  Classes="nav"
-                  Content="←  Switch project"
-                  Command="{Binding ReturnToProjectSetupCommand}"
-                  Margin="10,0,10,12" />
-        </Grid>
-      </Border>
-
-      <Grid Grid.Column="1" Background="#F2F8FC">
-        <views:OverviewView IsVisible="{Binding IsOverviewSelected}" />
-
-        <Grid IsVisible="{Binding IsDetailsWorkspaceSelected}" Margin="24" RowDefinitions="Auto,*" RowSpacing="16">
+      <Grid IsVisible="{Binding IsDetailsWorkspaceSelected}" RowDefinitions="92,*">
+        <Border Background="#FFFFFF" BorderBrush="#E2E4EC" BorderThickness="0,0,0,1" Padding="28,18">
           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="18">
-            <StackPanel Spacing="4">
-              <TextBlock Classes="eyebrow" Text="{Binding SelectedWorkspaceSection, StringFormat='TOOLS / {0}'}" />
-              <TextBlock Text="{Binding SelectedWorkspaceSectionTitle}" FontSize="28" FontWeight="Black" />
-              <TextBlock Text="{Binding SelectedWorkspaceSectionDescription}" Classes="muted" TextWrapping="Wrap" />
+            <StackPanel Spacing="3" VerticalAlignment="Center">
+              <TextBlock Text="{Binding SelectedWorkspaceSectionTitle}" Classes="page-title" />
+              <TextBlock Text="{Binding SelectedWorkspaceSectionDescription}"
+                         Classes="muted"
+                         TextWrapping="Wrap" />
             </StackPanel>
-            <Button Grid.Column="1" Classes="secondary" Content="Return to canvas" Command="{Binding NavigateToOverviewCommand}" VerticalAlignment="Center" />
+            <Button Grid.Column="1"
+                    Classes="secondary"
+                    Content="Back to Home"
+                    Command="{Binding NavigateToOverviewCommand}"
+                    VerticalAlignment="Center" />
           </Grid>
+        </Border>
 
-          <Grid Grid.Row="1">
-            <views:ReleasePlannerView IsVisible="{Binding IsReleasesSelected}" />
-            <views:TeamView IsVisible="{Binding IsTeamSelected}" />
-            <views:SyncView IsVisible="{Binding IsSyncSelected}" />
-            <views:TrustView IsVisible="{Binding IsTrustSelected}" />
-            <views:IntegrationsView IsVisible="{Binding IsIntegrationsSelected}" />
-          </Grid>
+        <Grid Grid.Row="1" Margin="24">
+          <views:ReleasePlannerView IsVisible="{Binding IsReleasesSelected}" />
+          <views:TeamView IsVisible="{Binding IsTeamSelected}" />
+          <views:SyncView IsVisible="{Binding IsSyncSelected}" />
+          <views:TrustView IsVisible="{Binding IsTrustSelected}" />
+          <views:IntegrationsView IsVisible="{Binding IsIntegrationsSelected}" />
         </Grid>
       </Grid>
+    </Grid>
     </Grid>
   </Grid>
 </Window>

--- a/Blueprints.App/Views/MainWindow.axaml.cs
+++ b/Blueprints.App/Views/MainWindow.axaml.cs
@@ -1,4 +1,7 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Blueprints.App.ViewModels;
 
 namespace Blueprints.App.Views;
 
@@ -7,5 +10,34 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        AddHandler(KeyDownEvent, HandleGlobalKeyDown, RoutingStrategies.Tunnel);
+    }
+
+    private void HandleGlobalKeyDown(object? sender, KeyEventArgs eventArgs)
+    {
+        if (DataContext is not MainWindowViewModel viewModel
+            || !viewModel.HasActiveSession
+            || (eventArgs.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Meta)) == 0)
+        {
+            return;
+        }
+
+        var command = eventArgs.Key switch
+        {
+            Key.D1 or Key.NumPad1 => viewModel.NavigateToOverviewCommand,
+            Key.D2 or Key.NumPad2 => viewModel.NavigateToReleasesCommand,
+            Key.D3 or Key.NumPad3 => viewModel.NavigateToIntegrationsCommand,
+            Key.D4 or Key.NumPad4 => viewModel.NavigateToTeamCommand,
+            Key.D5 or Key.NumPad5 => viewModel.NavigateToSyncCommand,
+            Key.D6 or Key.NumPad6 => viewModel.NavigateToTrustCommand,
+            _ => null,
+        };
+        if (command is null)
+        {
+            return;
+        }
+
+        command.Execute(null);
+        eventArgs.Handled = true;
     }
 }

--- a/Blueprints.Security/Abstractions/IIdentityService.cs
+++ b/Blueprints.Security/Abstractions/IIdentityService.cs
@@ -9,4 +9,8 @@ public interface IIdentityService
     StoredIdentity GetOrCreateDefaultIdentity(string displayName);
 
     IReadOnlyList<IdentityProfile> ListProfiles();
+
+    string ExportBackup(string filePath, string passphrase);
+
+    StoredIdentity ImportBackup(string filePath, string passphrase);
 }

--- a/Blueprints.Security/Abstractions/IIdentityStore.cs
+++ b/Blueprints.Security/Abstractions/IIdentityStore.cs
@@ -7,4 +7,6 @@ public interface IIdentityStore
     StoredIdentity Create(string displayName);
 
     StoredIdentity Load(Guid userId);
+
+    StoredIdentity Import(IdentityProfile profile, byte[] privateKeyBytes);
 }

--- a/Blueprints.Security/Models/IdentityBackupFile.cs
+++ b/Blueprints.Security/Models/IdentityBackupFile.cs
@@ -1,0 +1,11 @@
+namespace Blueprints.Security.Models;
+
+public sealed record IdentityBackupFile(
+    int SchemaVersion,
+    IdentityProfile Identity,
+    string KeyDerivation,
+    int Iterations,
+    string SaltBase64,
+    string NonceBase64,
+    string CiphertextBase64,
+    string TagBase64);

--- a/Blueprints.Security/Services/FileSystemIdentityStore.cs
+++ b/Blueprints.Security/Services/FileSystemIdentityStore.cs
@@ -91,6 +91,67 @@ public sealed class FileSystemIdentityStore : IIdentityStore
             new SignaturePublicKey(profile.KeyId, publicKeyBytes));
     }
 
+    public StoredIdentity Import(IdentityProfile profile, byte[] privateKeyBytes)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(privateKeyBytes);
+        if (profile.UserId == Guid.Empty
+            || string.IsNullOrWhiteSpace(profile.DisplayName)
+            || string.IsNullOrWhiteSpace(profile.KeyId)
+            || privateKeyBytes.Length == 0)
+        {
+            throw new InvalidOperationException("The restored identity is incomplete.");
+        }
+
+        var identityDirectory = GetIdentityDirectory(profile.UserId);
+        if (Directory.Exists(identityDirectory))
+        {
+            throw new InvalidOperationException(
+                "An identity with this user ID already exists on this device.");
+        }
+
+        var importedProfile = profile with
+        {
+            DisplayName = profile.DisplayName.Trim(),
+            KeyStorageProvider = _privateKeyProtector.ProviderName,
+        };
+        var stagingDirectory = identityDirectory + ".importing";
+        if (Directory.Exists(stagingDirectory))
+        {
+            throw new InvalidOperationException(
+                "An incomplete identity import directory already exists. Inspect or move it before retrying.");
+        }
+
+        Directory.CreateDirectory(stagingDirectory);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(stagingDirectory, "identity.json"),
+                JsonSerializer.Serialize(importedProfile, SerializerOptions),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.WriteAllBytes(
+                Path.Combine(stagingDirectory, "private.key.protected"),
+                _privateKeyProtector.Protect(privateKeyBytes));
+            Directory.Move(stagingDirectory, identityDirectory);
+        }
+        catch
+        {
+            if (Directory.Exists(stagingDirectory))
+            {
+                Directory.Delete(stagingDirectory, recursive: true);
+            }
+
+            throw;
+        }
+
+        return new StoredIdentity(
+            importedProfile,
+            new SignatureKeyMaterial(importedProfile.KeyId, privateKeyBytes.ToArray()),
+            new SignaturePublicKey(
+                importedProfile.KeyId,
+                Convert.FromBase64String(importedProfile.PublicKeyBase64)));
+    }
+
     private string GetIdentityDirectory(Guid userId) =>
         Path.Combine(_rootDirectory, userId.ToString("N"));
 

--- a/Blueprints.Security/Services/IdentityBackupService.cs
+++ b/Blueprints.Security/Services/IdentityBackupService.cs
@@ -1,0 +1,253 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Blueprints.Security.Abstractions;
+using Blueprints.Security.Models;
+
+namespace Blueprints.Security.Services;
+
+public sealed class IdentityBackupService
+{
+    private const int CurrentSchemaVersion = 1;
+    private const int SaltLength = 16;
+    private const int NonceLength = 12;
+    private const int TagLength = 16;
+    private const int KeyLength = 32;
+    private const int DerivationIterations = 600_000;
+    private const long MaximumBackupBytes = 1024 * 1024;
+    private const string KeyDerivation = "PBKDF2-SHA256";
+    private static readonly byte[] ProofPayload =
+        "Blueprints identity backup proof v1"u8.ToArray();
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly IIdentityStore _identityStore;
+    private readonly ISignatureService _signatureService;
+
+    public IdentityBackupService(
+        IIdentityStore identityStore,
+        ISignatureService signatureService)
+    {
+        _identityStore = identityStore;
+        _signatureService = signatureService;
+    }
+
+    public string Export(
+        string filePath,
+        StoredIdentity identity,
+        string passphrase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(identity);
+        ValidatePassphrase(passphrase);
+
+        var salt = RandomNumberGenerator.GetBytes(SaltLength);
+        var nonce = RandomNumberGenerator.GetBytes(NonceLength);
+        var tag = new byte[TagLength];
+        var ciphertext = new byte[identity.SigningKey.PrivateKeyBytes.Length];
+        var key = DeriveKey(passphrase, salt, DerivationIterations);
+        try
+        {
+            using var aes = new AesGcm(key, TagLength);
+            aes.Encrypt(
+                nonce,
+                identity.SigningKey.PrivateKeyBytes,
+                ciphertext,
+                tag,
+                CreateAssociatedData(identity.Profile));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+
+        var backup = new IdentityBackupFile(
+            CurrentSchemaVersion,
+            identity.Profile,
+            KeyDerivation,
+            DerivationIterations,
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(nonce),
+            Convert.ToBase64String(ciphertext),
+            Convert.ToBase64String(tag));
+        WriteAtomically(filePath, JsonSerializer.Serialize(backup, SerializerOptions));
+        return Path.GetFullPath(filePath);
+    }
+
+    public StoredIdentity Import(string filePath, string passphrase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ValidatePassphrase(passphrase);
+        var info = new FileInfo(filePath);
+        if (!info.Exists)
+        {
+            throw new FileNotFoundException("Identity backup was not found.", filePath);
+        }
+
+        if (info.Length > MaximumBackupBytes)
+        {
+            throw new InvalidOperationException("Identity backup exceeds the supported size.");
+        }
+
+        var backup = JsonSerializer.Deserialize<IdentityBackupFile>(
+            File.ReadAllText(filePath, Encoding.UTF8),
+            SerializerOptions)
+            ?? throw new InvalidOperationException("Identity backup could not be read.");
+        ValidateBackup(backup);
+
+        byte[] salt;
+        byte[] nonce;
+        byte[] ciphertext;
+        byte[] tag;
+        try
+        {
+            salt = Convert.FromBase64String(backup.SaltBase64);
+            nonce = Convert.FromBase64String(backup.NonceBase64);
+            ciphertext = Convert.FromBase64String(backup.CiphertextBase64);
+            tag = Convert.FromBase64String(backup.TagBase64);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException(
+                "Identity backup contains malformed encrypted data.",
+                exception);
+        }
+
+        if (salt.Length != SaltLength
+            || nonce.Length != NonceLength
+            || tag.Length != TagLength
+            || ciphertext.Length is < 32 or > 256)
+        {
+            throw new InvalidOperationException(
+                "Identity backup encryption parameters are invalid.");
+        }
+
+        var privateKey = new byte[ciphertext.Length];
+        var key = DeriveKey(passphrase, salt, backup.Iterations);
+        try
+        {
+            using var aes = new AesGcm(key, TagLength);
+            aes.Decrypt(
+                nonce,
+                ciphertext,
+                tag,
+                privateKey,
+                CreateAssociatedData(backup.Identity));
+            VerifyPrivateKey(backup.Identity, privateKey);
+            return _identityStore.Import(backup.Identity, privateKey);
+        }
+        catch (AuthenticationTagMismatchException exception)
+        {
+            throw new InvalidOperationException(
+                "The passphrase is incorrect or the identity backup was changed.",
+                exception);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+            CryptographicOperations.ZeroMemory(privateKey);
+        }
+    }
+
+    private void VerifyPrivateKey(IdentityProfile profile, byte[] privateKey)
+    {
+        try
+        {
+            var signingKey = new SignatureKeyMaterial(profile.KeyId, privateKey);
+            var publicKey = new SignaturePublicKey(
+                profile.KeyId,
+                Convert.FromBase64String(profile.PublicKeyBase64));
+            var proof = _signatureService.Sign(ProofPayload, signingKey);
+            if (!_signatureService.Verify(ProofPayload, proof, publicKey))
+            {
+                throw new InvalidOperationException(
+                    "The identity backup private key does not match its public identity.");
+            }
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException(
+                "Identity backup contains an invalid public key.",
+                exception);
+        }
+    }
+
+    private static void ValidateBackup(IdentityBackupFile backup)
+    {
+        if (backup.SchemaVersion != CurrentSchemaVersion
+            || !string.Equals(backup.KeyDerivation, KeyDerivation, StringComparison.Ordinal)
+            || backup.Iterations != DerivationIterations
+            || backup.Identity.UserId == Guid.Empty
+            || string.IsNullOrWhiteSpace(backup.Identity.DisplayName)
+            || string.IsNullOrWhiteSpace(backup.Identity.KeyId)
+            || backup.Identity.DisplayName.Length > 200
+            || backup.Identity.KeyId.Length > 128)
+        {
+            throw new InvalidOperationException(
+                "Identity backup format or identity metadata is unsupported.");
+        }
+    }
+
+    private static void ValidatePassphrase(string passphrase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(passphrase);
+        if (passphrase.Length < 12 || passphrase.Length > 1024)
+        {
+            throw new InvalidOperationException(
+                "Identity backup passphrases must contain at least 12 characters.");
+        }
+    }
+
+    private static byte[] DeriveKey(
+        string passphrase,
+        byte[] salt,
+        int iterations)
+    {
+        var passphraseBytes = Encoding.UTF8.GetBytes(passphrase);
+        try
+        {
+            return Rfc2898DeriveBytes.Pbkdf2(
+                passphraseBytes,
+                salt,
+                iterations,
+                HashAlgorithmName.SHA256,
+                KeyLength);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(passphraseBytes);
+        }
+    }
+
+    private static byte[] CreateAssociatedData(IdentityProfile identity) =>
+        JsonSerializer.SerializeToUtf8Bytes(
+            new
+            {
+                identity.UserId,
+                identity.DisplayName,
+                identity.KeyId,
+                identity.PublicKeyBase64,
+                identity.CreatedUtc,
+            },
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            });
+
+    private static void WriteAtomically(string filePath, string json)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        var parent = Path.GetDirectoryName(fullPath)
+            ?? throw new InvalidOperationException("Identity backup path has no parent.");
+        Directory.CreateDirectory(parent);
+        var temporaryPath = fullPath + ".tmp";
+        File.WriteAllText(
+            temporaryPath,
+            json,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        File.Move(temporaryPath, fullPath, overwrite: true);
+    }
+}

--- a/Blueprints.Security/Services/IdentityService.cs
+++ b/Blueprints.Security/Services/IdentityService.cs
@@ -7,6 +7,7 @@ public sealed class IdentityService : IIdentityService
 {
     private readonly string _rootDirectory;
     private readonly IIdentityStore _identityStore;
+    private readonly IdentityBackupService _backupService;
 
     public IdentityService(string rootDirectory, IIdentityStore identityStore)
     {
@@ -14,6 +15,9 @@ public sealed class IdentityService : IIdentityService
 
         _rootDirectory = rootDirectory;
         _identityStore = identityStore;
+        _backupService = new IdentityBackupService(
+            identityStore,
+            new Ed25519SignatureService());
     }
 
     public StoredIdentity GetOrCreateDefaultIdentity(string displayName)
@@ -29,6 +33,15 @@ public sealed class IdentityService : IIdentityService
 
     public StoredIdentity CreateIdentity(string displayName) =>
         _identityStore.Create(displayName);
+
+    public string ExportBackup(string filePath, string passphrase) =>
+        _backupService.Export(
+            filePath,
+            GetOrCreateDefaultIdentity("Local Admin"),
+            passphrase);
+
+    public StoredIdentity ImportBackup(string filePath, string passphrase) =>
+        _backupService.Import(filePath, passphrase);
 
     public IReadOnlyList<IdentityProfile> ListProfiles()
     {

--- a/Blueprints.Storage/Abstractions/IWorkspaceMigration.cs
+++ b/Blueprints.Storage/Abstractions/IWorkspaceMigration.cs
@@ -1,0 +1,12 @@
+using Blueprints.Security.Models;
+
+namespace Blueprints.Storage.Abstractions;
+
+public interface IWorkspaceMigration
+{
+    int SourceSchemaVersion { get; }
+
+    int TargetSchemaVersion { get; }
+
+    void Apply(string stagedWorkspaceRoot, SignatureKeyMaterial signingKey);
+}

--- a/Blueprints.Storage/Abstractions/IWorkspaceTransactionService.cs
+++ b/Blueprints.Storage/Abstractions/IWorkspaceTransactionService.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.Storage.Abstractions;
+
+public interface IWorkspaceTransactionService
+{
+    void Recover(string workspaceRoot);
+
+    void Execute(string workspaceRoot, Action<string> writeToStagedWorkspace);
+}

--- a/Blueprints.Storage/Models/WorkspaceMigrationResult.cs
+++ b/Blueprints.Storage/Models/WorkspaceMigrationResult.cs
@@ -1,0 +1,10 @@
+namespace Blueprints.Storage.Models;
+
+public sealed record WorkspaceMigrationResult(
+    int OriginalSchemaVersion,
+    int CurrentSchemaVersion,
+    IReadOnlyList<int> AppliedSchemaVersions,
+    string? BackupPath)
+{
+    public bool WasMigrated => AppliedSchemaVersions.Count > 0;
+}

--- a/Blueprints.Storage/Models/WorkspaceTransactionPhase.cs
+++ b/Blueprints.Storage/Models/WorkspaceTransactionPhase.cs
@@ -1,0 +1,8 @@
+namespace Blueprints.Storage.Models;
+
+public enum WorkspaceTransactionPhase
+{
+    Staged,
+    OriginalBackedUp,
+    Promoted,
+}

--- a/Blueprints.Storage/Services/FileSystemWorkspaceTransactionService.cs
+++ b/Blueprints.Storage/Services/FileSystemWorkspaceTransactionService.cs
@@ -1,0 +1,250 @@
+using System.Text.Json;
+using Blueprints.Storage.Abstractions;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.Storage.Services;
+
+public sealed class FileSystemWorkspaceTransactionService : IWorkspaceTransactionService
+{
+    private const int MarkerSchemaVersion = 1;
+    private const long MaximumMarkerBytes = 32 * 1024;
+    private static readonly JsonSerializerOptions MarkerSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private readonly Action<WorkspaceTransactionPhase>? _checkpoint;
+
+    public FileSystemWorkspaceTransactionService(
+        Action<WorkspaceTransactionPhase>? checkpoint = null)
+    {
+        _checkpoint = checkpoint;
+    }
+
+    public void Recover(string workspaceRoot)
+    {
+        var paths = ResolvePaths(workspaceRoot);
+        if (!File.Exists(paths.MarkerPath))
+        {
+            return;
+        }
+
+        var marker = ReadAndValidateMarker(paths);
+        if (!Directory.Exists(paths.WorkspaceRoot))
+        {
+            if (Directory.Exists(marker.BackupRoot))
+            {
+                Directory.Move(marker.BackupRoot, paths.WorkspaceRoot);
+            }
+            else if (Directory.Exists(marker.StagingRoot)
+                     && string.Equals(marker.State, "promoting", StringComparison.Ordinal))
+            {
+                Directory.Move(marker.StagingRoot, paths.WorkspaceRoot);
+            }
+        }
+
+        DeleteDirectoryIfPresent(marker.StagingRoot);
+        DeleteDirectoryIfPresent(marker.BackupRoot);
+        File.Delete(paths.MarkerPath);
+    }
+
+    public void Execute(string workspaceRoot, Action<string> writeToStagedWorkspace)
+    {
+        ArgumentNullException.ThrowIfNull(writeToStagedWorkspace);
+        var paths = ResolvePaths(workspaceRoot);
+        Recover(paths.WorkspaceRoot);
+
+        if (Directory.Exists(paths.StagingRoot)
+            || Directory.Exists(paths.BackupRoot)
+            || File.Exists(paths.MarkerPath)
+            || File.Exists(paths.MarkerPath + ".tmp"))
+        {
+            throw new InvalidOperationException(
+                "Untracked workspace transaction artifacts already exist. Move them aside and inspect their contents before retrying.");
+        }
+
+        if (Directory.Exists(paths.WorkspaceRoot))
+        {
+            CopyDirectory(paths.WorkspaceRoot, paths.StagingRoot);
+        }
+        else
+        {
+            Directory.CreateDirectory(paths.StagingRoot);
+        }
+
+        try
+        {
+            writeToStagedWorkspace(paths.StagingRoot);
+            WriteMarker(paths, "staged");
+            _checkpoint?.Invoke(WorkspaceTransactionPhase.Staged);
+
+            if (Directory.Exists(paths.WorkspaceRoot))
+            {
+                Directory.Move(paths.WorkspaceRoot, paths.BackupRoot);
+                WriteMarker(paths, "backedUp");
+                _checkpoint?.Invoke(WorkspaceTransactionPhase.OriginalBackedUp);
+            }
+
+            WriteMarker(paths, "promoting");
+            Directory.Move(paths.StagingRoot, paths.WorkspaceRoot);
+            WriteMarker(paths, "committed");
+            _checkpoint?.Invoke(WorkspaceTransactionPhase.Promoted);
+
+            DeleteDirectoryIfPresent(paths.BackupRoot);
+            File.Delete(paths.MarkerPath);
+        }
+        catch
+        {
+            RestorePreviousWorkspace(paths);
+            throw;
+        }
+    }
+
+    private static void RestorePreviousWorkspace(TransactionPaths paths)
+    {
+        if (Directory.Exists(paths.BackupRoot))
+        {
+            if (Directory.Exists(paths.WorkspaceRoot))
+            {
+                DeleteDirectoryIfPresent(paths.WorkspaceRoot);
+            }
+
+            Directory.Move(paths.BackupRoot, paths.WorkspaceRoot);
+        }
+
+        DeleteDirectoryIfPresent(paths.StagingRoot);
+        if (File.Exists(paths.MarkerPath))
+        {
+            File.Delete(paths.MarkerPath);
+        }
+    }
+
+    private static void CopyDirectory(string sourceRoot, string destinationRoot)
+    {
+        var source = new DirectoryInfo(sourceRoot);
+        if (source.LinkTarget is not null)
+        {
+            throw new InvalidOperationException(
+                "A workspace root cannot be a symbolic link during an atomic update.");
+        }
+
+        Directory.CreateDirectory(destinationRoot);
+        foreach (var entry in source.EnumerateFileSystemInfos())
+        {
+            if (entry.LinkTarget is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Workspace transactions do not follow linked entries: {entry.FullName}");
+            }
+
+            var destination = Path.Combine(destinationRoot, entry.Name);
+            if (entry is DirectoryInfo directory)
+            {
+                CopyDirectory(directory.FullName, destination);
+            }
+            else if (entry is FileInfo file)
+            {
+                file.CopyTo(destination, overwrite: false);
+            }
+        }
+    }
+
+    private static TransactionMarker ReadAndValidateMarker(TransactionPaths paths)
+    {
+        var markerInfo = new FileInfo(paths.MarkerPath);
+        if (markerInfo.Length > MaximumMarkerBytes)
+        {
+            throw new InvalidOperationException("The workspace transaction marker is too large.");
+        }
+
+        var marker = JsonSerializer.Deserialize<TransactionMarker>(
+            File.ReadAllText(paths.MarkerPath),
+            MarkerSerializerOptions)
+            ?? throw new InvalidOperationException("The workspace transaction marker is invalid.");
+
+        if (marker.SchemaVersion != MarkerSchemaVersion
+            || !PathsEqual(marker.WorkspaceRoot, paths.WorkspaceRoot)
+            || !PathsEqual(marker.StagingRoot, paths.StagingRoot)
+            || !PathsEqual(marker.BackupRoot, paths.BackupRoot))
+        {
+            throw new InvalidOperationException(
+                "The workspace transaction marker does not match the requested workspace.");
+        }
+
+        return marker;
+    }
+
+    private static void WriteMarker(TransactionPaths paths, string state)
+    {
+        var marker = new TransactionMarker(
+            MarkerSchemaVersion,
+            paths.WorkspaceRoot,
+            paths.StagingRoot,
+            paths.BackupRoot,
+            state,
+            DateTimeOffset.UtcNow);
+        var temporaryPath = paths.MarkerPath + ".tmp";
+        if (File.Exists(temporaryPath))
+        {
+            throw new InvalidOperationException(
+                "A temporary workspace transaction marker already exists.");
+        }
+
+        File.WriteAllText(
+            temporaryPath,
+            JsonSerializer.Serialize(marker, MarkerSerializerOptions));
+        File.Move(temporaryPath, paths.MarkerPath, overwrite: true);
+    }
+
+    private static TransactionPaths ResolvePaths(string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        var fullRoot = Path.GetFullPath(workspaceRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var parent = Path.GetDirectoryName(fullRoot)
+            ?? throw new InvalidOperationException("The workspace must have a parent directory.");
+        var name = Path.GetFileName(fullRoot);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidOperationException("The workspace path must name a directory.");
+        }
+
+        Directory.CreateDirectory(parent);
+        return new TransactionPaths(
+            fullRoot,
+            Path.Combine(parent, $".{name}.blueprints-staging"),
+            Path.Combine(parent, $".{name}.blueprints-backup"),
+            Path.Combine(parent, $".{name}.blueprints-transaction.json"));
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(
+            Path.GetFullPath(left),
+            Path.GetFullPath(right),
+            OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal);
+
+    private static void DeleteDirectoryIfPresent(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private sealed record TransactionPaths(
+        string WorkspaceRoot,
+        string StagingRoot,
+        string BackupRoot,
+        string MarkerPath);
+
+    private sealed record TransactionMarker(
+        int SchemaVersion,
+        string WorkspaceRoot,
+        string StagingRoot,
+        string BackupRoot,
+        string State,
+        DateTimeOffset UpdatedUtc);
+}

--- a/Blueprints.Storage/Services/WorkspaceMigrationService.cs
+++ b/Blueprints.Storage/Services/WorkspaceMigrationService.cs
@@ -1,0 +1,162 @@
+using System.IO.Compression;
+using Blueprints.Security.Models;
+using Blueprints.Storage.Abstractions;
+using Blueprints.Storage.Models;
+
+namespace Blueprints.Storage.Services;
+
+public sealed class WorkspaceMigrationService
+{
+    public const int MinimumSupportedSchemaVersion = 1;
+    public const int CurrentSchemaVersion = 1;
+
+    private readonly IWorkspaceTransactionService _transactionService;
+    private readonly IReadOnlyDictionary<int, IWorkspaceMigration> _migrations;
+    private readonly int _targetSchemaVersion;
+
+    public WorkspaceMigrationService(
+        IWorkspaceTransactionService transactionService,
+        IEnumerable<IWorkspaceMigration>? migrations = null,
+        int targetSchemaVersion = CurrentSchemaVersion)
+    {
+        ArgumentNullException.ThrowIfNull(transactionService);
+        if (targetSchemaVersion < MinimumSupportedSchemaVersion)
+        {
+            throw new ArgumentOutOfRangeException(nameof(targetSchemaVersion));
+        }
+
+        _transactionService = transactionService;
+        _targetSchemaVersion = targetSchemaVersion;
+        _migrations = (migrations ?? [])
+            .ToDictionary(static migration => migration.SourceSchemaVersion);
+        ValidateMigrationChain();
+    }
+
+    public WorkspaceMigrationResult MigrateIfNeeded(
+        string workspaceRoot,
+        SignatureKeyMaterial signingKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(signingKey);
+        _transactionService.Recover(workspaceRoot);
+
+        var originalVersion = WorkspaceSchemaInspector.ReadSchemaVersion(workspaceRoot);
+        if (originalVersion > _targetSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"This workspace uses schema {originalVersion}, but this Blueprints version supports up to schema {_targetSchemaVersion}. Update Blueprints before opening it.");
+        }
+
+        if (originalVersion < MinimumSupportedSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"Workspace schema {originalVersion} is no longer supported.");
+        }
+
+        if (originalVersion == _targetSchemaVersion)
+        {
+            return new WorkspaceMigrationResult(
+                originalVersion,
+                originalVersion,
+                [],
+                null);
+        }
+
+        var backupPath = CreateBackup(workspaceRoot, originalVersion);
+        var appliedVersions = new List<int>();
+        try
+        {
+            _transactionService.Execute(workspaceRoot, stagedRoot =>
+            {
+                var currentVersion = originalVersion;
+                while (currentVersion < _targetSchemaVersion)
+                {
+                    if (!_migrations.TryGetValue(currentVersion, out var migration))
+                    {
+                        throw new InvalidOperationException(
+                            $"No migration is available from workspace schema {currentVersion}.");
+                    }
+
+                    migration.Apply(stagedRoot, signingKey);
+                    var migratedVersion = WorkspaceSchemaInspector.ReadSchemaVersion(stagedRoot);
+                    if (migratedVersion != migration.TargetSchemaVersion)
+                    {
+                        throw new InvalidOperationException(
+                            $"Migration from schema {currentVersion} produced schema {migratedVersion} instead of {migration.TargetSchemaVersion}.");
+                    }
+
+                    currentVersion = migratedVersion;
+                    appliedVersions.Add(currentVersion);
+                }
+            });
+        }
+        catch
+        {
+            if (File.Exists(backupPath))
+            {
+                File.Delete(backupPath);
+            }
+
+            throw;
+        }
+
+        return new WorkspaceMigrationResult(
+            originalVersion,
+            _targetSchemaVersion,
+            appliedVersions.ToArray(),
+            backupPath);
+    }
+
+    private string CreateBackup(string workspaceRoot, int schemaVersion)
+    {
+        var fullRoot = Path.GetFullPath(workspaceRoot);
+        var parent = Path.GetDirectoryName(fullRoot)
+            ?? throw new InvalidOperationException("The workspace must have a parent directory.");
+        var workspaceName = Path.GetFileName(fullRoot);
+        var backupRoot = Path.Combine(
+            parent,
+            $".{workspaceName}.blueprints-migration-backups");
+        if (Directory.Exists(backupRoot)
+            && new DirectoryInfo(backupRoot).LinkTarget is not null)
+        {
+            throw new InvalidOperationException(
+                "The migration backup directory cannot be a symbolic link.");
+        }
+
+        Directory.CreateDirectory(backupRoot);
+        var backupPath = Path.Combine(
+            backupRoot,
+            $"schema-{schemaVersion}-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}.zip");
+        ZipFile.CreateFromDirectory(
+            fullRoot,
+            backupPath,
+            CompressionLevel.Optimal,
+            includeBaseDirectory: true);
+        return backupPath;
+    }
+
+    private void ValidateMigrationChain()
+    {
+        foreach (var migration in _migrations.Values)
+        {
+            if (migration.SourceSchemaVersion < MinimumSupportedSchemaVersion
+                || migration.TargetSchemaVersion != migration.SourceSchemaVersion + 1
+                || migration.TargetSchemaVersion > _targetSchemaVersion)
+            {
+                throw new InvalidOperationException(
+                    "Workspace migrations must advance exactly one supported schema version.");
+            }
+        }
+
+        for (var version = MinimumSupportedSchemaVersion;
+             version < _targetSchemaVersion;
+             version++)
+        {
+            if (!_migrations.ContainsKey(version))
+            {
+                throw new InvalidOperationException(
+                    $"The workspace migration chain is missing schema {version}.");
+            }
+        }
+    }
+}

--- a/Blueprints.Storage/Services/WorkspaceSchemaInspector.cs
+++ b/Blueprints.Storage/Services/WorkspaceSchemaInspector.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+
+namespace Blueprints.Storage.Services;
+
+public static class WorkspaceSchemaInspector
+{
+    private const long MaximumProjectDocumentBytes = 4 * 1024 * 1024;
+
+    public static int ReadSchemaVersion(string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        var projectPath = Path.Combine(workspaceRoot, "project", "project.json");
+        var info = new FileInfo(projectPath);
+        if (!info.Exists)
+        {
+            throw new FileNotFoundException(
+                "The workspace project document was not found.",
+                projectPath);
+        }
+
+        if (info.Length > MaximumProjectDocumentBytes)
+        {
+            throw new InvalidOperationException(
+                "The workspace project document exceeds the supported size.");
+        }
+
+        using var stream = File.OpenRead(projectPath);
+        using var document = JsonDocument.Parse(
+            stream,
+            new JsonDocumentOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = 32,
+            });
+        if (!document.RootElement.TryGetProperty("schemaVersion", out var schemaElement)
+            || !schemaElement.TryGetInt32(out var schemaVersion)
+            || schemaVersion < 1)
+        {
+            throw new InvalidOperationException(
+                "The workspace project document has an invalid schema version.");
+        }
+
+        return schemaVersion;
+    }
+}

--- a/Blueprints.Tests/FileSystemWorkspaceTransactionServiceTests.cs
+++ b/Blueprints.Tests/FileSystemWorkspaceTransactionServiceTests.cs
@@ -1,0 +1,175 @@
+using Blueprints.Storage.Models;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class FileSystemWorkspaceTransactionServiceTests : IDisposable
+{
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "WorkspaceTransactions",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Execute_PromotesCompleteStagedWorkspace()
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        Directory.CreateDirectory(workspaceRoot);
+        File.WriteAllText(Path.Combine(workspaceRoot, "before.txt"), "before");
+
+        var service = new FileSystemWorkspaceTransactionService();
+        service.Execute(workspaceRoot, stagedRoot =>
+        {
+            File.Delete(Path.Combine(stagedRoot, "before.txt"));
+            File.WriteAllText(Path.Combine(stagedRoot, "after.txt"), "after");
+        });
+
+        Assert.False(File.Exists(Path.Combine(workspaceRoot, "before.txt")));
+        Assert.Equal("after", File.ReadAllText(Path.Combine(workspaceRoot, "after.txt")));
+        AssertNoTransactionArtifacts(workspaceRoot);
+    }
+
+    [Fact]
+    public void Execute_WhenStagedWriteFails_LeavesOriginalWorkspaceUntouched()
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        Directory.CreateDirectory(workspaceRoot);
+        File.WriteAllText(Path.Combine(workspaceRoot, "project.txt"), "trusted");
+        var service = new FileSystemWorkspaceTransactionService();
+
+        Assert.Throws<IOException>(() =>
+            service.Execute(workspaceRoot, stagedRoot =>
+            {
+                File.WriteAllText(Path.Combine(stagedRoot, "project.txt"), "partial");
+                throw new IOException("Simulated write interruption.");
+            }));
+
+        Assert.Equal("trusted", File.ReadAllText(Path.Combine(workspaceRoot, "project.txt")));
+        AssertNoTransactionArtifacts(workspaceRoot);
+    }
+
+    [Theory]
+    [InlineData(WorkspaceTransactionPhase.Staged)]
+    [InlineData(WorkspaceTransactionPhase.OriginalBackedUp)]
+    [InlineData(WorkspaceTransactionPhase.Promoted)]
+    public void Execute_WhenPromotionIsInterrupted_RestoresOriginalWorkspace(
+        WorkspaceTransactionPhase interruptedPhase)
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        Directory.CreateDirectory(workspaceRoot);
+        File.WriteAllText(Path.Combine(workspaceRoot, "project.txt"), "trusted");
+        var service = new FileSystemWorkspaceTransactionService(phase =>
+        {
+            if (phase == interruptedPhase)
+            {
+                throw new IOException($"Interrupted at {phase}.");
+            }
+        });
+
+        Assert.Throws<IOException>(() =>
+            service.Execute(workspaceRoot, stagedRoot =>
+                File.WriteAllText(Path.Combine(stagedRoot, "project.txt"), "replacement")));
+
+        Assert.Equal("trusted", File.ReadAllText(Path.Combine(workspaceRoot, "project.txt")));
+        AssertNoTransactionArtifacts(workspaceRoot);
+    }
+
+    [Fact]
+    public void Execute_RejectsLinkedWorkspaceEntries()
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        var externalRoot = Path.Combine(_testRoot, "external");
+        Directory.CreateDirectory(workspaceRoot);
+        Directory.CreateDirectory(externalRoot);
+        File.WriteAllText(Path.Combine(externalRoot, "outside.txt"), "outside");
+        var linkPath = Path.Combine(workspaceRoot, "linked");
+
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, externalRoot);
+        }
+        catch (Exception exception) when (
+            exception is UnauthorizedAccessException
+                or IOException
+                or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        var service = new FileSystemWorkspaceTransactionService();
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            service.Execute(workspaceRoot, _ => { }));
+
+        Assert.Contains("linked entries", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("outside", File.ReadAllText(Path.Combine(externalRoot, "outside.txt")));
+    }
+
+    [Fact]
+    public void Recover_RejectsMarkerThatRedirectsBackupOutsideWorkspacePaths()
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        var outsideRoot = Path.Combine(_testRoot, "must-not-delete");
+        Directory.CreateDirectory(workspaceRoot);
+        Directory.CreateDirectory(outsideRoot);
+        File.WriteAllText(Path.Combine(outsideRoot, "evidence.txt"), "preserve");
+        var markerPath = Path.Combine(
+            _testRoot,
+            ".workspace.blueprints-transaction.json");
+        File.WriteAllText(
+            markerPath,
+            $$"""
+            {
+              "schemaVersion": 1,
+              "workspaceRoot": "{{workspaceRoot.Replace("\\", "\\\\", StringComparison.Ordinal)}}",
+              "stagingRoot": "{{Path.Combine(_testRoot, ".workspace.blueprints-staging").Replace("\\", "\\\\", StringComparison.Ordinal)}}",
+              "backupRoot": "{{outsideRoot.Replace("\\", "\\\\", StringComparison.Ordinal)}}",
+              "state": "backedUp",
+              "updatedUtc": "2026-07-31T00:00:00Z"
+            }
+            """);
+        var service = new FileSystemWorkspaceTransactionService();
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            service.Recover(workspaceRoot));
+
+        Assert.Contains("does not match", error.Message, StringComparison.Ordinal);
+        Assert.Equal("preserve", File.ReadAllText(Path.Combine(outsideRoot, "evidence.txt")));
+    }
+
+    [Fact]
+    public void Execute_DoesNotDeleteUntrackedReservedSibling()
+    {
+        var workspaceRoot = Path.Combine(_testRoot, "workspace");
+        var reservedRoot = Path.Combine(
+            _testRoot,
+            ".workspace.blueprints-staging");
+        Directory.CreateDirectory(workspaceRoot);
+        Directory.CreateDirectory(reservedRoot);
+        File.WriteAllText(Path.Combine(reservedRoot, "evidence.txt"), "preserve");
+        var service = new FileSystemWorkspaceTransactionService();
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            service.Execute(workspaceRoot, _ => { }));
+
+        Assert.Contains("Untracked", error.Message, StringComparison.Ordinal);
+        Assert.Equal("preserve", File.ReadAllText(Path.Combine(reservedRoot, "evidence.txt")));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    private static void AssertNoTransactionArtifacts(string workspaceRoot)
+    {
+        var parent = Path.GetDirectoryName(workspaceRoot)!;
+        var name = Path.GetFileName(workspaceRoot);
+        Assert.False(Directory.Exists(Path.Combine(parent, $".{name}.blueprints-staging")));
+        Assert.False(Directory.Exists(Path.Combine(parent, $".{name}.blueprints-backup")));
+        Assert.False(File.Exists(Path.Combine(parent, $".{name}.blueprints-transaction.json")));
+    }
+}

--- a/Blueprints.Tests/HostedSourceProviderContractTests.cs
+++ b/Blueprints.Tests/HostedSourceProviderContractTests.cs
@@ -1,0 +1,79 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class HostedSourceProviderContractTests
+{
+    [Fact]
+    public void Router_RejectsIncompatibleContractVersion()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            new HostedSourceProviderRouter([new StubReader(contractVersion: 2)]));
+
+        Assert.Contains("requires contract 1", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Router_RejectsUnboundedProviderResponse()
+    {
+        var reader = new StubReader(
+            candidateCount: HostedSourceProviderContract.MaximumCandidatesPerDiscovery + 1);
+        var router = new HostedSourceProviderRouter([reader]);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            router.Read(
+                "/repository",
+                new HostedRepositoryDescriptor(SourceProviderKind.GitHub, "owner/repo")));
+
+        Assert.Contains("bounded contract", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuiltInReadersDeclareStableCapabilities()
+    {
+        IHostedSourceProviderReader github = new GitHubRestSourceProviderReader();
+        IHostedSourceProviderReader gitlab = new GitLabRestSourceProviderReader();
+
+        Assert.Equal(1, github.ContractVersion);
+        Assert.Equal(SourceProviderKind.GitHub, github.Provider);
+        Assert.True(github.Capabilities.HasFlag(SourceProviderCapabilities.Issues));
+        Assert.Equal(1, gitlab.ContractVersion);
+        Assert.Equal(SourceProviderKind.GitLab, gitlab.Provider);
+        Assert.True(gitlab.Capabilities.HasFlag(SourceProviderCapabilities.ChangeRequests));
+    }
+
+    private sealed class StubReader(
+        int contractVersion = HostedSourceProviderContract.CurrentVersion,
+        int candidateCount = 0) : IHostedSourceProviderReader
+    {
+        public int ContractVersion => contractVersion;
+
+        public SourceProviderKind Provider => SourceProviderKind.GitHub;
+
+        public SourceProviderCapabilities Capabilities =>
+            SourceProviderCapabilities.Issues;
+
+        public HostedSourceDiscoveryResult Read(
+            string repositoryRoot,
+            HostedRepositoryDescriptor repository) =>
+            new(
+                Enumerable.Range(0, candidateCount)
+                    .Select(index => new SourceDiscoveryCandidate(
+                        SourceArtifactKind.Issue,
+                        $"Issue {index}",
+                        null,
+                        "issue",
+                        "fixed",
+                        false,
+                        $"issue:{index}",
+                        "Contract test",
+                        1))
+                    .ToArray(),
+                [],
+                candidateCount,
+                0,
+                0,
+                0);
+    }
+}

--- a/Blueprints.Tests/IdentityBackupServiceTests.cs
+++ b/Blueprints.Tests/IdentityBackupServiceTests.cs
@@ -1,0 +1,112 @@
+using Blueprints.Security.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class IdentityBackupServiceTests : IDisposable
+{
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "IdentityBackups",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ExportAndImport_RestoresSameSigningIdentityUnderLocalProtection()
+    {
+        var sourceRoot = Path.Combine(_testRoot, "source");
+        var destinationRoot = Path.Combine(_testRoot, "destination");
+        var sourceStore = CreateStore(sourceRoot);
+        var destinationStore = CreateStore(destinationRoot);
+        var original = sourceStore.Create("Backup Owner");
+        var backupPath = Path.Combine(_testRoot, "identity.blueprints-backup");
+        const string passphrase = "a long test passphrase";
+        var exportService = new IdentityBackupService(
+            sourceStore,
+            new Ed25519SignatureService());
+        var importService = new IdentityBackupService(
+            destinationStore,
+            new Ed25519SignatureService());
+
+        exportService.Export(backupPath, original, passphrase);
+        var restored = importService.Import(backupPath, passphrase);
+
+        Assert.Equal(original.Profile.UserId, restored.Profile.UserId);
+        Assert.Equal(original.Profile.KeyId, restored.Profile.KeyId);
+        Assert.Equal(original.Profile.PublicKeyBase64, restored.Profile.PublicKeyBase64);
+        var reloaded = destinationStore.Load(restored.Profile.UserId);
+        var signatureService = new Ed25519SignatureService();
+        var message = "restored identity proof"u8.ToArray();
+        var signature = signatureService.Sign(message, reloaded.SigningKey);
+        Assert.True(signatureService.Verify(message, signature, original.PublicKey));
+    }
+
+    [Fact]
+    public void Import_RejectsWrongPassphraseWithoutCreatingIdentity()
+    {
+        var sourceRoot = Path.Combine(_testRoot, "source");
+        var destinationRoot = Path.Combine(_testRoot, "destination");
+        var sourceStore = CreateStore(sourceRoot);
+        var destinationStore = CreateStore(destinationRoot);
+        var original = sourceStore.Create("Backup Owner");
+        var backupPath = Path.Combine(_testRoot, "identity.blueprints-backup");
+        var exportService = new IdentityBackupService(
+            sourceStore,
+            new Ed25519SignatureService());
+        var importService = new IdentityBackupService(
+            destinationStore,
+            new Ed25519SignatureService());
+        exportService.Export(backupPath, original, "correct horse battery staple");
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            importService.Import(backupPath, "incorrect passphrase"));
+
+        Assert.Contains("incorrect", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(
+            Path.Combine(destinationRoot, original.Profile.UserId.ToString("N"))));
+    }
+
+    [Fact]
+    public void Import_RejectsChangedPublicIdentityEvenWithValidCiphertext()
+    {
+        var sourceRoot = Path.Combine(_testRoot, "source");
+        var destinationRoot = Path.Combine(_testRoot, "destination");
+        var sourceStore = CreateStore(sourceRoot);
+        var destinationStore = CreateStore(destinationRoot);
+        var original = sourceStore.Create("Backup Owner");
+        var backupPath = Path.Combine(_testRoot, "identity.blueprints-backup");
+        var service = new IdentityBackupService(
+            sourceStore,
+            new Ed25519SignatureService());
+        service.Export(backupPath, original, "correct horse battery staple");
+        var json = File.ReadAllText(backupPath);
+        File.WriteAllText(
+            backupPath,
+            json.Replace(
+                "\"displayName\": \"Backup Owner\"",
+                "\"displayName\": \"Attacker\"",
+                StringComparison.Ordinal));
+        var importService = new IdentityBackupService(
+            destinationStore,
+            new Ed25519SignatureService());
+
+        Assert.Throws<InvalidOperationException>(() =>
+            importService.Import(backupPath, "correct horse battery staple"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    private static FileSystemIdentityStore CreateStore(string root)
+    {
+        Directory.CreateDirectory(root);
+        return new FileSystemIdentityStore(
+            root,
+            new Ed25519KeyPairGenerator(),
+            new LocalFilePrivateKeyProtector(Path.Combine(root, "protector.key")));
+    }
+}

--- a/Blueprints.Tests/MainWindowNavigationTests.cs
+++ b/Blueprints.Tests/MainWindowNavigationTests.cs
@@ -19,7 +19,7 @@ public sealed class MainWindowNavigationTests
         Assert.False(viewModel.IsSyncSelected);
         Assert.False(viewModel.IsTrustSelected);
         Assert.False(viewModel.IsIntegrationsSelected);
-        Assert.Equal("Release drafting board", viewModel.SelectedWorkspaceSectionTitle);
+        Assert.Equal("Plan releases", viewModel.SelectedWorkspaceSectionTitle);
     }
 
     [Fact]

--- a/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
+++ b/Blueprints.Tests/MarkdownSourceDiscoveryParserTests.cs
@@ -194,6 +194,13 @@ public sealed class MarkdownSourceDiscoveryParserTests : IDisposable
 
     private sealed class TestHostedSourceProviderReader : IHostedSourceProviderReader
     {
+        public int ContractVersion => HostedSourceProviderContract.CurrentVersion;
+
+        public SourceProviderKind Provider => SourceProviderKind.GitHub;
+
+        public SourceProviderCapabilities Capabilities =>
+            SourceProviderCapabilities.ChangeRequests;
+
         public string RepositoryRoot { get; private set; } = string.Empty;
 
         public HostedRepositoryDescriptor Repository { get; private set; } =

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -658,6 +658,67 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
     }
 
     [Fact]
+    public void ArchiveItem_WhenPromotionIsInterrupted_RestoresItemAndDoesNotPublishArchive()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "archive-failure-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "archive-failure-shared", "BP");
+        var interruptArchive = false;
+        var transactionService = new FileSystemWorkspaceTransactionService(phase =>
+        {
+            if (interruptArchive
+                && phase == Blueprints.Storage.Models.WorkspaceTransactionPhase.OriginalBackedUp)
+            {
+                throw new IOException("Simulated archive promotion interruption.");
+            }
+        });
+        var service = CreateService(transactionService);
+        service.CreateProject(
+            new ProjectCreateRequest(
+                "Blueprints",
+                "BP",
+                "SemVer",
+                localRoot,
+                sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(
+                null,
+                "0.6.0",
+                ReleaseStatus.InProgress,
+                null));
+        var versionId = Assert.Single(versionSession.LoadResult.Workspace.Versions)
+            .Version.VersionId;
+        var itemSession = service.SaveItem(
+            localRoot,
+            sharedRoot,
+            new ItemEditRequest(
+                versionId,
+                null,
+                "feature",
+                "added",
+                "Must survive",
+                null,
+                false));
+        var itemId = Assert.Single(
+            itemSession.LoadResult.Workspace.Versions.Single().Items).ItemId;
+
+        interruptArchive = true;
+        Assert.Throws<IOException>(() =>
+            service.ArchiveItem(localRoot, sharedRoot, versionId, itemId));
+        interruptArchive = false;
+
+        var restored = service.OpenProject(localRoot, sharedRoot);
+        Assert.Equal(
+            itemId,
+            Assert.Single(restored.LoadResult.Workspace.Versions.Single().Items).ItemId);
+        var archiveRoot = Path.Combine(localRoot, ".blueprints", "archive");
+        Assert.True(
+            !Directory.Exists(archiveRoot)
+            || !Directory.EnumerateDirectories(archiveRoot).Any());
+    }
+
+    [Fact]
     public void ExportVersionChangelog_WritesMarkdownAndExcludesIncompleteItemsByDefault()
     {
         var localRoot = Path.Combine(_rootDirectory, "changelog-local", "BP");
@@ -1121,7 +1182,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         Assert.Contains("not configured", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    private ProjectWorkspaceCoordinatorService CreateService()
+    private ProjectWorkspaceCoordinatorService CreateService(
+        Blueprints.Storage.Abstractions.IWorkspaceTransactionService? transactionService = null)
     {
         var identityRoot = Path.Combine(_rootDirectory, "identities");
         var signedStore = new FileSystemSignedDocumentStore(
@@ -1154,7 +1216,8 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
             workspaceSyncService,
             new RecentProjectsStore(Path.Combine(_rootDirectory, "recent-projects.json")),
             auditLogService,
-            new Blueprints.Collaboration.Services.SharedFolderSafetyInspector());
+            new Blueprints.Collaboration.Services.SharedFolderSafetyInspector(),
+            transactionService);
     }
 
     private static string FindGenesisAuditEntry(string logRoot) =>

--- a/Blueprints.Tests/WorkspaceMigrationServiceTests.cs
+++ b/Blueprints.Tests/WorkspaceMigrationServiceTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using Blueprints.Security.Models;
+using Blueprints.Storage.Abstractions;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class WorkspaceMigrationServiceTests : IDisposable
+{
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        "Blueprints.Tests",
+        "WorkspaceMigrations",
+        Guid.NewGuid().ToString("N"));
+    private static readonly SignatureKeyMaterial TestKey =
+        new("test", new byte[32]);
+
+    [Fact]
+    public void MigrateIfNeeded_CurrentSchemaDoesNotRewriteWorkspace()
+    {
+        var workspaceRoot = CreateWorkspace(schemaVersion: 1);
+        var projectPath = Path.Combine(workspaceRoot, "project", "project.json");
+        var original = File.ReadAllText(projectPath);
+        var service = new WorkspaceMigrationService(
+            new FileSystemWorkspaceTransactionService());
+
+        var result = service.MigrateIfNeeded(workspaceRoot, TestKey);
+
+        Assert.False(result.WasMigrated);
+        Assert.Null(result.BackupPath);
+        Assert.Equal(original, File.ReadAllText(projectPath));
+    }
+
+    [Fact]
+    public void MigrateIfNeeded_FutureSchemaExplainsRequiredUpgrade()
+    {
+        var workspaceRoot = CreateWorkspace(schemaVersion: 2);
+        var service = new WorkspaceMigrationService(
+            new FileSystemWorkspaceTransactionService());
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            service.MigrateIfNeeded(workspaceRoot, TestKey));
+
+        Assert.Contains("Update Blueprints", error.Message, StringComparison.Ordinal);
+        Assert.Equal(2, WorkspaceSchemaInspector.ReadSchemaVersion(workspaceRoot));
+    }
+
+    [Fact]
+    public void MigrateIfNeeded_AppliesOrderedMigrationAndKeepsBackup()
+    {
+        var workspaceRoot = CreateWorkspace(schemaVersion: 1);
+        var service = new WorkspaceMigrationService(
+            new FileSystemWorkspaceTransactionService(),
+            [new TestMigration()],
+            targetSchemaVersion: 2);
+
+        var result = service.MigrateIfNeeded(workspaceRoot, TestKey);
+
+        Assert.True(result.WasMigrated);
+        Assert.Equal([2], result.AppliedSchemaVersions);
+        Assert.Equal(2, WorkspaceSchemaInspector.ReadSchemaVersion(workspaceRoot));
+        Assert.NotNull(result.BackupPath);
+        Assert.True(File.Exists(result.BackupPath));
+    }
+
+    [Fact]
+    public void MigrateIfNeeded_WhenMigrationFails_RestoresWorkspaceAndRemovesBackup()
+    {
+        var workspaceRoot = CreateWorkspace(schemaVersion: 1);
+        var service = new WorkspaceMigrationService(
+            new FileSystemWorkspaceTransactionService(),
+            [new FailingMigration()],
+            targetSchemaVersion: 2);
+
+        Assert.Throws<IOException>(() =>
+            service.MigrateIfNeeded(workspaceRoot, TestKey));
+
+        Assert.Equal(1, WorkspaceSchemaInspector.ReadSchemaVersion(workspaceRoot));
+        var parent = Path.GetDirectoryName(workspaceRoot)!;
+        var backupRoot = Path.Combine(
+            parent,
+            $".{Path.GetFileName(workspaceRoot)}.blueprints-migration-backups");
+        Assert.Empty(Directory.EnumerateFiles(backupRoot));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    private string CreateWorkspace(int schemaVersion)
+    {
+        var root = Path.Combine(_testRoot, $"workspace-{schemaVersion}");
+        var projectRoot = Path.Combine(root, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(
+            Path.Combine(projectRoot, "project.json"),
+            JsonSerializer.Serialize(new { schemaVersion, name = "Migration test" }));
+        return root;
+    }
+
+    private sealed class TestMigration : IWorkspaceMigration
+    {
+        public int SourceSchemaVersion => 1;
+
+        public int TargetSchemaVersion => 2;
+
+        public void Apply(string stagedWorkspaceRoot, SignatureKeyMaterial signingKey)
+        {
+            var path = Path.Combine(stagedWorkspaceRoot, "project", "project.json");
+            File.WriteAllText(
+                path,
+                JsonSerializer.Serialize(new { schemaVersion = 2, name = "Migrated" }));
+        }
+    }
+
+    private sealed class FailingMigration : IWorkspaceMigration
+    {
+        public int SourceSchemaVersion => 1;
+
+        public int TargetSchemaVersion => 2;
+
+        public void Apply(string stagedWorkspaceRoot, SignatureKeyMaterial signingKey)
+        {
+            var path = Path.Combine(stagedWorkspaceRoot, "project", "project.json");
+            File.WriteAllText(path, JsonSerializer.Serialize(new { schemaVersion = 2 }));
+            throw new IOException("Simulated migration interruption.");
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+### Added
+
+- A completely rebuilt beginner-first desktop shell with task-based setup, plain-language navigation, modern visual hierarchy, and focused new/open/join project paths.
+- Encrypted signing-identity backup and clean-profile restore using AES-256-GCM, PBKDF2-SHA256 with 600,000 iterations, authenticated identity metadata, private/public-key verification, bounded input, and destination-device key rewrapping.
+- Atomic local workspace transactions that stage complete signed mutations with their audit append, promote the staged directory, and restore the prior workspace when any promotion checkpoint fails.
+- A workspace schema inspector and ordered migration engine with future-schema rejection, pre-migration ZIP backup, transactional application, and failed-migration rollback.
+- A versioned hosted-provider extension contract with declared capabilities, compatibility checks, and bounded result limits for built-in and future readers.
+- An attacker-focused threat model plus a planned stable platform, supported-version, release-qualification, and vulnerability-response policy.
+
+### Changed
+
+- Primary navigation now uses familiar outcomes—Home, Plan releases, Find work, People, Share changes, and Safety check—instead of implementation terminology.
+- The canvas retains the blueprint concept while the surrounding application uses a calmer neutral-and-violet product system, clearer primary actions, larger targets, and simpler guidance.
+- Project creation now commits the project, local trust anchors, and initial audit entry as one recoverable transaction.
+- Canvas and relationship mutations now commit signed data and audit evidence through the same transaction boundary.
+- Source-provider routing now validates contract versions, provider capabilities, duplicate registrations, and bounded response counts before accepting extension output.
+
+### Security
+
+- Transaction recovery accepts only deterministic sibling staging and backup paths and rejects a marker that attempts to redirect recovery or cleanup.
+- Identity recovery rejects wrong passphrases, changed authenticated metadata, malformed encryption parameters, mismatched private keys, oversized files, and duplicate local identities.
+- Workspace transactions refuse symbolic-link entries instead of copying through them.
+
+### Workspace compatibility
+
+- Signed workspace schema remains version 1.
+- Current schema-1 workspaces open without rewriting.
+- Future schemas fail with an explicit upgrade requirement; future migrations must advance one schema at a time, verify their produced version, retain a complete pre-migration backup, and pass through atomic promotion.
+
+### Known limitations
+
+- Distribution and installer work remains intentionally deferred.
+- Automated same-user key rotation, time-qualified revocation, and hardware-backed key support remain future security work.
+- Platform qualification still requires retained manual install, accessibility, upgrade, and recovery results on the final supported operating-system matrix.
+
 ## 0.5.0 — 2026-07-31
 
 VaultSync recovery integration milestone. This release adds passive backup-health awareness, explicit project-specific exchange registration, advisory release-safety evidence, and a tested restore path while preserving Blueprints as the authority for signed release state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+## 0.6.0 — 2026-07-31
+
+Stable-foundations milestone. This release rebuilds the desktop experience for first-time users while adding atomic local mutation, migration, identity-recovery, provider-contract, accessibility, and security-policy foundations for v1.0.
+
 ### Added
 
 - A completely rebuilt beginner-first desktop shell with task-based setup, plain-language navigation, modern visual hierarchy, and focused new/open/join project paths.
@@ -15,11 +19,14 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ### Changed
 
+- Completed release builds identify themselves as `0.6.0`.
 - Primary navigation now uses familiar outcomes—Home, Plan releases, Find work, People, Share changes, and Safety check—instead of implementation terminology.
 - The canvas retains the blueprint concept while the surrounding application uses a calmer neutral-and-violet product system, clearer primary actions, larger targets, and simpler guidance.
 - Project creation now commits the project, local trust anchors, and initial audit entry as one recoverable transaction.
 - Canvas and relationship mutations now commit signed data and audit evidence through the same transaction boundary.
+- Draft item and version archives now create their recovery copy, remove active files, update signed state, and append audit evidence inside one transaction; interruption publishes neither the removal nor a partial archive.
 - Source-provider routing now validates contract versions, provider capabilities, duplicate registrations, and bounded response counts before accepting extension output.
+- Main destinations now expose explicit accessibility names and `Ctrl`/`Command` plus number shortcuts; icon-only canvas actions expose readable names and tooltips.
 
 ### Security
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 
 - [Documentation index](docs/README.md)
 - [User guide](docs/user-guide.md)
+- [Accessibility](docs/accessibility.md)
 - [Canvas engine](docs/canvas-engine.md)
 - [Source Lens](docs/source-lens.md)
 - [VaultSync integration](docs/vaultsync-integration.md)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Blueprints uses a local workspace as the editable source of truth and a separate
 - [Architecture](docs/architecture.md)
 - [Workspace format](docs/workspace-format.md)
 - [Security model](docs/security-model.md)
+- [Threat model](docs/threat-model.md)
+- [Support policy](docs/support-policy.md)
 - [SonarQube Cloud](docs/sonarqube.md)
 - [Development guide](docs/development.md)
 - [Release process](docs/releasing.md)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -100,16 +100,18 @@ Exit criteria:
 - VaultSync owns backup/sync transport and verification;
 - either product remains usable when the other is absent.
 
-## v1.0: dependable small-team release planner
+## In progress — v1.0: dependable small-team release planner
 
 Goal: supported installers and documented recovery for small teams.
 
-- accessible and polished desktop navigation;
-- versioned workspace schema and migrations;
-- signed, reproducible packages and release attestations;
-- tested Windows, macOS, and Linux support policy;
-- documented threat model, limitations, backup, restore, and key recovery;
-- stable extension contracts for providers.
+- [x] Replace the engineering-console shell with beginner-first setup, plain-language task navigation, and a modern visual system.
+- [ ] Complete retained keyboard, focus, scaling, and screen-reader qualification on every supported desktop.
+- [x] Add versioned workspace inspection, ordered migrations, backups, and rollback.
+- [ ] Add signed, reproducible packages and release attestations when distribution work begins.
+- [ ] Retain manual qualification results for Windows, macOS, and Linux under the published support policy.
+- [x] Document the attacker-focused threat model, limitations, backup, restore, identity recovery, and support targets.
+- [x] Stabilize and bound the version-1 extension contract for hosted source providers.
+- [ ] Add automated same-user key rotation, revocation evidence, and stronger platform-keystore integration.
 
 ## Explicit non-goals before v1.0
 
@@ -124,14 +126,14 @@ Goal: supported installers and documented recovery for small teams.
 
 Security work is a release requirement across every milestone, not a one-time feature:
 
-- [ ] maintain an attacker-focused threat model for every trust boundary;
-- [ ] add adversarial tests for malformed, replayed, rolled-back, partially written, and maliciously signed input;
+- [x] maintain an attacker-focused threat model for every trust boundary;
+- [x] add adversarial tests for malformed, replayed, rolled-back, partially written, and maliciously signed input;
 - [ ] define key rotation, revocation, recovery, and platform keystore integration;
-- [ ] make workspace updates atomic and recoverable;
+- [x] make core local signed workspace updates atomic and recoverable;
 - [ ] generate an SBOM for every published package;
 - [ ] generate provenance attestations when downloadable packages are introduced;
 - [ ] commission an independent security review before a stable release;
-- [ ] publish supported-version and vulnerability-response targets;
+- [x] publish supported-version and vulnerability-response targets;
 - [ ] never describe a release as audited unless its exact source and artifacts were reviewed.
 
 No release can guarantee that every user is always safe. Blueprints instead aims to make its trust boundaries explicit, minimize sensitive state, fail closed when integrity cannot be established, and respond transparently when a weakness is found.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -100,18 +100,36 @@ Exit criteria:
 - VaultSync owns backup/sync transport and verification;
 - either product remains usable when the other is absent.
 
+## Completed — v0.6: stable foundations and approachable desktop
+
+Goal: make the application understandable on first contact while establishing the data-safety contracts required for stable releases.
+
+- [x] Replace the engineering-console shell with beginner-first setup, plain-language task navigation, and a modern visual system.
+- [x] Add explicit accessibility names, keyboard destination shortcuts, readable icon actions, and an accessibility qualification guide.
+- [x] Make core local signed mutations and recoverable archives atomic across project state and their audit evidence.
+- [x] Add versioned workspace inspection, ordered migrations, complete pre-migration backups, rollback, and future-schema rejection.
+- [x] Add encrypted signing-identity backup and clean-profile recovery with private/public-key verification.
+- [x] Stabilize and bound the version-1 hosted-source provider contract.
+- [x] Publish an attacker-focused threat model plus planned platform, version-support, release-qualification, and vulnerability-response targets.
+- [x] Expand interruption, malicious-marker, linked-path, migration, provider-contract, and identity-recovery tests.
+
+Exit criteria:
+
+- a first-time user can distinguish starting, opening, and joining without understanding Blueprints internals;
+- interrupted local mutation or archive promotion restores the prior workspace;
+- current workspaces open without rewriting, future schemas fail clearly, and migration failures preserve the original;
+- a signing identity can be encrypted, restored on a clean profile, and verified before use;
+- extension and security boundaries are versioned, bounded, tested, and documented.
+
 ## In progress — v1.0: dependable small-team release planner
 
 Goal: supported installers and documented recovery for small teams.
 
-- [x] Replace the engineering-console shell with beginner-first setup, plain-language task navigation, and a modern visual system.
 - [ ] Complete retained keyboard, focus, scaling, and screen-reader qualification on every supported desktop.
-- [x] Add versioned workspace inspection, ordered migrations, backups, and rollback.
 - [ ] Add signed, reproducible packages and release attestations when distribution work begins.
 - [ ] Retain manual qualification results for Windows, macOS, and Linux under the published support policy.
-- [x] Document the attacker-focused threat model, limitations, backup, restore, identity recovery, and support targets.
-- [x] Stabilize and bound the version-1 extension contract for hosted source providers.
 - [ ] Add automated same-user key rotation, revocation evidence, and stronger platform-keystore integration.
+- [ ] Commission independent security and recovery review of the stable source tree.
 
 ## Explicit non-goals before v1.0
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Blueprints is pre-release. Security fixes target the latest commit on `develop` and are promoted to `main` with the next release candidate. No released version is currently covered by a long-term support commitment.
+Blueprints is pre-release. Security fixes target the latest commit on `develop` and are promoted to `main` with the next release candidate. No released version is currently covered by a long-term support commitment. The planned stable-version coverage and response targets are documented in [the support policy](docs/support-policy.md).
 
 ## Reporting a vulnerability
 
@@ -32,3 +32,4 @@ Changes involving these areas need explicit review and adversarial tests:
 - recovery behavior after corrupt or untrusted input.
 
 Read [the security model](docs/security-model.md) before changing these components.
+Use [the threat model](docs/threat-model.md) to review attacker capabilities and residual risk.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,4 +9,4 @@ Blueprints is currently a community-supported technical preview.
 
 Include the operating system, .NET SDK version, Blueprints commit/version, relevant logs, and sanitized reproduction steps. Never upload private keys, access tokens, or real confidential workspace content.
 
-There is no guaranteed response time or production support commitment before v1.0.
+There is no guaranteed response time or production support commitment before v1.0. The platform matrix and response targets being qualified for stable releases are documented in [the support policy](docs/support-policy.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Use this directory as the canonical technical and user documentation.
 | Understanding the code | [Architecture](architecture.md) |
 | Inspecting project files | [Workspace format](workspace-format.md) |
 | Reviewing trust boundaries | [Security model](security-model.md) |
+| Understanding attacker assumptions | [Threat model](threat-model.md) |
+| Reviewing platform and response targets | [Support policy](support-policy.md) |
 | Rotating or recovering member keys | [Member key lifecycle](key-lifecycle.md) |
 | Backing up or restoring a project | [Backup and disaster recovery](backup-recovery.md) |
 | Activating SonarQube Cloud | [SonarQube Cloud](sonarqube.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use this directory as the canonical technical and user documentation.
 | Audience | Document |
 | --- | --- |
 | Trying the app | [User guide](user-guide.md) |
+| Using keyboard or assistive technology | [Accessibility](accessibility.md) |
 | Understanding the visual workspace | [Canvas engine](canvas-engine.md) |
 | Importing issues and planning files | [Source Lens](source-lens.md) |
 | Inspecting VaultSync backup health | [VaultSync integration](vaultsync-integration.md) |

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,37 @@
+# Accessibility
+
+Blueprints is designed so the release-planning workflow does not depend on recognizing unfamiliar icons or understanding its signature implementation.
+
+## Current interaction support
+
+- Main destinations use outcome-based text labels and explicit accessible names.
+- `Ctrl+1` through `Ctrl+6` switches between Home, Plan releases, Find work, People, Share changes, and Safety check. Use `Command` instead of `Ctrl` on macOS.
+- Standard `Tab` and `Shift+Tab` navigation reaches form fields and actions.
+- All icon-only canvas controls expose text tooltips and accessible names.
+- Canvas nodes support keyboard selection and movement; the on-screen footer lists the available keys.
+- Destructive and irreversible actions use text labels and explain their consequences.
+- Color is supplemented by labels, counts, status text, and guidance.
+- Default Fluent focus presentation is retained rather than hidden by custom styling.
+
+## Language rules
+
+Primary navigation and first-run setup use user outcomes rather than implementation terms. Advanced evidence such as signatures, manifests, key IDs, and audit details belongs in Safety check, Share changes, or People, where it is accompanied by plain-language guidance.
+
+Every new empty, blocked, invalid, or read-only state should answer:
+
+1. what happened;
+2. whether the user's data changed;
+3. what the user can safely do next.
+
+## Stable-release qualification
+
+The current repository has automated command and workflow coverage, but it does not yet claim completed assistive-technology certification. Before v1.0, retain manual results for every supported desktop platform covering:
+
+- keyboard-only first run, project creation, release planning, export, invitation, sync, conflict, and identity recovery;
+- visible focus at 100%, 150%, and 200% display scaling;
+- screen-reader names, roles, state changes, and reading order;
+- high-contrast or increased-contrast settings;
+- reduced-motion behavior if motion is introduced;
+- text clipping at supported window minimums and increased system text sizes.
+
+Accessibility regressions are release blockers for the primary workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,10 +56,24 @@ There is no dependency-injection container. Constructor composition keeps the cu
 
 1. Require a trusted workspace and no unresolved conflicts.
 2. Validate role or lifecycle rules.
-3. create the updated immutable record graph.
-4. Write canonical JSON and detached signatures.
-5. Append a signed, hash-linked audit entry.
-6. Reload the session so displayed state comes from disk.
+3. Create the updated immutable record graph.
+4. Copy the local workspace to a deterministic sibling staging directory without following links.
+5. Write canonical JSON and detached signatures into the staged workspace.
+6. Append the signed, hash-linked audit entry to that same staged workspace.
+7. Move the original directory to a recoverable backup, promote the staging directory, and remove the backup only after promotion succeeds.
+8. Recover the original directory if any checkpoint fails.
+9. Reload the session so displayed state comes from disk.
+
+Opening a workspace first processes any bounded transaction marker. Marker paths must match the deterministic workspace, staging, and backup paths exactly; marker content cannot redirect cleanup.
+
+### Schema compatibility
+
+1. Inspect the bounded `project/project.json` schema field before normal loading.
+2. Open the current schema without rewriting it.
+3. Reject a future schema with an explicit application-upgrade requirement.
+4. For an older supported schema, create a complete pre-migration ZIP backup.
+5. Apply every declared one-version migration inside the workspace transaction.
+6. Require each step to produce its declared schema before promotion.
 
 ### Canvas layout mutation
 
@@ -140,8 +154,9 @@ The VaultSync recovery drill exercises the boundary without invoking VaultSync: 
 - `MainWindowViewModel` combines screen state, workflow commands, mapping, diagnostics, and design data.
 - `MainWindow.axaml` contains all application sections in one file.
 - `ProjectWorkspaceCoordinatorService` combines multiple application use cases.
-- file writes are signed but not yet implemented as a transactional workspace commit;
-- workspace schema migration and formal compatibility rules do not yet exist;
-- automated end-to-end UI and two-user collaboration tests are absent.
+- archive and shared-exchange operations use their own staging/recovery flows rather than the core local transaction boundary;
+- no schema-2 migration exists yet because schema 1 remains current, although the compatibility and migration engine is in place;
+- automated end-to-end desktop UI tests are absent;
+- automated same-user key rotation and time-qualified revocation remain unimplemented.
 
 These are tracked in [the roadmap](../Roadmap.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ The VaultSync recovery drill exercises the boundary without invoking VaultSync: 
 - `MainWindowViewModel` combines screen state, workflow commands, mapping, diagnostics, and design data.
 - `MainWindow.axaml` contains all application sections in one file.
 - `ProjectWorkspaceCoordinatorService` combines multiple application use cases.
-- archive and shared-exchange operations use their own staging/recovery flows rather than the core local transaction boundary;
+- shared-exchange operations use their own staging, rollback-pair, and recovery flow rather than the core local transaction boundary;
 - no schema-2 migration exists yet because schema 1 remains current, although the compatibility and migration engine is in place;
 - automated end-to-end desktop UI tests are absent;
 - automated same-user key rotation and time-qualified revocation remain unimplemented.

--- a/docs/key-lifecycle.md
+++ b/docs/key-lifecycle.md
@@ -28,4 +28,16 @@ Blueprints does not silently rewrite historical signatures. Deactivation prevent
 
 Keep identity backups separate from project backups. Project workspaces contain public keys, not private signing keys. Conflict recovery copies preserve documents, not identities.
 
-Automated same-user key rotation, platform-keystore migration, revocation timestamps, and hardware-backed keys remain future security work.
+Blueprints can export the current identity as an encrypted recovery file:
+
+1. open **People** and enter a passphrase of at least 12 characters;
+2. create the encrypted backup;
+3. store the backup separately from project backups;
+4. store the passphrase in a different trusted location;
+5. test restoration on a clean operating-system user profile before relying on it.
+
+The recovery file uses AES-256-GCM and authenticates the public identity metadata. Its key is derived with PBKDF2-SHA256 using a random salt and 600,000 iterations. Restore verifies that the decrypted private key matches the recorded public key, then protects it again using the destination device's configured local key protector.
+
+Anyone with both the backup and passphrase can sign as that identity. Do not store them together. Restoring does not reactivate a member that an administrator already deactivated.
+
+Automated same-user key rotation, platform-keystore migration beyond the current platform protectors, revocation timestamps, and hardware-backed keys remain future security work.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,7 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.6.0` | 2026-07-31 | Stable foundations and approachable desktop | Beginner-first desktop redesign, atomic signed workspace and archive mutations, migration and compatibility infrastructure, encrypted identity recovery, stable bounded provider contracts, accessibility shortcuts, threat modeling, and support targets |
 | `v0.5.0` | 2026-07-31 | VaultSync recovery integration | Passive bounded backup-health awareness, explicit project-specific exchange registration, advisory release-safety diagnostics, atomic local integration settings, and an end-to-end local/exchange restore drill |
 | `v0.4.0` | 2026-07-30 | Provider-neutral source-control awareness | Advanced canvas editing, signed typed relationships, multi-repository readiness analysis, provider-neutral references, direct bounded GitHub and GitLab discovery, isolated credentials, and an explicit approval boundary for future provider writes |
 | `v0.3.0` | 2026-07-30 | Understandable collaboration | Distinct signing identities, signed invitation onboarding, member-key-aware trust, staged and recoverable sync, semantic conflict comparison, manifest/audit evidence, recoverable archives, explicit identity setup, and disaster-recovery guidance |
@@ -16,7 +17,6 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Milestone outcome |
 | --- | --- |
-| `v0.2.0` | Complete the coherent solo workflow with identity onboarding, editing history, archive/delete flows, and release polish |
 | `v1.0.0` | A dependable, supported small-team release planner |
 
 ## Release record requirements

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,6 +19,9 @@ Each roadmap milestone maps to one semantic version:
 v0.1 milestone -> v0.1.0
 v0.2 milestone -> v0.2.0
 v0.3 milestone -> v0.3.0
+v0.4 milestone -> v0.4.0
+v0.5 milestone -> v0.5.0
+v0.6 milestone -> v0.6.0
 ```
 
 Use SemVer prerelease identifiers for honest intermediate checkpoints, for example `v0.2.0-alpha.2`. Use the clean `v0.x.0` form only when that roadmap milestone's exit criteria are complete. GitHub records remain marked as prereleases until v1.0.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -74,7 +74,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Linux/macOS key protection ultimately depends on file permissions protecting the local AES key.
 - The audit chain detects many edits and deletions, but is not anchored to an external transparency service.
 - Shared-folder availability, confidentiality, and rollback resistance depend on the underlying storage.
-- Core local mutations stage signed documents and their audit append together, promote the staged workspace as one directory transaction, and restore the prior directory when promotion is interrupted. Archive and shared-exchange operations retain their separately documented staging and recovery behavior.
+- Core local mutations, including recoverable archives, stage signed documents and their audit append together, promote the staged workspace as one directory transaction, and restore the prior directory when promotion is interrupted. Shared-exchange operations retain their separately documented staging and rollback-pair behavior.
 - Canvas layout is a whole signed document; concurrent arrangements conflict as a unit and are not field-merged.
 - Conflict resolution provides semantic summaries for known document types but still operates on whole documents rather than merging individual fields.
 - Conflict recovery copies are local, unsigned operational records; protect and back them up according to the sensitivity of project content.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -70,11 +70,11 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 ## Important limitations
 
 - A valid member key can sign malicious or incorrect content; signatures establish key possession, not intent.
-- The current model does not provide key revocation, rotation, hardware-backed storage, or recovery.
+- The current model does not provide automated key revocation, same-user rotation, or hardware-backed storage. Encrypted identity backup and clean-profile recovery are available.
 - Linux/macOS key protection ultimately depends on file permissions protecting the local AES key.
 - The audit chain detects many edits and deletions, but is not anchored to an external transparency service.
 - Shared-folder availability, confidentiality, and rollback resistance depend on the underlying storage.
-- Current workspace saves are not a single atomic transaction across all changed files.
+- Core local mutations stage signed documents and their audit append together, promote the staged workspace as one directory transaction, and restore the prior directory when promotion is interrupted. Archive and shared-exchange operations retain their separately documented staging and recovery behavior.
 - Canvas layout is a whole signed document; concurrent arrangements conflict as a unit and are not field-merged.
 - Conflict resolution provides semantic summaries for known document types but still operates on whole documents rather than merging individual fields.
 - Conflict recovery copies are local, unsigned operational records; protect and back them up according to the sensitivity of project content.
@@ -94,4 +94,4 @@ Security-sensitive pull requests should include:
 
 Report vulnerabilities using [SECURITY.md](../SECURITY.md).
 
-Operational behavior for planned rotation, compromise, and lost keys is defined in [member key lifecycle](key-lifecycle.md). Automated same-user rotation and revocation remain unimplemented.
+Operational behavior for planned rotation, compromise, lost keys, and encrypted identity recovery is defined in [member key lifecycle](key-lifecycle.md). Automated same-user rotation and revocation remain unimplemented. Attacker capabilities and abuse cases are maintained in the [threat model](threat-model.md).

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -1,0 +1,54 @@
+# Support policy
+
+Blueprints remains pre-release until the v1.0 release criteria are complete. This document defines the support target being qualified; it is not yet a claim that preview builds are production-supported.
+
+## Planned v1.x platform tiers
+
+| Tier | Platforms | Commitment |
+| --- | --- | --- |
+| Supported desktop | Windows 11 x64/Arm64, macOS 14 or newer on Apple silicon and Intel, Ubuntu 24.04 LTS x64 | Clean install/launch, core workflow, upgrade, identity recovery, and two-user exchange are release-tested |
+| Best effort | Other current x64/Arm64 Linux distributions with compatible .NET and desktop dependencies | Bugs are accepted, but every distribution is not release-tested |
+| Unsupported | End-of-life operating systems, mobile platforms, web browsers, and network filesystems that cannot provide normal file replacement semantics | No compatibility or recovery guarantee |
+
+The exact minimum versions may move before v1.0 when an operating system or runtime reaches end of support. A stable release will record its final matrix in its release notes.
+
+## Supported versions
+
+Once v1.0 is published:
+
+- the latest v1.x minor release receives security and correctness fixes;
+- the immediately previous minor release receives critical security fixes for at least 90 days after its successor;
+- preview builds receive fixes only through a newer preview;
+- workspace migration support is maintained from every stable v1.x schema to the current v1.x schema.
+
+Breaking workspace or extension-contract changes require a new major version.
+
+## Response targets
+
+These are project targets, not a paid service-level agreement:
+
+| Severity | Acknowledge | Initial assessment | Fix or mitigation target |
+| --- | ---: | ---: | ---: |
+| Critical: key disclosure, trusted-state bypass, or unauthenticated arbitrary file mutation | 2 business days | 3 business days | 7 days |
+| High: integrity or authorization weakness requiring meaningful user interaction | 3 business days | 7 days | 30 days |
+| Moderate/low security issue | 7 days | 14 days | Next appropriate release |
+| Data-loss defect without a security boundary bypass | 3 business days | 7 days | 30 days |
+
+Complex reports may require more time. The maintainer should communicate changed expectations privately rather than leaving a reporter without an update.
+
+## Release qualification matrix
+
+Every supported desktop target must exercise:
+
+- clean launch and first-run identity creation;
+- encrypted identity backup and clean-profile restore;
+- create, reopen, edit, freeze, release, preview, and export;
+- schema inspection, migration backup, failure rollback, and future-schema rejection;
+- two distinct identities exchanging changes;
+- tampered, replayed, incomplete, and conflicting shared input;
+- interrupted local transaction recovery;
+- local and exchange backup restoration;
+- keyboard navigation, visible focus, scaling, and a basic screen-reader smoke test;
+- upgrade and uninstall behavior once distribution work begins.
+
+CI compilation alone is not platform qualification. Results should be retained with the release record.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,64 @@
+# Threat model
+
+This document describes attacker goals, capabilities, trust boundaries, and residual risk for Blueprints. It complements the invariant-focused [security model](security-model.md).
+
+## Security objectives
+
+Blueprints aims to:
+
+- preserve the integrity and authorship evidence of release plans;
+- prevent untrusted shared-folder content from silently changing trusted local state;
+- keep private signing keys and provider credentials out of projects and shared folders;
+- preserve a recoverable previous workspace when a local mutation is interrupted;
+- make conflicts, invalid signatures, and incomplete state visible before editing continues.
+
+Blueprints does not promise confidentiality for project content, prevent an authorized member from signing harmful content, or make an untrusted storage provider available.
+
+## Attacker capabilities
+
+The design assumes an attacker may:
+
+- read, add, replace, truncate, replay, or delete files in the shared exchange root;
+- provide malformed JSON, oversized values, deep object graphs, invalid Base64, unknown schemas, and mismatched document/signature pairs;
+- copy an older valid shared snapshot over a newer one;
+- interrupt the process or exhaust disk space between filesystem operations;
+- control repository content and hosted-provider response text;
+- provide a malicious invitation, recovery file, VaultSync sidecar, integration path, or transaction marker;
+- possess the valid signing key of a current or former project member;
+- attempt to trick a user into approving the wrong provider or exchange operation.
+
+The model does not assume resistance after the attacker has arbitrary code execution as the same operating-system user. Such an attacker can access application memory and act with the user's filesystem permissions.
+
+## Trust boundaries and abuse cases
+
+| Boundary | Attacker goal | Required treatment | Residual risk |
+| --- | --- | --- | --- |
+| Local workspace | Leave partially updated signed truth or audit history | Stage the complete mutation, append audit evidence in the staged copy, atomically promote it, and restore the prior directory after interruption | Filesystem or hardware failure may still damage both copies |
+| Shared exchange | Inject, replay, delete, or partially copy project files | Bound paths and sizes, verify manifests and signatures, stage pulls, detect conflicts and continuity failures, retain rollback pairs | Storage can deny service or withhold newer data |
+| Transaction marker | Redirect cleanup or recovery outside the workspace | Use deterministic sibling paths and require the bounded marker to match every resolved path exactly | Same-user arbitrary code execution can replace local state |
+| Identity store | Steal or replace a private signing key | Apply platform/local key protection, restrict local files, verify restored private keys against public identity | macOS/Linux fallback protection depends on a local secret and filesystem permissions |
+| Identity backup | Guess the passphrase or alter recovery metadata | AES-256-GCM, PBKDF2-SHA256 with 600,000 iterations, authenticated identity metadata, strict size bounds, and proof that the key matches the public identity | A weak user-chosen passphrase remains guessable offline |
+| Invitations | Substitute a different member, project, or key | Signed proof of key possession and exact project/member binding; explicit administrator review | Users can still intentionally trust the wrong person |
+| Hosted providers | Exfiltrate credentials or inject authoritative state | Environment-only credentials, bounded read contracts, explicit proposal approval, exact-target single-use write authorization | Provider data can mislead a user who approves it |
+| Git worktree | Trigger code execution through discovery | Read metadata and bounded text only; never execute project hooks or scripts | Git itself and the local filesystem remain external dependencies |
+| Canvas/UI input | Cause unsafe persistence or rendering resource exhaustion | Validate identities, counts, coordinate bounds, text bounds, and full batches before persistence | Extremely large otherwise-valid projects may still feel slow |
+| Backup-health evidence | Claim a backup is healthy when it is not | Treat external health as bounded advisory evidence and keep it outside signed truth | Blueprints cannot independently prove external backup contents |
+
+## Key compromise
+
+Signatures prove possession of a key, not benign intent. A current authorized member can sign incorrect or malicious project content. Administrators must deactivate a suspected member, stop exchange while reviewing the audit trail, and remove that person's write access at the storage layer.
+
+Deactivation prevents the key from authorizing future project mutations but intentionally does not invalidate historical signatures. Automated same-user rotation and time-qualified revocation remain planned work.
+
+## Release security gates
+
+Before a stable release:
+
+1. run the complete cross-platform test and adversarial-input suites;
+2. exercise interrupted workspace promotion and recovery;
+3. restore an encrypted identity backup on a clean user profile;
+4. perform the documented local and exchange recovery drill;
+5. review changes to canonical serialization, signatures, membership, migration, sync, recovery, and provider approval boundaries;
+6. commission independent review of the exact source and, once distribution begins, the exact downloadable artifacts.
+
+Do not describe Blueprints or a release as audited unless the stated source and artifacts were actually included in that review.

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -1,6 +1,6 @@
 # Workspace format
 
-This document describes the current schema-1 layout. The format is pre-release and may change before v1.0.
+This document describes the current schema-1 layout. The format remains pre-release, but Blueprints now inspects it through an explicit compatibility and migration boundary before loading signed project state.
 
 ## Local workspace
 
@@ -166,7 +166,13 @@ Contains a unique change ID, operation, human summary, author, membership revisi
 
 ## Compatibility
 
-There is no general migration engine yet. Optional schema-1 documents, including the canvas layout and relationship graph, use explicit missing-file compatibility. Do not manually change `schemaVersion`. Before adopting a future schema, preserve a complete copy of the workspace and identity data.
+Schema 1 is the minimum and current supported schema. Optional schema-1 documents, including the canvas layout and relationship graph, use explicit missing-file compatibility.
+
+Before normal loading, Blueprints reads the bounded `project.json` schema field. A schema newer than the application supports is rejected with an upgrade instruction instead of being interpreted optimistically. Current-schema workspaces are not rewritten.
+
+The migration engine requires an uninterrupted one-version-at-a-time chain. Before a migration it creates a complete ZIP backup in a machine-local sibling migration-backup directory. Each migration runs against a staged workspace, must produce its declared target schema, and is promoted through the atomic workspace transaction only after validation. A failure restores the original directory and removes the incomplete backup.
+
+Do not manually change `schemaVersion`. Project backups do not contain private signing keys; preserve and test an encrypted identity backup separately.
 
 ## Files that must never be shared as project data
 


### PR DESCRIPTION
## What changed

- rebuilds the desktop shell and first-run experience around plain-language tasks for new, open, and join workflows
- adds a modern neutral-and-violet visual system while retaining the interactive blueprint canvas
- makes local signed mutations, audit appends, and recoverable archives atomic and interruption-safe
- adds explicit workspace schema inspection, ordered migration infrastructure, pre-migration backups, rollback, and future-schema rejection
- adds encrypted identity backup and clean-profile restore with private/public-key verification
- versions and bounds the hosted-source provider extension contract
- adds keyboard destination shortcuts, accessible names, threat modeling, and stable support targets

## Why

Blueprints had the core planning and collaboration features, but its interface assumed too much implementation knowledge and its release foundations lacked a general transaction, migration, and identity-recovery boundary. This milestone makes the product approachable on first contact and closes the highest-risk local data-safety gaps before v1.0 qualification.

## User and developer impact

New users get one obvious setup path and outcome-based navigation. Existing schema-1 workspaces open without rewriting. Interrupted local saves and archives restore the previous workspace. Signing identities can be backed up separately and restored under the destination device's local protection. Future providers and workspace schemas now have explicit compatibility contracts.

Distribution and installers remain intentionally deferred. Automated same-user key rotation, revocation evidence, retained cross-platform accessibility qualification, and independent review remain v1.0 work.

## Validation

- `./scripts/verify.sh`
- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- 174 tests passing
- warning-free Release build
- runtime launch and visual inspection on macOS