### PR TITLE
Promote Blueprints 0.8.0 to main

### DIFF
--- a/Blueprints.App/App.axaml
+++ b/Blueprints.App/App.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:Blueprints.App"
              x:Class="Blueprints.App.App"
-             RequestedThemeVariant="Light">
+             RequestedThemeVariant="Default">
   <Application.DataTemplates>
     <local:ViewLocator />
   </Application.DataTemplates>
@@ -14,6 +14,7 @@
     every form and navigation label.
   -->
   <Application.Resources>
+    <ResourceDictionary>
     <Color x:Key="BlueprintInk">#191A2C</Color>
     <Color x:Key="BlueprintBlue">#6254D9</Color>
     <Color x:Key="BlueprintBright">#7767EA</Color>
@@ -28,6 +29,63 @@
     <SolidColorBrush x:Key="PaperBrush" Color="{StaticResource BlueprintPaper}" />
     <SolidColorBrush x:Key="LineBrush" Color="{StaticResource BlueprintLine}" />
     <SolidColorBrush x:Key="MutedBrush" Color="{StaticResource BlueprintMuted}" />
+    <ResourceDictionary.ThemeDictionaries>
+      <ResourceDictionary x:Key="Light">
+        <SolidColorBrush x:Key="CanvasBackgroundBrush" Color="#F7F7FA" />
+        <SolidColorBrush x:Key="CanvasToolbarBrush" Color="#FFFFFF" />
+        <SolidColorBrush x:Key="CanvasInspectorBrush" Color="#FFFFFF" />
+        <SolidColorBrush x:Key="CanvasInspectorHeaderBrush" Color="#FAFAFD" />
+        <SolidColorBrush x:Key="CanvasOverlayBrush" Color="#F5FFFFFF" />
+        <SolidColorBrush x:Key="CanvasControlBackgroundBrush" Color="#F2F2F7" />
+        <SolidColorBrush x:Key="CanvasFrameBackgroundBrush" Color="#F9F9FC" />
+        <SolidColorBrush x:Key="CanvasFrameHeaderBrush" Color="#F1F0F8" />
+        <SolidColorBrush x:Key="CanvasFrameBorderBrush" Color="#D6D8E2" />
+        <SolidColorBrush x:Key="CanvasColumnBackgroundBrush" Color="#F2F3F7" />
+        <SolidColorBrush x:Key="CanvasColumnBorderBrush" Color="#E1E2E9" />
+        <SolidColorBrush x:Key="CanvasCardBackgroundBrush" Color="#FFFFFF" />
+        <SolidColorBrush x:Key="CanvasCardBorderBrush" Color="#D8DAE4" />
+        <SolidColorBrush x:Key="CanvasAccentBrush" Color="#6254D9" />
+        <SolidColorBrush x:Key="CanvasSelectionBrush" Color="#6254D9" />
+        <SolidColorBrush x:Key="CanvasSelectionFillBrush" Color="#226254D9" />
+        <SolidColorBrush x:Key="CanvasWarningBrush" Color="#C64D42" />
+        <SolidColorBrush x:Key="CanvasMutedBrush" Color="#66697A" />
+        <SolidColorBrush x:Key="CanvasResizeBrush" Color="#CBC7E8" />
+        <SolidColorBrush x:Key="CanvasStatusBarBrush" Color="#202238" />
+        <SolidColorBrush x:Key="CanvasMinimapBackgroundBrush" Color="#E9E9EF" />
+        <SolidColorBrush x:Key="CanvasMinimapSelectionBrush" Color="#F1C96A" />
+        <SolidColorBrush x:Key="CanvasMinimapFrameBrush" Color="#8D83DF" />
+        <SolidColorBrush x:Key="CanvasMinimapNodeBrush" Color="#56AFA2" />
+        <SolidColorBrush x:Key="CanvasViewportFillBrush" Color="#166254D9" />
+      </ResourceDictionary>
+      <ResourceDictionary x:Key="Dark">
+        <SolidColorBrush x:Key="CanvasBackgroundBrush" Color="#161722" />
+        <SolidColorBrush x:Key="CanvasToolbarBrush" Color="#20212E" />
+        <SolidColorBrush x:Key="CanvasInspectorBrush" Color="#1D1E2A" />
+        <SolidColorBrush x:Key="CanvasInspectorHeaderBrush" Color="#242532" />
+        <SolidColorBrush x:Key="CanvasOverlayBrush" Color="#F5222330" />
+        <SolidColorBrush x:Key="CanvasControlBackgroundBrush" Color="#30313E" />
+        <SolidColorBrush x:Key="CanvasFrameBackgroundBrush" Color="#20212C" />
+        <SolidColorBrush x:Key="CanvasFrameHeaderBrush" Color="#292A38" />
+        <SolidColorBrush x:Key="CanvasFrameBorderBrush" Color="#414353" />
+        <SolidColorBrush x:Key="CanvasColumnBackgroundBrush" Color="#1B1C27" />
+        <SolidColorBrush x:Key="CanvasColumnBorderBrush" Color="#353746" />
+        <SolidColorBrush x:Key="CanvasCardBackgroundBrush" Color="#292A36" />
+        <SolidColorBrush x:Key="CanvasCardBorderBrush" Color="#454756" />
+        <SolidColorBrush x:Key="CanvasAccentBrush" Color="#A79CF7" />
+        <SolidColorBrush x:Key="CanvasSelectionBrush" Color="#A79CF7" />
+        <SolidColorBrush x:Key="CanvasSelectionFillBrush" Color="#22A79CF7" />
+        <SolidColorBrush x:Key="CanvasWarningBrush" Color="#E67B70" />
+        <SolidColorBrush x:Key="CanvasMutedBrush" Color="#AFB1C0" />
+        <SolidColorBrush x:Key="CanvasResizeBrush" Color="#6D6896" />
+        <SolidColorBrush x:Key="CanvasStatusBarBrush" Color="#12131C" />
+        <SolidColorBrush x:Key="CanvasMinimapBackgroundBrush" Color="#11121B" />
+        <SolidColorBrush x:Key="CanvasMinimapSelectionBrush" Color="#F1C96A" />
+        <SolidColorBrush x:Key="CanvasMinimapFrameBrush" Color="#8D83DF" />
+        <SolidColorBrush x:Key="CanvasMinimapNodeBrush" Color="#56AFA2" />
+        <SolidColorBrush x:Key="CanvasViewportFillBrush" Color="#22A79CF7" />
+      </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
   </Application.Resources>
 
   <Application.Styles>
@@ -213,6 +271,13 @@
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="CornerRadius" Value="10" />
       <Setter Property="Padding" Value="13" />
+    </Style>
+    <Style Selector="Border.status-pill">
+      <Setter Property="Background" Value="{DynamicResource CanvasControlBackgroundBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource LineBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="6" />
+      <Setter Property="Padding" Value="8,4" />
     </Style>
     <Style Selector="Border.success">
       <Setter Property="Background" Value="#EAF8F4" />

--- a/Blueprints.App/Models/CanvasBoardProjection.cs
+++ b/Blueprints.App/Models/CanvasBoardProjection.cs
@@ -1,0 +1,44 @@
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+
+namespace Blueprints.App.Models;
+
+public sealed record CanvasBoardProjection(
+    CanvasViewMode ViewMode,
+    IReadOnlyList<CanvasVersionFrame> Frames,
+    IReadOnlyList<CanvasDependencyNode> DependencyNodes,
+    IReadOnlyList<CanvasRelationshipProjection> Relationships);
+
+public sealed record CanvasVersionFrame(
+    WorkspaceVersionCard Version,
+    IReadOnlyList<CanvasLifecycleColumn> Columns,
+    int CompletionPercentage,
+    int WarningCount,
+    int BlockerCount,
+    string ReadinessSummary);
+
+public sealed record CanvasLifecycleColumn(
+    WorkItemLifecycle State,
+    string DisplayName,
+    IReadOnlyList<WorkspaceItemCard> Items);
+
+public sealed record CanvasDependencyNode(
+    string NodeType,
+    Guid EntityId,
+    string Key,
+    string Title,
+    string Subtitle,
+    Guid? VersionId,
+    WorkItemLifecycle? WorkflowState);
+
+public sealed record CanvasRelationshipProjection(
+    RelationshipEdge Edge,
+    RelationshipTypeDefinition Type);
+
+public sealed record CanvasBoardFilter(
+    string SearchText = "",
+    string Version = "All",
+    string Lifecycle = "All",
+    string ItemType = "All",
+    string Category = "All",
+    bool WarningsOnly = false);

--- a/Blueprints.App/Models/CanvasMiniMapNode.cs
+++ b/Blueprints.App/Models/CanvasMiniMapNode.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.App.Models;
+
+public sealed record CanvasMiniMapNode(
+    Guid EntityId,
+    double X,
+    double Y,
+    double Width,
+    double Height,
+    bool IsSelected);

--- a/Blueprints.App/Models/CanvasViewMode.cs
+++ b/Blueprints.App/Models/CanvasViewMode.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.App.Models;
+
+public enum CanvasViewMode
+{
+    Plan,
+    Dependencies,
+    ReleaseNotes,
+    Timeline,
+}

--- a/Blueprints.App/Models/CanvasViewState.cs
+++ b/Blueprints.App/Models/CanvasViewState.cs
@@ -3,7 +3,24 @@ namespace Blueprints.App.Models;
 public sealed record CanvasViewState(
     double Zoom,
     double HorizontalOffset,
-    double VerticalOffset)
+    double VerticalOffset,
+    CanvasViewMode ViewMode = CanvasViewMode.Plan,
+    string SearchText = "",
+    string LifecycleFilter = "All",
+    string VersionFilter = "All",
+    bool MinimapVisible = true,
+    string CollapsedVersionIds = "",
+    string ItemTypeFilter = "All",
+    string CategoryFilter = "All",
+    bool WarningsOnly = false)
 {
     public static CanvasViewState Default { get; } = new(1, 0, 0);
+
+    public IReadOnlyList<Guid> ParseCollapsedVersionIds() =>
+        CollapsedVersionIds
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(static value => Guid.TryParse(value, out var id) ? id : Guid.Empty)
+            .Where(static id => id != Guid.Empty)
+            .Distinct()
+            .ToArray();
 }

--- a/Blueprints.App/Models/ItemEditRequest.cs
+++ b/Blueprints.App/Models/ItemEditRequest.cs
@@ -1,3 +1,5 @@
+using Blueprints.Core.Enums;
+
 namespace Blueprints.App.Models;
 
 public sealed record ItemEditRequest(
@@ -7,4 +9,5 @@ public sealed record ItemEditRequest(
     string CategoryId,
     string Title,
     string? Description,
-    bool IsDone);
+    bool IsDone,
+    WorkItemLifecycle? WorkflowState = null);

--- a/Blueprints.App/Models/WorkItemLifecycleChangeRequest.cs
+++ b/Blueprints.App/Models/WorkItemLifecycleChangeRequest.cs
@@ -1,0 +1,8 @@
+using Blueprints.Core.Enums;
+
+namespace Blueprints.App.Models;
+
+public sealed record WorkItemLifecycleChangeRequest(
+    Guid VersionId,
+    Guid ItemId,
+    WorkItemLifecycle WorkflowState);

--- a/Blueprints.App/Models/WorkspaceItemCard.cs
+++ b/Blueprints.App/Models/WorkspaceItemCard.cs
@@ -1,3 +1,5 @@
+using Blueprints.Core.Enums;
+
 namespace Blueprints.App.Models;
 
 public sealed record WorkspaceItemCard(
@@ -7,4 +9,14 @@ public sealed record WorkspaceItemCard(
     string CategoryId,
     string Title,
     string? Description,
-    bool IsDone);
+    bool IsDone,
+    WorkItemLifecycle WorkflowState = WorkItemLifecycle.Planned,
+    IReadOnlyList<string>? Tags = null)
+{
+    public string? SourceReference =>
+        Tags?.FirstOrDefault(static tag =>
+            tag.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            tag.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        ?? Tags?.FirstOrDefault(static tag =>
+            tag.StartsWith("source:", StringComparison.OrdinalIgnoreCase));
+}

--- a/Blueprints.App/Services/CanvasBoardProjectionService.cs
+++ b/Blueprints.App/Services/CanvasBoardProjectionService.cs
@@ -1,0 +1,169 @@
+using Blueprints.App.Models;
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+
+namespace Blueprints.App.Services;
+
+public static class CanvasBoardProjectionService
+{
+    private static readonly WorkItemLifecycle[] LifecycleOrder =
+    [
+        WorkItemLifecycle.Planned,
+        WorkItemLifecycle.InProgress,
+        WorkItemLifecycle.Review,
+        WorkItemLifecycle.Complete,
+    ];
+
+    public static CanvasBoardProjection Build(
+        CanvasViewMode viewMode,
+        IReadOnlyList<WorkspaceVersionCard> versions,
+        RelationshipDocument? relationshipDocument,
+        CanvasBoardFilter? filter = null,
+        ProjectSummary? project = null)
+    {
+        ArgumentNullException.ThrowIfNull(versions);
+        filter ??= new CanvasBoardFilter();
+
+        var types = (relationshipDocument?.Types ?? [])
+            .ToDictionary(static type => type.TypeId, StringComparer.Ordinal);
+        var relationships = (relationshipDocument?.Relationships ?? [])
+            .Where(edge => types.ContainsKey(edge.TypeId))
+            .Select(edge => new CanvasRelationshipProjection(edge, types[edge.TypeId]))
+            .ToArray();
+        var blockerTargets = relationships
+            .Where(static relationship =>
+                relationship.Type.TypeId.Contains("block", StringComparison.OrdinalIgnoreCase) ||
+                relationship.Type.Name.Contains("block", StringComparison.OrdinalIgnoreCase))
+            .Select(static relationship => relationship.Edge.Target.EntityId)
+            .ToHashSet();
+
+        var frames = versions
+            .Where(version => MatchesVersion(version, filter))
+            .Select(version => BuildFrame(version, filter, blockerTargets))
+            .ToArray();
+
+        var visibleIds = frames
+            .SelectMany(frame => frame.Columns.SelectMany(static column => column.Items))
+            .Select(static item => item.ItemId)
+            .Concat(frames.Select(static frame => frame.Version.VersionId))
+            .ToHashSet();
+        if (viewMode == CanvasViewMode.Dependencies &&
+            project is { ProjectId: var projectId } &&
+            projectId != Guid.Empty)
+        {
+            visibleIds.Add(projectId);
+        }
+
+        var dependencyNodes = (viewMode == CanvasViewMode.Dependencies &&
+                               project is { ProjectId: var dependencyProjectId } &&
+                               dependencyProjectId != Guid.Empty
+                ? new[]
+                {
+                    new CanvasDependencyNode(
+                        "project",
+                        dependencyProjectId,
+                        project.Code,
+                        project.Name,
+                        "Project root",
+                        null,
+                        null),
+                }
+                : [])
+            .Concat(frames
+            .SelectMany(frame =>
+                new[]
+                {
+                    new CanvasDependencyNode(
+                        "version",
+                        frame.Version.VersionId,
+                        "VERSION",
+                        frame.Version.Name,
+                        $"{frame.Version.Status} · {frame.CompletionPercentage}% complete",
+                        frame.Version.VersionId,
+                        null),
+                }
+                .Concat(frame.Columns.SelectMany(column => column.Items.Select(item =>
+                    new CanvasDependencyNode(
+                        "item",
+                        item.ItemId,
+                        item.ItemKey,
+                        item.Title,
+                        $"{Format(column.State)} · {item.ItemTypeId} · {item.CategoryId}",
+                        frame.Version.VersionId,
+                        column.State))))))
+            .ToArray();
+
+        return new CanvasBoardProjection(
+            viewMode,
+            frames,
+            dependencyNodes,
+            relationships
+                .Where(relationship =>
+                    visibleIds.Contains(relationship.Edge.Source.EntityId) &&
+                    visibleIds.Contains(relationship.Edge.Target.EntityId))
+                .ToArray());
+    }
+
+    private static CanvasVersionFrame BuildFrame(
+        WorkspaceVersionCard version,
+        CanvasBoardFilter filter,
+        IReadOnlySet<Guid> blockerTargets)
+    {
+        var items = version.Items
+            .Where(item => MatchesItem(item, filter, blockerTargets))
+            .ToArray();
+        var columns = LifecycleOrder
+            .Select(state => new CanvasLifecycleColumn(
+                state,
+                Format(state),
+                items.Where(item => item.WorkflowState == state)
+                    .OrderBy(static item => item.ItemKey, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()))
+            .ToArray();
+        var completion = version.ItemCount == 0
+            ? 0
+            : (int)Math.Round(version.CompletedItemCount * 100d / version.ItemCount);
+        var warnings = version.Items.Count(static item =>
+            string.IsNullOrWhiteSpace(item.Title) || !item.IsDone);
+        var blockers = version.Items.Count(item => blockerTargets.Contains(item.ItemId));
+        var readiness = blockers > 0
+            ? $"{blockers} blocker{(blockers == 1 ? string.Empty : "s")}"
+            : warnings > 0
+                ? $"{warnings} item{(warnings == 1 ? string.Empty : "s")} need attention"
+                : version.ItemCount == 0
+                    ? "No work items"
+                    : "Ready for review";
+        return new CanvasVersionFrame(version, columns, completion, warnings, blockers, readiness);
+    }
+
+    private static bool MatchesVersion(WorkspaceVersionCard version, CanvasBoardFilter filter) =>
+        (filter.Version == "All" ||
+         string.Equals(version.Name, filter.Version, StringComparison.OrdinalIgnoreCase))
+        && (string.IsNullOrWhiteSpace(filter.SearchText) ||
+            version.Name.Contains(filter.SearchText, StringComparison.OrdinalIgnoreCase) ||
+            version.Items.Any(item => MatchesSearch(item, filter.SearchText)));
+
+    private static bool MatchesItem(
+        WorkspaceItemCard item,
+        CanvasBoardFilter filter,
+        IReadOnlySet<Guid> blockerTargets) =>
+        (string.IsNullOrWhiteSpace(filter.SearchText) || MatchesSearch(item, filter.SearchText))
+        && (filter.Lifecycle == "All" ||
+            string.Equals(Format(item.WorkflowState), filter.Lifecycle, StringComparison.OrdinalIgnoreCase))
+        && (filter.ItemType == "All" ||
+            string.Equals(item.ItemTypeId, filter.ItemType, StringComparison.OrdinalIgnoreCase))
+        && (filter.Category == "All" ||
+            string.Equals(item.CategoryId, filter.Category, StringComparison.OrdinalIgnoreCase))
+        && (!filter.WarningsOnly || !item.IsDone || blockerTargets.Contains(item.ItemId));
+
+    private static bool MatchesSearch(WorkspaceItemCard item, string search) =>
+        item.ItemKey.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        item.Title.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        item.ItemTypeId.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        item.CategoryId.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        (item.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false) ||
+        (item.Tags?.Any(tag => tag.Contains(search, StringComparison.OrdinalIgnoreCase)) ?? false);
+
+    public static string Format(WorkItemLifecycle state) =>
+        state == WorkItemLifecycle.InProgress ? "In Progress" : state.ToString();
+}

--- a/Blueprints.App/Services/CanvasMiniMapProjectionService.cs
+++ b/Blueprints.App/Services/CanvasMiniMapProjectionService.cs
@@ -1,0 +1,31 @@
+using Blueprints.App.Models;
+
+namespace Blueprints.App.Services;
+
+public static class CanvasMiniMapProjectionService
+{
+    public static IReadOnlyList<CanvasMiniMapNode> Project(
+        IReadOnlyList<CanvasNodeBounds> nodes,
+        IReadOnlySet<Guid> selectedIds,
+        double surfaceWidth,
+        double surfaceHeight,
+        double mapWidth,
+        double mapHeight)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentNullException.ThrowIfNull(selectedIds);
+        if (surfaceWidth <= 0 || surfaceHeight <= 0 || mapWidth <= 0 || mapHeight <= 0)
+        {
+            return [];
+        }
+
+        var scale = Math.Min(mapWidth / surfaceWidth, mapHeight / surfaceHeight);
+        return nodes.Select(node => new CanvasMiniMapNode(
+            node.EntityId,
+            node.X * scale,
+            node.Y * scale,
+            Math.Max(3, node.Width * scale),
+            Math.Max(2, node.Height * scale),
+            selectedIds.Contains(node.EntityId))).ToArray();
+    }
+}

--- a/Blueprints.App/Services/FileSystemCanvasViewStateStore.cs
+++ b/Blueprints.App/Services/FileSystemCanvasViewStateStore.cs
@@ -61,7 +61,50 @@ public sealed class FileSystemCanvasViewStateStore
         ValidateRange(state.Zoom, MinimumZoom, MaximumZoom, "Canvas zoom");
         ValidateRange(state.HorizontalOffset, 0, MaximumOffset, "Canvas horizontal offset");
         ValidateRange(state.VerticalOffset, 0, MaximumOffset, "Canvas vertical offset");
-        return state;
+        if (state.SearchText is null ||
+            state.LifecycleFilter is null ||
+            state.VersionFilter is null ||
+            state.ItemTypeFilter is null ||
+            state.CategoryFilter is null ||
+            state.CollapsedVersionIds is null)
+        {
+            throw new InvalidOperationException("Canvas view preferences contain invalid null values.");
+        }
+        if (!Enum.IsDefined(state.ViewMode))
+        {
+            throw new InvalidOperationException("Canvas view mode is not supported.");
+        }
+
+        if (state.SearchText.Length > 200 ||
+            state.LifecycleFilter.Length > 200 ||
+            state.VersionFilter.Length > 200 ||
+            state.ItemTypeFilter.Length > 200 ||
+            state.CategoryFilter.Length > 200)
+        {
+            throw new InvalidOperationException("Canvas search and filter values cannot exceed 200 characters.");
+        }
+
+        if (state.CollapsedVersionIds.Length > 370_000)
+        {
+            throw new InvalidOperationException("Canvas collapse preferences exceed the supported limit.");
+        }
+        var collapsedVersionIds = state.ParseCollapsedVersionIds();
+        if (collapsedVersionIds.Count > 10_000)
+        {
+            throw new InvalidOperationException("Canvas collapse preferences exceed the supported limit.");
+        }
+
+        return state with
+        {
+            SearchText = state.SearchText.Trim(),
+            LifecycleFilter = string.IsNullOrWhiteSpace(state.LifecycleFilter) ? "All" : state.LifecycleFilter,
+            VersionFilter = string.IsNullOrWhiteSpace(state.VersionFilter) ? "All" : state.VersionFilter,
+            ItemTypeFilter = string.IsNullOrWhiteSpace(state.ItemTypeFilter) ? "All" : state.ItemTypeFilter,
+            CategoryFilter = string.IsNullOrWhiteSpace(state.CategoryFilter) ? "All" : state.CategoryFilter,
+            CollapsedVersionIds = string.Join(
+                ',',
+                collapsedVersionIds.Order()),
+        };
     }
 
     private static void ValidateRange(double value, double minimum, double maximum, string name)

--- a/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
+++ b/Blueprints.App/Services/ProjectWorkspaceCoordinatorService.cs
@@ -63,6 +63,19 @@ public sealed class ProjectWorkspaceCoordinatorService
     public IReadOnlyList<RecentProjectReference> GetRecentProjects() =>
         _recentProjectsStore.Load();
 
+    public IReadOnlyList<AuditLogEntry> GetAuditHistory(
+        string localWorkspaceRoot,
+        int maximumCount = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localWorkspaceRoot);
+        var identity = _identityService.GetOrCreateDefaultIdentity("Local Admin");
+        var keys = _projectTrustStore.LoadKeys(localWorkspaceRoot, identity);
+        return _auditLogService.ReadVerifiedEntries(
+            localWorkspaceRoot,
+            keys,
+            maximumCount);
+    }
+
     public bool HasLocalIdentity => _identityService.ListProfiles().Count > 0;
 
     public IdentitySummary CreateInitialIdentity(string displayName)
@@ -324,6 +337,11 @@ public sealed class ProjectWorkspaceCoordinatorService
         var items = targetVersion.Items.ToList();
         var normalizedTitle = request.Title.Trim();
         var normalizedDescription = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        var workflowState = request.IsDone
+            ? WorkItemLifecycle.Complete
+            : request.WorkflowState is null or WorkItemLifecycle.Complete
+                ? WorkItemLifecycle.Planned
+                : request.WorkflowState.Value;
 
         if (string.IsNullOrWhiteSpace(normalizedTitle))
         {
@@ -345,7 +363,8 @@ public sealed class ProjectWorkspaceCoordinatorService
                 CategoryId = request.CategoryId,
                 Title = normalizedTitle,
                 Description = normalizedDescription,
-                IsDone = request.IsDone,
+                IsDone = workflowState == WorkItemLifecycle.Complete,
+                WorkflowState = workflowState,
                 UpdatedUtc = DateTimeOffset.UtcNow,
                 LastModifiedByUserId = identity.Profile.UserId,
                 LastModifiedByName = identity.Profile.DisplayName,
@@ -365,12 +384,13 @@ public sealed class ProjectWorkspaceCoordinatorService
                     request.CategoryId,
                     normalizedTitle,
                     normalizedDescription,
-                    request.IsDone,
+                    workflowState == WorkItemLifecycle.Complete,
                     [],
                     createdUtc,
                     createdUtc,
                     identity.Profile.UserId,
-                    identity.Profile.DisplayName));
+                    identity.Profile.DisplayName,
+                    workflowState));
         }
 
         versions[versionIndex] = targetVersion with
@@ -461,7 +481,10 @@ public sealed class ProjectWorkspaceCoordinatorService
                         createdUtc,
                         createdUtc,
                         identity.Profile.UserId,
-                        identity.Profile.DisplayName))
+                        identity.Profile.DisplayName,
+                        import.IsDone
+                            ? WorkItemLifecycle.Complete
+                            : WorkItemLifecycle.Planned))
                 .ToArray();
             versions[versionIndex] = targetVersion with
             {

--- a/Blueprints.App/ViewModels/MainWindowViewModel.cs
+++ b/Blueprints.App/ViewModels/MainWindowViewModel.cs
@@ -65,6 +65,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _itemEditorTitle = string.Empty;
     private string _itemEditorDescription = string.Empty;
     private bool _itemEditorIsDone;
+    private WorkItemLifecycle _itemEditorWorkflowState = WorkItemLifecycle.Planned;
     private string _selectedItemTypeId = "feature";
     private string _selectedCategoryId = "added";
     private string _changelogPreview = string.Empty;
@@ -118,6 +119,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _gitCommitMessage = string.Empty;
     private bool _isRunningGitOperation;
     private CanvasGroupingMode _canvasGroupingMode = CanvasGroupingMode.ChangelogCategory;
+    private int _inspectorTabIndex;
 
     public MainWindowViewModel()
     {
@@ -136,6 +138,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RelationshipTypes = new ObservableCollection<RelationshipTypeDefinition>();
         Relationships = new ObservableCollection<RelationshipEdge>();
         RelationshipEndpoints = new ObservableCollection<RelationshipEndpointOption>();
+        AuditHistory = new ObservableCollection<AuditLogEntry>();
         _integrationStatusService = new IntegrationStatusService();
         _sourceDiscoveryService = new RepositorySourceDiscoveryService();
         _canvasViewStateStore = new FileSystemCanvasViewStateStore();
@@ -176,6 +179,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RelationshipTypes = new ObservableCollection<RelationshipTypeDefinition>();
         Relationships = new ObservableCollection<RelationshipEdge>();
         RelationshipEndpoints = new ObservableCollection<RelationshipEndpointOption>();
+        AuditHistory = new ObservableCollection<AuditLogEntry>();
         SourceImportProposals = new ObservableCollection<SourceImportProposal>();
 
         RefreshRecentProjects();
@@ -216,6 +220,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<RelationshipEdge> Relationships { get; }
 
     public ObservableCollection<RelationshipEndpointOption> RelationshipEndpoints { get; }
+
+    public ObservableCollection<AuditLogEntry> AuditHistory { get; }
 
     public SourceImportProposal? SelectedSourceProposal
     {
@@ -519,6 +525,7 @@ public partial class MainWindowViewModel : ViewModelBase
                         option.Endpoint == value.Target);
                     RelationshipLabel = value.Label ?? string.Empty;
                 }
+                OnPropertyChanged(nameof(InspectorSelectionSummary));
                 OnPropertyChanged(nameof(CanRemoveRelationship));
             }
         }
@@ -598,6 +605,12 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         get => _canvasViewState;
         private set => SetProperty(ref _canvasViewState, value);
+    }
+
+    public int InspectorTabIndex
+    {
+        get => _inspectorTabIndex;
+        set => SetProperty(ref _inspectorTabIndex, Math.Clamp(value, 0, 3));
     }
 
     public string Title
@@ -904,6 +917,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             if (SetProperty(ref _selectedVersion, value))
             {
+                SelectedRelationship = null;
                 PopulateVersionEditor();
                 ChangelogPreview = string.Empty;
                 LastChangelogExportPath = string.Empty;
@@ -931,6 +945,10 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             if (SetProperty(ref _selectedItem, value))
             {
+                if (value is not null)
+                {
+                    SelectedRelationship = null;
+                }
                 PopulateItemEditor();
                 OnPropertyChanged(nameof(HasSelectedItem));
                 OnPropertyChanged(nameof(InspectorSelectionSummary));
@@ -943,8 +961,10 @@ public partial class MainWindowViewModel : ViewModelBase
     public bool HasSelectedItem => SelectedItem is not null;
 
     public string InspectorSelectionSummary =>
-        SelectedItem is not null
-            ? $"{SelectedItem.ItemKey} / {SelectedItem.ItemTypeId}"
+        SelectedRelationship is not null
+            ? $"RELATIONSHIP / {SelectedRelationship.TypeId}"
+            : SelectedItem is not null
+                ? $"{SelectedItem.ItemKey} / {SelectedItem.ItemTypeId}"
             : SelectedVersion is not null
                 ? $"VERSION / {SelectedVersion.Name}"
                 : "SELECT A NODE";
@@ -988,8 +1008,30 @@ public partial class MainWindowViewModel : ViewModelBase
     public bool ItemEditorIsDone
     {
         get => _itemEditorIsDone;
-        set => SetProperty(ref _itemEditorIsDone, value);
+        set
+        {
+            if (SetProperty(ref _itemEditorIsDone, value) && value)
+            {
+                ItemEditorWorkflowState = WorkItemLifecycle.Complete;
+            }
+        }
     }
+
+    public WorkItemLifecycle ItemEditorWorkflowState
+    {
+        get => _itemEditorWorkflowState;
+        set
+        {
+            if (SetProperty(ref _itemEditorWorkflowState, value))
+            {
+                _itemEditorIsDone = value == WorkItemLifecycle.Complete;
+                OnPropertyChanged(nameof(ItemEditorIsDone));
+            }
+        }
+    }
+
+    public IReadOnlyList<WorkItemLifecycle> AvailableWorkflowStates { get; } =
+        Enum.GetValues<WorkItemLifecycle>();
 
     public string SelectedItemTypeId
     {
@@ -1383,6 +1425,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
         SelectedVersion = version;
         SelectedItem = null;
+        SelectedRelationship = null;
+        InspectorTabIndex = 0;
         OnPropertyChanged(nameof(InspectorSelectionSummary));
     }
 
@@ -1401,6 +1445,8 @@ public partial class MainWindowViewModel : ViewModelBase
         }
 
         SelectedItem = item;
+        SelectedRelationship = null;
+        InspectorTabIndex = 0;
         OnPropertyChanged(nameof(InspectorSelectionSummary));
     }
 
@@ -2524,7 +2570,8 @@ public partial class MainWindowViewModel : ViewModelBase
                         SelectedCategoryId,
                         ItemEditorTitle,
                         ItemEditorDescription,
-                        ItemEditorIsDone)));
+                        ItemEditorIsDone,
+                        ItemEditorWorkflowState)));
             ReselectVersion(versionId);
             WorkspaceMessage = $"Added item {ItemEditorTitle}.";
             ClearItemEditorForNewItem();
@@ -2559,10 +2606,52 @@ public partial class MainWindowViewModel : ViewModelBase
                         SelectedCategoryId,
                         ItemEditorTitle,
                         ItemEditorDescription,
-                        ItemEditorIsDone)));
+                        ItemEditorIsDone,
+                        ItemEditorWorkflowState)));
             ReselectVersion(versionId);
             ReselectItem(itemId);
             WorkspaceMessage = $"Updated item {ItemEditorTitle}.";
+        }
+        catch (Exception exception)
+        {
+            WorkspaceMessage = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void ChangeItemLifecycle(WorkItemLifecycleChangeRequest? request)
+    {
+        if (_coordinatorService is null || _currentSession is null || request is null)
+        {
+            return;
+        }
+
+        var version = Versions.FirstOrDefault(candidate => candidate.VersionId == request.VersionId);
+        var item = version?.Items.FirstOrDefault(candidate => candidate.ItemId == request.ItemId);
+        if (version is null || item is null)
+        {
+            WorkspaceMessage = "The work item is no longer available.";
+            return;
+        }
+
+        try
+        {
+            ApplySession(
+                _coordinatorService.SaveItem(
+                    _currentSession.Paths.LocalWorkspaceRoot,
+                    _currentSession.Paths.SharedProjectRoot,
+                    new ItemEditRequest(
+                        version.VersionId,
+                        item.ItemId,
+                        item.ItemTypeId,
+                        item.CategoryId,
+                        item.Title,
+                        item.Description,
+                        request.WorkflowState == WorkItemLifecycle.Complete,
+                        request.WorkflowState)));
+            ReselectVersion(version.VersionId);
+            ReselectItem(item.ItemId);
+            WorkspaceMessage = $"Moved {item.ItemKey} to {FormatWorkflowState(request.WorkflowState)}.";
         }
         catch (Exception exception)
         {
@@ -2823,6 +2912,16 @@ public partial class MainWindowViewModel : ViewModelBase
             TrustDiagnostics.Add(diagnostic);
         }
 
+        AuditHistory.Clear();
+        if (_coordinatorService is not null && session.AuditLogValidation.IsValid)
+        {
+            foreach (var entry in _coordinatorService.GetAuditHistory(
+                         session.Paths.LocalWorkspaceRoot))
+            {
+                AuditHistory.Add(entry);
+            }
+        }
+
         VersionSourceChangeDiagnostics.Clear();
         ReleaseReadinessDiagnostics.Clear();
 
@@ -2924,6 +3023,7 @@ public partial class MainWindowViewModel : ViewModelBase
         RelationshipTypes.Clear();
         Relationships.Clear();
         RelationshipEndpoints.Clear();
+        AuditHistory.Clear();
         SelectedRelationship = null;
         SelectedRelationshipType = null;
         SelectedRelationshipSource = null;
@@ -3278,7 +3378,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         ItemEditorTitle = SelectedItem.Title;
         ItemEditorDescription = SelectedItem.Description ?? string.Empty;
-        ItemEditorIsDone = SelectedItem.IsDone;
+        ItemEditorWorkflowState = SelectedItem.WorkflowState;
         SelectedItemTypeId = SelectedItem.ItemTypeId;
         SelectedCategoryId = SelectedItem.CategoryId;
     }
@@ -3295,7 +3395,7 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedItem = null;
         ItemEditorTitle = string.Empty;
         ItemEditorDescription = string.Empty;
-        ItemEditorIsDone = false;
+        ItemEditorWorkflowState = WorkItemLifecycle.Planned;
         SelectedItemTypeId = AvailableItemTypes.FirstOrDefault() ?? "feature";
         SelectedCategoryId = AvailableCategories.FirstOrDefault() ?? "added";
     }
@@ -3789,8 +3889,17 @@ public partial class MainWindowViewModel : ViewModelBase
                     item.CategoryId,
                     item.Title,
                     item.Description,
-                    item.IsDone))
+                    item.IsDone,
+                    item.EffectiveWorkflowState,
+                    item.Tags))
                 .ToArray());
+
+    private static string FormatWorkflowState(WorkItemLifecycle state) =>
+        state switch
+        {
+            WorkItemLifecycle.InProgress => "In Progress",
+            _ => state.ToString(),
+        };
 
     private static LocalWorkspaceSession CreateDesignSession()
     {

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml
@@ -1,10 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:automation="using:Avalonia.Automation"
              x:Class="Blueprints.App.Views.Components.BlueprintCanvasSurface"
-             Focusable="True">
-  <Border Background="#F5F4FA"
-          BorderBrush="#DEDDE8"
-          BorderThickness="0"
+             Focusable="True"
+             automation:AutomationProperties.Name="Interactive blueprint canvas"
+             automation:AutomationProperties.HelpText="Use the toolbar to change views, search, connect work, arrange, and zoom.">
+  <Border Background="{DynamicResource CanvasBackgroundBrush}"
+          BorderBrush="{DynamicResource CanvasFrameBorderBrush}"
           ClipToBounds="True">
     <Grid>
       <ScrollViewer x:Name="Viewport"
@@ -18,42 +20,41 @@
           <Canvas x:Name="Surface"
                   Width="1500"
                   Height="960"
-                  Background="#F5F4FA" />
+                  Background="{DynamicResource CanvasBackgroundBrush}" />
         </Viewbox>
       </ScrollViewer>
 
-      <Border HorizontalAlignment="Left"
-              VerticalAlignment="Top"
-              Margin="18"
-              Padding="11,7"
-              Background="#F2FFFFFF"
-              BorderBrush="#DEDCEB"
-              BorderThickness="1"
-              CornerRadius="10"
-              IsHitTestVisible="False">
-        <TextBlock Text="Drag cards to shape the plan  ·  Drag the background to select  ·  Middle-drag to move"
-                   Foreground="#5D5C6D"
-                   FontSize="11" />
-      </Border>
-
-      <Border HorizontalAlignment="Right"
+      <Border x:Name="MiniMapPanel"
+              HorizontalAlignment="Right"
               VerticalAlignment="Bottom"
-              Width="190"
-              Height="132"
+              Width="204"
+              Height="146"
               Margin="0,0,18,18"
-              Padding="7"
-              Background="#F2FFFFFF"
-              BorderBrush="#D4D2E2"
+              Padding="9"
+              Background="{DynamicResource CanvasOverlayBrush}"
+              BorderBrush="{DynamicResource CanvasFrameBorderBrush}"
               BorderThickness="1"
-              CornerRadius="9"
-              IsHitTestVisible="False">
-        <Grid RowDefinitions="Auto,*" RowSpacing="4">
-          <TextBlock Text="MAP" Foreground="#6254D9" FontSize="8" FontWeight="Bold" LetterSpacing="1" />
+              CornerRadius="7">
+        <Grid RowDefinitions="Auto,*" RowSpacing="6">
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="BOARD MAP"
+                       Foreground="{DynamicResource CanvasAccentBrush}"
+                       FontSize="9"
+                       FontWeight="Bold"
+                       LetterSpacing="1" />
+            <TextBlock Grid.Column="1"
+                       Text="Click to navigate"
+                       Foreground="{DynamicResource CanvasMutedBrush}"
+                       FontSize="9" />
+          </Grid>
           <Canvas x:Name="MiniMapSurface"
                   Grid.Row="1"
-                  Width="174"
-                  Height="106"
-                  Background="#E8E6F0" />
+                  Width="184"
+                  Height="112"
+                  Background="{DynamicResource CanvasMinimapBackgroundBrush}"
+                  Cursor="Hand"
+                  automation:AutomationProperties.Name="Blueprint minimap"
+                  automation:AutomationProperties.HelpText="Click a location to center the canvas there." />
         </Grid>
       </Border>
     </Grid>

--- a/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
+++ b/Blueprints.App/Views/Components/BlueprintCanvasSurface.axaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
@@ -11,87 +12,251 @@ using Avalonia.Threading;
 using Blueprints.App.Models;
 using Blueprints.App.Services;
 using Blueprints.App.ViewModels;
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
 
 namespace Blueprints.App.Views.Components;
 
 public partial class BlueprintCanvasSurface : UserControl
 {
-    private const double NodeWidth = 220;
-    private const double VersionNodeHeight = 104;
-    private const double ItemNodeHeight = 82;
+    private const double DependencyNodeWidth = 250;
+    private const double DependencyNodeHeight = 112;
+    private const double FrameWidth = 1120;
+    private const double FrameHeaderHeight = 86;
+    private const double CardHeight = 132;
+    private readonly Dictionary<(string Type, Guid Id), Control> _nodes = [];
+    private readonly Dictionary<(string Type, Guid Id), Rect> _nodeBounds = [];
     private readonly Dictionary<Guid, Point> _positions = [];
-    private readonly Dictionary<Guid, Control> _nodes = [];
-    private readonly Dictionary<(string Type, Guid Id), Control> _typedNodes = [];
+    private readonly Dictionary<Guid, Size> _frameSizes = [];
     private readonly HashSet<Guid> _selectedNodeIds = [];
-    private readonly List<ConnectionVisual> _connections = [];
-    private readonly List<Line> _alignmentGuideVisuals = [];
+    private readonly HashSet<Guid> _collapsedVersionIds = [];
     private readonly CanvasLayoutHistory _layoutHistory = new();
-    private MainWindowViewModel? _viewModel;
-    private Control? _draggedNode;
-    private IReadOnlyList<CanvasNodeLayoutEdit>? _dragStartLayout;
-    private IReadOnlyDictionary<Guid, Point> _dragStartPositions = new Dictionary<Guid, Point>();
-    private Point _dragStartPointer;
-    private double _zoom = 1;
-    private bool _isRestoringLayout;
-    private bool _isPersistingLayout;
     private readonly DispatcherTimer _viewportSaveTimer;
+    private MainWindowViewModel? _viewModel;
+    private CanvasViewMode _viewMode = CanvasViewMode.Plan;
+    private string _searchText = string.Empty;
+    private string _lifecycleFilter = "All";
+    private string _versionFilter = "All";
+    private string _itemTypeFilter = "All";
+    private string _categoryFilter = "All";
+    private bool _warningsOnly;
+    private bool _focusMode;
+    private string _preFocusSearch = string.Empty;
+    private string _preFocusVersion = "All";
+    private bool _minimapVisible = true;
+    private bool _connectMode;
+    private RelationshipEndpoint? _connectionSource;
+    private Control? _draggedNode;
+    private (string Type, Guid Id)? _draggedIdentity;
+    private Point _dragStartPointer;
+    private Point _dragStartPosition;
+    private IReadOnlyList<CanvasNodeLayoutEdit>? _dragStartLayout;
+    private WorkspaceVersionCard? _draggedItemVersion;
+    private WorkspaceItemCard? _draggedItem;
+    private double _zoom = 1;
+    private bool _isRestoring;
+    private bool _isPersisting;
     private bool _isPanning;
     private Point _panStart;
     private Vector _panOrigin;
     private bool _isBoxSelecting;
-    private Point _boxSelectionStart;
-    private Rectangle? _boxSelectionVisual;
-    private IReadOnlySet<Guid> _selectionBeforeBox = new HashSet<Guid>();
+    private Point _boxStart;
+    private Rectangle? _boxVisual;
 
     public event EventHandler? HistoryStateChanged;
-
     public event EventHandler? SelectionStateChanged;
-
     public event EventHandler? ZoomChanged;
+    public event EventHandler? ViewModeChanged;
+    public event EventHandler? ConnectModeChanged;
 
     public bool CanUndo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanUndo;
-
     public bool CanRedo => _viewModel?.CanMutateWorkspace == true && _layoutHistory.CanRedo;
-
-    public string SelectionSummary =>
-        _selectedNodeIds.Count switch
-        {
-            0 => "No canvas nodes selected",
-            1 => "1 canvas node selected",
-            _ => $"{_selectedNodeIds.Count} canvas nodes selected",
-        };
-
+    public bool IsConnectMode => _connectMode;
+    public bool IsFocusMode => _focusMode;
+    public CanvasViewMode ViewMode => _viewMode;
     public string ZoomSummary => $"{_zoom:P0}";
+    public string SelectionSummary => _selectedNodeIds.Count switch
+    {
+        0 when _viewModel?.SelectedRelationship is not null => "1 relationship selected",
+        0 => "Nothing selected",
+        1 => "1 entity selected",
+        _ => $"{_selectedNodeIds.Count} entities selected",
+    };
 
     public BlueprintCanvasSurface()
     {
         InitializeComponent();
-        _viewportSaveTimer = new DispatcherTimer
+        _viewportSaveTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _viewportSaveTimer.Tick += (_, _) =>
         {
-            Interval = TimeSpan.FromMilliseconds(650),
+            _viewportSaveTimer.Stop();
+            PersistViewState();
         };
-        _viewportSaveTimer.Tick += HandleViewportSaveTimerTick;
-        Viewport.ScrollChanged += HandleViewportScrollChanged;
+        Viewport.ScrollChanged += (_, _) =>
+        {
+            RenderMiniMap();
+            if (!_isRestoring)
+            {
+                _viewportSaveTimer.Stop();
+                _viewportSaveTimer.Start();
+            }
+        };
         Surface.PointerPressed += HandleSurfacePointerPressed;
         Surface.PointerMoved += HandleSurfacePointerMoved;
         Surface.PointerReleased += HandleSurfacePointerReleased;
-        Surface.PointerWheelChanged += HandleSurfacePointerWheelChanged;
+        Surface.PointerWheelChanged += HandlePointerWheel;
+        MiniMapSurface.PointerPressed += HandleMiniMapPointerPressed;
         KeyDown += HandleKeyDown;
         DataContextChanged += HandleDataContextChanged;
         DetachedFromVisualTree += (_, _) => DetachViewModel();
     }
 
-    public void ZoomIn() => SetZoom(_zoom + 0.1, persist: true);
-
-    public void ZoomOut() => SetZoom(_zoom - 0.1, persist: true);
+    public void ZoomIn() => SetZoom(_zoom + 0.1, true);
+    public void ZoomOut() => SetZoom(_zoom - 0.1, true);
 
     public void FitView()
     {
-        var availableWidth = Math.Max(320, Viewport.Bounds.Width - 36);
-        var availableHeight = Math.Max(240, Viewport.Bounds.Height - 36);
-        var fit = Math.Min(availableWidth / Surface.Width, availableHeight / Surface.Height);
-        SetZoom(Math.Clamp(fit, 0.25, 1));
-        Viewport.Offset = Vector.Zero;
+        var content = GetContentBounds();
+        if (content.Width <= 0 || content.Height <= 0)
+        {
+            return;
+        }
+
+        var availableWidth = Math.Max(320, Viewport.Bounds.Width - 64);
+        var availableHeight = Math.Max(240, Viewport.Bounds.Height - 64);
+        var fit = Math.Clamp(Math.Min(availableWidth / content.Width, availableHeight / content.Height), .25, 1.25);
+        SetZoom(fit);
+        Viewport.Offset = new Vector(
+            Math.Max(0, content.X * fit - 24),
+            Math.Max(0, content.Y * fit - 24));
+        PersistViewState();
+    }
+
+    public void ZoomToSelection()
+    {
+        var selected = _nodeBounds
+            .Where(pair => _selectedNodeIds.Contains(pair.Key.Id))
+            .Select(static pair => pair.Value)
+            .ToArray();
+        if (selected.Length == 0)
+        {
+            FitView();
+            return;
+        }
+
+        var bounds = Union(selected);
+        var zoom = Math.Clamp(
+            Math.Min(
+                Math.Max(320, Viewport.Bounds.Width - 80) / bounds.Width,
+                Math.Max(240, Viewport.Bounds.Height - 80) / bounds.Height),
+            .25,
+            2.5);
+        SetZoom(zoom);
+        Viewport.Offset = new Vector(
+            Math.Max(0, bounds.Center.X * zoom - Viewport.Viewport.Width / 2),
+            Math.Max(0, bounds.Center.Y * zoom - Viewport.Viewport.Height / 2));
+        PersistViewState();
+    }
+
+    public void SetViewMode(CanvasViewMode mode)
+    {
+        if (mode == CanvasViewMode.Timeline)
+        {
+            return;
+        }
+
+        _viewMode = mode;
+        RenderGraph();
+        PersistViewState();
+        ViewModeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void SetSearch(string? value)
+    {
+        _focusMode = false;
+        _searchText = (value ?? string.Empty).Trim();
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void ToggleFocusMode()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+        if (_focusMode)
+        {
+            _focusMode = false;
+            _searchText = _preFocusSearch;
+            _versionFilter = _preFocusVersion;
+        }
+        else if (_viewModel.SelectedItem is { } item)
+        {
+            _preFocusSearch = _searchText;
+            _preFocusVersion = _versionFilter;
+            _focusMode = true;
+            _searchText = item.ItemKey;
+            _versionFilter = "All";
+        }
+        else if (_viewModel.SelectedVersion is { } version)
+        {
+            _preFocusSearch = _searchText;
+            _preFocusVersion = _versionFilter;
+            _focusMode = true;
+            _searchText = string.Empty;
+            _versionFilter = version.Name;
+        }
+        RenderGraph();
+    }
+
+    public void SetLifecycleFilter(string? value)
+    {
+        _lifecycleFilter = string.IsNullOrWhiteSpace(value) ? "All" : value;
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void SetVersionFilter(string? value)
+    {
+        _versionFilter = string.IsNullOrWhiteSpace(value) ? "All" : value;
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void SetItemTypeFilter(string? value)
+    {
+        _itemTypeFilter = string.IsNullOrWhiteSpace(value) ? "All" : value;
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void SetCategoryFilter(string? value)
+    {
+        _categoryFilter = string.IsNullOrWhiteSpace(value) ? "All" : value;
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void SetWarningsOnly(bool value)
+    {
+        _warningsOnly = value;
+        RenderGraph();
+        PersistViewState();
+    }
+
+    public void ToggleConnectMode()
+    {
+        _connectMode = !_connectMode && _viewModel?.CanMutateWorkspace == true;
+        _connectionSource = null;
+        RenderGraph();
+        ConnectModeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void ToggleMiniMap()
+    {
+        _minimapVisible = !_minimapVisible;
+        MiniMapPanel.IsVisible = _minimapVisible;
         PersistViewState();
     }
 
@@ -103,66 +268,68 @@ public partial class BlueprintCanvasSurface : UserControl
         }
 
         var previous = CaptureLayout();
-        _positions.Clear();
-        SetZoom(1);
+        if (_viewMode == CanvasViewMode.Dependencies)
+        {
+            var dependencyIndex = 0;
+            if (_viewModel.CurrentProject.ProjectId != Guid.Empty)
+            {
+                _positions[_viewModel.CurrentProject.ProjectId] =
+                    DependencyPosition(dependencyIndex++);
+            }
+            foreach (var version in _viewModel.Versions)
+            {
+                _positions[version.VersionId] = DependencyPosition(dependencyIndex++);
+                foreach (var item in version.Items)
+                {
+                    _positions[item.ItemId] = DependencyPosition(dependencyIndex++);
+                }
+            }
+        }
+        else
+        {
+            foreach (var version in _viewModel.Versions.Select((value, index) => (value, index)))
+            {
+                _positions[version.value.VersionId] = new Point(
+                    80,
+                    80 + version.index * 720);
+            }
+        }
+
         RenderGraph();
         _layoutHistory.Record(previous, CaptureLayout());
-        NotifyHistoryStateChanged();
-        Viewport.Offset = Vector.Zero;
         PersistLayout();
-        PersistViewState();
+        HistoryStateChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void SaveLayout() => PersistLayout();
 
     public void UndoLayout()
     {
-        if (_viewModel?.CanMutateWorkspace != true
-            || !_layoutHistory.TryUndo(CaptureLayout(), out var previous))
+        if (_viewModel?.CanMutateWorkspace != true ||
+            !_layoutHistory.TryUndo(CaptureLayout(), out var previous))
         {
             return;
         }
 
         ApplyLayout(previous);
         PersistLayout();
-        NotifyHistoryStateChanged();
     }
 
     public void RedoLayout()
     {
-        if (_viewModel?.CanMutateWorkspace != true
-            || !_layoutHistory.TryRedo(CaptureLayout(), out var next))
+        if (_viewModel?.CanMutateWorkspace != true ||
+            !_layoutHistory.TryRedo(CaptureLayout(), out var next))
         {
             return;
         }
 
         ApplyLayout(next);
         PersistLayout();
-        NotifyHistoryStateChanged();
-    }
-
-    private void SetZoom(double value, bool persist = false)
-    {
-        _zoom = Math.Clamp(value, 0.25, 2.5);
-        ZoomHost.Width = Surface.Width * _zoom;
-        ZoomHost.Height = Surface.Height * _zoom;
-        Surface.RenderTransform = new ScaleTransform(_zoom, _zoom);
-        Surface.RenderTransformOrigin = RelativePoint.TopLeft;
-        if (persist)
-        {
-            PersistViewState();
-        }
-
-        RenderMiniMap();
-        ZoomChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
     {
         DetachViewModel();
-        ClearLayoutHistory();
-        _selectedNodeIds.Clear();
-        NotifySelectionStateChanged();
         _viewModel = DataContext as MainWindowViewModel;
         if (_viewModel is not null)
         {
@@ -171,8 +338,8 @@ public partial class BlueprintCanvasSurface : UserControl
         }
 
         RestoreLayout();
-        RenderGraph();
         RestoreViewState();
+        RenderGraph();
     }
 
     private void DetachViewModel()
@@ -189,98 +356,34 @@ public partial class BlueprintCanvasSurface : UserControl
 
     private void HandleVersionsChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
     {
-        _viewportSaveTimer.Stop();
-        _isRestoringLayout = true;
-        if (!_isPersistingLayout)
+        if (!_isPersisting)
         {
-            ClearLayoutHistory();
+            _layoutHistory.Clear();
         }
-
         RenderGraph();
-        Dispatcher.UIThread.Post(
-            () => _isRestoringLayout = false,
-            DispatcherPriority.Loaded);
     }
 
     private void HandleViewModelPropertyChanged(object? sender, PropertyChangedEventArgs eventArgs)
     {
-        if (eventArgs.PropertyName is nameof(MainWindowViewModel.SelectedVersion)
-            or nameof(MainWindowViewModel.SelectedItem))
+        if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasLayout))
         {
-            UpdateSelectionVisuals();
-        }
-        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasLayout))
-        {
-            if (!_isPersistingLayout)
-            {
-                ClearLayoutHistory();
-            }
-
             RestoreLayout();
             RenderGraph();
         }
-        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.RelationshipDocument))
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.RelationshipDocument)
+                 or nameof(MainWindowViewModel.CanMutateWorkspace))
         {
             RenderGraph();
+        }
+        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.SelectedItem)
+                 or nameof(MainWindowViewModel.SelectedVersion))
+        {
+            UpdateSelectionVisuals();
         }
         else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasViewState))
         {
             RestoreViewState();
-        }
-        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanvasGroupingMode))
-        {
-            AutoArrange();
-        }
-        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.VersionCount)
-            or nameof(MainWindowViewModel.ItemCount))
-        {
             RenderGraph();
-        }
-        else if (eventArgs.PropertyName is nameof(MainWindowViewModel.CanMutateWorkspace))
-        {
-            NotifyHistoryStateChanged();
-        }
-    }
-
-    private void UpdateSelectionVisuals()
-    {
-        if (_viewModel is null)
-        {
-            return;
-        }
-
-        foreach (var border in Surface.Children.OfType<Border>())
-        {
-            if (border.Tag is not NodeTag tag || tag.Id is not Guid id)
-            {
-                continue;
-            }
-
-            var selected = _selectedNodeIds.Contains(id)
-                || tag.Type switch
-                {
-                    "version" => _viewModel.SelectedVersion?.VersionId == id,
-                    "item" => _viewModel.SelectedItem?.ItemId == id,
-                    _ => false,
-                };
-            border.Background = Brush.Parse(
-                selected
-                    ? "#6658DA"
-                    : tag.Type switch
-                    {
-                        "project" => "#202238",
-                        "version" => "#34304F",
-                        _ => "#2B2D48",
-                    });
-            border.BorderBrush = Brush.Parse(
-                selected
-                    ? "#FFFFFF"
-                    : tag.Type switch
-                    {
-                        "project" => "#B8B2F4",
-                        "version" => "#9187E8",
-                        _ => "#6F6A9E",
-                    });
         }
     }
 
@@ -288,532 +391,1099 @@ public partial class BlueprintCanvasSurface : UserControl
     {
         Surface.Children.Clear();
         _nodes.Clear();
-        _typedNodes.Clear();
-        _connections.Clear();
-        _alignmentGuideVisuals.Clear();
-
+        _nodeBounds.Clear();
         if (_viewModel is null)
         {
             return;
         }
 
-        var groupedItems = BuildItemGroups();
-        var largestGroup = groupedItems.Count == 0
-            ? 0
-            : groupedItems.Max(static group => group.Items.Count);
-        Surface.Height = Math.Max(
-            900,
-            Math.Max(220 + _viewModel.Versions.Count * 180, 210 + largestGroup * 112));
-        Surface.Width = Math.Max(1260, 690 + groupedItems.Count * 286);
+        var projection = CanvasBoardProjectionService.Build(
+            _viewMode,
+            _viewModel.Versions,
+            _viewModel.RelationshipDocument,
+            new CanvasBoardFilter(
+                _searchText,
+                _versionFilter,
+                _lifecycleFilter,
+                _itemTypeFilter,
+                _categoryFilter,
+                _warningsOnly),
+            _viewModel.CurrentProject);
+
+        if (_viewMode == CanvasViewMode.Plan)
+        {
+            RenderPlan(projection);
+        }
+        else if (_viewMode == CanvasViewMode.Dependencies)
+        {
+            RenderDependencies(projection);
+        }
+        else
+        {
+            RenderReleaseNotes(projection);
+        }
+
         DrawGrid();
-        SetZoom(_zoom);
-
-        var projectNode = CreateProjectNode();
-        var projectPoint = GetPosition(
-            _viewModel.CurrentProject.ProjectId,
-            new Point(48, Math.Max(310, Surface.Height / 2 - 70)));
-        Place(projectNode, projectPoint);
-        Surface.Children.Add(projectNode);
-        RegisterNode(projectNode);
-
-        for (var versionIndex = 0; versionIndex < _viewModel.Versions.Count; versionIndex++)
-        {
-            var version = _viewModel.Versions[versionIndex];
-            var versionPoint = GetPosition(
-                version.VersionId,
-                new Point(350, 120 + versionIndex * 180));
-            var versionNode = CreateVersionNode(version);
-            Place(versionNode, versionPoint);
-            Surface.Children.Add(versionNode);
-            RegisterNode(versionNode);
-            AddConnection(projectNode, versionNode, "#8B7FEB", 2, 0.5);
-
-        }
-
-        for (var groupIndex = 0; groupIndex < groupedItems.Count; groupIndex++)
-        {
-            var group = groupedItems[groupIndex];
-            var groupX = 680 + groupIndex * 286;
-            Surface.Children.Add(CreateGroupHeader(
-                group.Label,
-                group.Items.Count,
-                new Point(groupX, 74)));
-
-            for (var itemIndex = 0; itemIndex < group.Items.Count; itemIndex++)
-            {
-                var (version, item) = group.Items[itemIndex];
-                var itemPoint = GetPosition(
-                    item.ItemId,
-                    new Point(groupX, 140 + itemIndex * 112));
-                var itemNode = CreateItemNode(version, item);
-                Place(itemNode, itemPoint);
-                Surface.Children.Add(itemNode);
-                RegisterNode(itemNode);
-                if (_typedNodes.TryGetValue(("version", version.VersionId), out var versionNode))
-                {
-                    AddConnection(
-                        versionNode,
-                        itemNode,
-                        item.IsDone ? "#38A890" : "#AAA6BD",
-                        item.IsDone ? 1.25 : 1,
-                        _viewModel.SelectedItem?.ItemId == item.ItemId ? 0.9 : 0.2);
-                }
-            }
-        }
-
-        if (_viewModel.RelationshipDocument is { } relationshipDocument)
-        {
-            var types = relationshipDocument.Types.ToDictionary(
-                static type => type.TypeId,
-                StringComparer.Ordinal);
-            foreach (var relationship in relationshipDocument.Relationships)
-            {
-                if (_typedNodes.TryGetValue(
-                        (relationship.Source.NodeType, relationship.Source.EntityId),
-                        out var source) &&
-                    _typedNodes.TryGetValue(
-                        (relationship.Target.NodeType, relationship.Target.EntityId),
-                        out var target) &&
-                    types.TryGetValue(relationship.TypeId, out var type))
-                {
-                    AddConnection(
-                        source,
-                        target,
-                        type.ColorHex,
-                        type.IsDirectional ? 3.25 : 2.5);
-                }
-            }
-        }
-
-        foreach (var connection in _connections)
-        {
-            Surface.Children.Insert(FindGridVisualCount(), connection.Line);
-            UpdateConnection(connection);
-        }
-
-        var selectionChanged = _selectedNodeIds.RemoveWhere(id => !_nodes.ContainsKey(id)) > 0;
-        UpdateSelectionVisuals();
+        RenderRelationships(projection.Relationships);
+        RenderEmptyState(projection);
         RenderMiniMap();
-        if (selectionChanged)
-        {
-            NotifySelectionStateChanged();
-        }
-
-        if (_viewModel.Versions.Count == 0)
-        {
-            var empty = new TextBlock
-            {
-                Text = "Create your first version to start the blueprint",
-                FontFamily = FontFamily.Parse("Cascadia Mono, SFMono-Regular, Consolas, monospace"),
-                FontSize = 16,
-                FontWeight = FontWeight.Bold,
-                Foreground = Brush.Parse("#6254D9"),
-            };
-            Place(empty, new Point(360, 330));
-            Surface.Children.Add(empty);
-        }
+        SetZoom(_zoom);
+        SelectionStateChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    private IReadOnlyList<CanvasItemGroup> BuildItemGroups()
+    private void RenderPlan(CanvasBoardProjection projection)
     {
-        if (_viewModel is null)
+        var y = 70d;
+        foreach (var frame in projection.Frames)
         {
-            return [];
+            var savedPosition = GetPosition(frame.Version.VersionId, new Point(70, y));
+            var position = new Point(savedPosition.X, Math.Max(savedPosition.Y, y));
+            _positions[frame.Version.VersionId] = position;
+            var collapsed = _collapsedVersionIds.Contains(frame.Version.VersionId);
+            var maximumItems = frame.Columns.Max(static column => column.Items.Count);
+            var naturalHeight = collapsed ? FrameHeaderHeight : Math.Max(360, 178 + maximumItems * (CardHeight + 14));
+            var configured = _frameSizes.GetValueOrDefault(
+                frame.Version.VersionId,
+                new Size(FrameWidth, naturalHeight));
+            var size = new Size(
+                Math.Max(FrameWidth, configured.Width),
+                collapsed ? FrameHeaderHeight : Math.Max(naturalHeight, configured.Height));
+            var root = CreateVersionFrame(frame, size, collapsed, position);
+            Place(root, position);
+            Surface.Children.Add(root);
+            _nodes[("version", frame.Version.VersionId)] = root;
+            _nodeBounds[("version", frame.Version.VersionId)] = new Rect(position, size);
+            y = Math.Max(y, position.Y + size.Height + 56);
         }
 
-        return _viewModel.Versions
-            .SelectMany(version => version.Items.Select(item => (Version: version, Item: item)))
-            .GroupBy(pair => _viewModel.CanvasGroupingMode switch
-            {
-                CanvasGroupingMode.WorkType => pair.Item.ItemTypeId,
-                CanvasGroupingMode.Version => pair.Version.Name,
-                _ => pair.Item.CategoryId,
-            }, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
-            .Select(group => new CanvasItemGroup(
-                HumanizeGroup(group.Key),
-                group.OrderBy(static pair => pair.Item.IsDone)
-                    .ThenBy(static pair => pair.Item.ItemKey, StringComparer.Ordinal)
-                    .ToArray()))
-            .ToArray();
+        SizeSurface();
     }
 
-    private static string HumanizeGroup(string value) =>
-        string.Join(
-            ' ',
-            value.Replace('-', ' ').Replace('_', ' ')
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                .Select(static word => char.ToUpperInvariant(word[0]) + word[1..]));
-
-    private static Control CreateGroupHeader(string label, int count, Point point)
+    private Control CreateVersionFrame(
+        CanvasVersionFrame frame,
+        Size size,
+        bool collapsed,
+        Point absolutePosition)
     {
-        var title = new TextBlock
+        var root = new Border
         {
-            Text = label,
-            Foreground = Brush.Parse("#5045B4"),
-            FontWeight = FontWeight.Bold,
-            FontSize = 12,
-            VerticalAlignment = VerticalAlignment.Center,
+            Width = size.Width,
+            Height = size.Height,
+            Background = ResourceBrush("CanvasFrameBackgroundBrush", "#F9F9FC"),
+            BorderBrush = IsSelected(frame.Version.VersionId)
+                ? ResourceBrush("CanvasSelectionBrush", "#6254D9")
+                : ResourceBrush("CanvasFrameBorderBrush", "#D6D8E2"),
+            BorderThickness = new Thickness(IsSelected(frame.Version.VersionId) ? 2.5 : 1),
+            CornerRadius = new CornerRadius(8),
+            Tag = new NodeTag("version", frame.Version.VersionId),
         };
-        var badge = new TextBlock
-        {
-            Text = count.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            Foreground = Brush.Parse("#77738B"),
-            FontSize = 11,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        Grid.SetColumn(badge, 1);
-        var content = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
-        content.Children.Add(title);
-        content.Children.Add(badge);
+        AutomationProperties.SetName(root, $"Version {frame.Version.Name}, {frame.CompletionPercentage} percent complete");
+        AutomationProperties.SetHelpText(root, $"{frame.ReadinessSummary}. Select to open version details.");
+
+        var layout = new Grid { RowDefinitions = new RowDefinitions("86,*") };
         var header = new Border
         {
-            Width = NodeWidth,
-            Height = 44,
-            Padding = new Thickness(12, 8),
-            Background = Brush.Parse("#E9E6F8"),
-            BorderBrush = Brush.Parse("#D1CCED"),
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(10),
-            IsHitTestVisible = false,
-            Child = content,
+            Padding = new Thickness(18, 13),
+            Background = ResourceBrush("CanvasFrameHeaderBrush", "#F1F0F8"),
+            BorderBrush = ResourceBrush("CanvasFrameBorderBrush", "#D6D8E2"),
+            BorderThickness = new Thickness(0, 0, 0, collapsed ? 0 : 1),
         };
-        Place(header, point);
-        return header;
-    }
+        var headerGrid = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
+        var heading = new StackPanel { Spacing = 5 };
+        var titleRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 9 };
+        titleRow.Children.Add(Text(frame.Version.Name, 21, FontWeight.Bold));
+        titleRow.Children.Add(Badge(frame.Version.Status.ToString(), "#E6E3FA", "#5548C7"));
+        heading.Children.Add(titleRow);
+        heading.Children.Add(Text(
+            $"{frame.Version.CompletedItemCount}/{frame.Version.ItemCount} complete · {frame.CompletionPercentage}% · {frame.ReadinessSummary}",
+            11,
+            FontWeight.Medium,
+            ResourceBrush("CanvasMutedBrush", "#66697A")));
+        headerGrid.Children.Add(heading);
 
-    private void RegisterNode(Control node)
-    {
-        if (node.Tag is NodeTag { Type: var nodeType, Id: Guid nodeId })
+        var actions = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 7 };
+        Grid.SetColumn(actions, 1);
+        var warning = Badge(
+            frame.BlockerCount > 0 ? $"⚠ {frame.BlockerCount} blocked" : $"{frame.WarningCount} open",
+            frame.BlockerCount > 0 ? "#FDE8E5" : "#ECEEF4",
+            frame.BlockerCount > 0 ? "#A93A31" : "#606477");
+        actions.Children.Add(warning);
+        var inspect = SmallButton("Details", "Open version inspector");
+        inspect.Click += (_, _) => SelectVersion(frame.Version);
+        actions.Children.Add(inspect);
+        if (_connectMode)
         {
-            _nodes[nodeId] = node;
-            _typedNodes[(nodeType, nodeId)] = node;
-        }
-    }
-
-    private int FindGridVisualCount()
-    {
-        var count = 0;
-        foreach (var child in Surface.Children)
-        {
-            if (child is not Line line || line.Tag as string != "grid")
+            var connect = SmallButton("●", $"Use {frame.Version.Name} as a relationship endpoint");
+            connect.Click += (_, eventArgs) =>
             {
-                break;
+                HandleConnectionEndpoint(new RelationshipEndpoint("version", frame.Version.VersionId));
+                eventArgs.Handled = true;
+            };
+            actions.Children.Add(connect);
+        }
+        var collapse = SmallButton(collapsed ? "Expand" : "Collapse", collapsed ? "Expand version frame" : "Collapse version frame");
+        collapse.Click += (_, eventArgs) =>
+        {
+            eventArgs.Handled = true;
+            if (!_collapsedVersionIds.Add(frame.Version.VersionId))
+            {
+                _collapsedVersionIds.Remove(frame.Version.VersionId);
             }
-
-            count++;
-        }
-
-        return count;
-    }
-
-    private void DrawGrid()
-    {
-        for (var x = 0; x <= Surface.Width; x += 40)
-        {
-            Surface.Children.Add(CreateGridLine(new Point(x, 0), new Point(x, Surface.Height), x % 200 == 0));
-        }
-
-        for (var y = 0; y <= Surface.Height; y += 40)
-        {
-            Surface.Children.Add(CreateGridLine(new Point(0, y), new Point(Surface.Width, y), y % 200 == 0));
-        }
-    }
-
-    private static Line CreateGridLine(Point start, Point end, bool major) =>
-        new()
-        {
-            StartPoint = start,
-            EndPoint = end,
-            Stroke = Brush.Parse(major ? "#DDD9EA" : "#EAE8F1"),
-            StrokeThickness = major ? 1 : 0.5,
-            IsHitTestVisible = false,
-            Tag = "grid",
+            RenderGraph();
+            PersistViewState();
         };
+        actions.Children.Add(collapse);
+        headerGrid.Children.Add(actions);
+        header.Child = headerGrid;
+        layout.Children.Add(header);
 
-    private Control CreateProjectNode()
-    {
-        var content = new StackPanel { Spacing = 7 };
-        content.Children.Add(CreateLabel("PROJECT", "#B8B2F4"));
-        content.Children.Add(CreateTitle(_viewModel?.CurrentProject.Name ?? "Project", 22));
-        content.Children.Add(CreateLabel(
-            $"{_viewModel?.CurrentProject.Code}  /  {_viewModel?.VersioningScheme}",
-            "#B9BBCB"));
-        content.Children.Add(CreateLabel(
-            $"{_viewModel?.VersionCount ?? 0} versions  ·  {_viewModel?.ItemCount ?? 0} items",
-            "#B9BBCB"));
-
-        var node = CreateNodeShell(
-            content,
-            250,
-            140,
-            "#24213F",
-            "#7C6DEA",
-            "project",
-            _viewModel?.CurrentProject.ProjectId);
-        if (_viewModel?.CurrentProject.ProjectId is Guid projectId && projectId != Guid.Empty)
+        if (!collapsed)
         {
-            AddDragHandlers(node, projectId);
+            var columns = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,*,*,*"),
+                Margin = new Thickness(14),
+            };
+            Grid.SetRow(columns, 1);
+            for (var index = 0; index < frame.Columns.Count; index++)
+            {
+                var column = frame.Columns[index];
+                var columnControl = CreateLifecycleColumn(
+                    frame.Version,
+                    column,
+                    absolutePosition,
+                    size.Width,
+                    index);
+                Grid.SetColumn(columnControl, index);
+                columns.Children.Add(columnControl);
+            }
+            layout.Children.Add(columns);
+
+            var resize = new Border
+            {
+                Width = 18,
+                Height = 18,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Bottom,
+                Cursor = new Cursor(StandardCursorType.BottomRightCorner),
+                Background = ResourceBrush("CanvasResizeBrush", "#CBC7E8"),
+            };
+            AddResizeHandlers(resize, root, frame.Version.VersionId);
+            layout.Children.Add(resize);
         }
 
-        return node;
+        root.Child = layout;
+        header.PointerPressed += (_, eventArgs) =>
+        {
+            SelectVersion(frame.Version, eventArgs.KeyModifiers);
+            BeginNodeDrag(root, ("version", frame.Version.VersionId), eventArgs);
+        };
+        AddNodeDragContinuation(root);
+        return root;
     }
 
-    private Control CreateVersionNode(WorkspaceVersionCard version)
+    private Control CreateLifecycleColumn(
+        WorkspaceVersionCard version,
+        CanvasLifecycleColumn column,
+        Point framePosition,
+        double frameWidth,
+        int columnIndex)
     {
-        var selected = _viewModel?.SelectedVersion?.VersionId == version.VersionId;
-        var content = new StackPanel { Spacing = 6 };
-        content.Children.Add(CreateLabel($"VERSION  /  {version.Status}", selected ? "#FFFFFF" : "#B8B2F4"));
-        content.Children.Add(CreateTitle(version.Name, 20));
-        content.Children.Add(CreateLabel(
-            $"{version.CompletedItemCount}/{version.ItemCount} complete",
-            version.CompletedItemCount == version.ItemCount && version.ItemCount > 0 ? "#62D3BC" : "#B9BBCB"));
+        var panel = new StackPanel { Spacing = 11 };
+        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto"), Margin = new Thickness(5, 2, 5, 0) };
+        header.Children.Add(Text(column.DisplayName.ToUpperInvariant(), 10, FontWeight.Bold, LifecycleBrush(column.State)));
+        var count = Text(column.Items.Count.ToString(System.Globalization.CultureInfo.InvariantCulture), 11, FontWeight.Bold);
+        Grid.SetColumn(count, 1);
+        header.Children.Add(count);
+        panel.Children.Add(header);
 
-        var node = CreateNodeShell(
-            content,
-            NodeWidth,
-            VersionNodeHeight,
-            selected ? "#6254D9" : "#34304F",
-            selected ? "#FFFFFF" : "#8E84DD",
-            "version",
-            version.VersionId);
-        node.AddHandler(
-            PointerPressedEvent,
-            (_, _) => _viewModel?.SelectVersionNodeCommand.Execute(version),
-            RoutingStrategies.Tunnel);
-        AddDragHandlers(node, version.VersionId);
-        return node;
+        foreach (var item in column.Items)
+        {
+            var card = CreateItemCard(version, item);
+            panel.Children.Add(card);
+            var localX = 14 + columnIndex * ((frameWidth - 28) / 4) + 7;
+            var localY = FrameHeaderHeight + 62 + (panel.Children.Count - 2) * (CardHeight + 11);
+            _nodes[("item", item.ItemId)] = card;
+            _nodeBounds[("item", item.ItemId)] = new Rect(
+                framePosition.X + localX,
+                framePosition.Y + localY,
+                (frameWidth - 28) / 4 - 22,
+                CardHeight);
+        }
+
+        return new Border
+        {
+            Margin = new Thickness(5, 0),
+            Padding = new Thickness(7),
+            Background = ResourceBrush("CanvasColumnBackgroundBrush", "#F2F3F7"),
+            BorderBrush = ResourceBrush("CanvasColumnBorderBrush", "#E1E2E9"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Child = panel,
+        };
     }
 
-    private Control CreateItemNode(WorkspaceVersionCard version, WorkspaceItemCard item)
+    private Control CreateItemCard(WorkspaceVersionCard version, WorkspaceItemCard item)
     {
-        var selected = _viewModel?.SelectedItem?.ItemId == item.ItemId;
-        var content = new StackPanel { Spacing = 4 };
-        var heading = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
-        heading.Children.Add(CreateLabel(item.ItemKey, selected ? "#FFFFFF" : "#B8B2F4"));
-        var state = CreateLabel(item.IsDone ? "DONE" : "OPEN", item.IsDone ? "#62D3BC" : "#F1C96A");
+        var selected = IsSelected(item.ItemId) || _viewModel?.SelectedItem?.ItemId == item.ItemId;
+        var blocked = IsBlocked(item.ItemId);
+        var content = new Grid { RowDefinitions = new RowDefinitions("Auto,*,Auto"), RowSpacing = 7 };
+        var heading = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions(_connectMode ? "*,Auto,Auto" : "*,Auto"),
+            ColumnSpacing = 5,
+        };
+        heading.Children.Add(Text(item.ItemKey, 11, FontWeight.Bold, ResourceBrush("CanvasAccentBrush", "#6254D9")));
+        var state = Badge(
+            CanvasBoardProjectionService.Format(item.WorkflowState),
+            LifecycleBackground(item.WorkflowState),
+            LifecycleColor(item.WorkflowState));
         Grid.SetColumn(state, 1);
         heading.Children.Add(state);
+        if (_connectMode)
+        {
+            var handle = Text("●", 15, FontWeight.Bold, ResourceBrush("CanvasAccentBrush", "#6254D9"));
+            ToolTip.SetTip(handle, "Relationship connection handle");
+            AutomationProperties.SetName(handle, $"Connect from {item.ItemKey}");
+            Grid.SetColumn(handle, 2);
+            heading.Children.Add(handle);
+        }
         content.Children.Add(heading);
-        content.Children.Add(CreateTitle(item.Title, 15));
-        content.Children.Add(CreateLabel($"{item.ItemTypeId}  /  {item.CategoryId}", "#A9ABBA"));
 
-        var node = CreateNodeShell(
-            content,
-            NodeWidth,
-            ItemNodeHeight,
-            selected ? "#6254D9" : "#292A43",
-            selected ? "#FFFFFF" : item.IsDone ? "#4DB7A5" : "#6F6A9E",
-            "item",
-            item.ItemId);
-        node.AddHandler(
-            PointerPressedEvent,
-            (_, _) => _viewModel?.SelectItemNodeCommand.Execute(item),
-            RoutingStrategies.Tunnel);
-        AddDragHandlers(node, item.ItemId);
-        return node;
-    }
+        var title = Text(item.Title, 14, FontWeight.SemiBold);
+        title.TextWrapping = TextWrapping.Wrap;
+        title.MaxLines = 3;
+        title.TextTrimming = TextTrimming.CharacterEllipsis;
+        Grid.SetRow(title, 1);
+        content.Children.Add(title);
 
-    private static Border CreateNodeShell(
-        Control content,
-        double width,
-        double height,
-        string background,
-        string border,
-        string nodeType,
-        Guid? nodeId) =>
-        new()
+        var metadata = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+        Grid.SetRow(metadata, 2);
+        metadata.Children.Add(Badge(item.ItemTypeId, "#ECEEF3", "#55596B"));
+        metadata.Children.Add(Badge(item.CategoryId, "#EEEAF9", "#6254A8"));
+        if (item.SourceReference is not null)
         {
-            Width = width,
-            Height = height,
-            Padding = new Thickness(15, 12),
-            Background = Brush.Parse(background),
-            BorderBrush = Brush.Parse(border),
-            BorderThickness = new Thickness(1.5),
-            CornerRadius = new CornerRadius(12),
-            Child = content,
+            metadata.Children.Add(Badge("source", "#E7F2F5", "#276A75"));
+        }
+        if (blocked)
+        {
+            metadata.Children.Add(Badge("⚠ blocked", "#FDE8E5", "#A93A31"));
+        }
+        content.Children.Add(metadata);
+
+        var shell = new Border
+        {
+            Height = CardHeight,
+            Padding = new Thickness(12, 10),
+            Background = ResourceBrush("CanvasCardBackgroundBrush", "#FFFFFF"),
+            BorderBrush = selected
+                ? ResourceBrush("CanvasSelectionBrush", "#6254D9")
+                : blocked
+                    ? ResourceBrush("CanvasWarningBrush", "#C64D42")
+                    : ResourceBrush("CanvasCardBorderBrush", "#D8DAE4"),
+            BorderThickness = new Thickness(selected ? 2 : 1),
+            CornerRadius = new CornerRadius(6),
             Cursor = new Cursor(StandardCursorType.Hand),
-            Tag = new NodeTag(nodeType, nodeId),
-            BoxShadow = new BoxShadows(new BoxShadow
-            {
-                Blur = 12,
-                OffsetX = 0,
-                OffsetY = 4,
-                Color = Color.Parse("#55000000"),
-            }),
+            Child = content,
+            Tag = new NodeTag("item", item.ItemId),
         };
-
-    private static TextBlock CreateLabel(string text, string foreground) =>
-        new()
+        AutomationProperties.SetName(shell, $"{item.ItemKey}, {item.Title}");
+        AutomationProperties.SetHelpText(
+            shell,
+            $"{CanvasBoardProjectionService.Format(item.WorkflowState)}, {item.ItemTypeId}, changelog category {item.CategoryId}.");
+        shell.PointerPressed += (_, eventArgs) =>
         {
-            Text = text,
-            FontFamily = FontFamily.Parse("Cascadia Mono, SFMono-Regular, Consolas, monospace"),
-            FontSize = 10,
-            FontWeight = FontWeight.SemiBold,
-            LetterSpacing = 0.8,
-            Foreground = Brush.Parse(foreground),
-            TextTrimming = TextTrimming.CharacterEllipsis,
-        };
-
-    private static TextBlock CreateTitle(string text, double size) =>
-        new()
-        {
-            Text = text,
-            FontSize = size,
-            FontWeight = FontWeight.Bold,
-            Foreground = Brushes.White,
-            TextTrimming = TextTrimming.CharacterEllipsis,
-        };
-
-    private void AddDragHandlers(Control node, Guid nodeId)
-    {
-        node.AddHandler(
-            PointerPressedEvent,
-            (_, eventArgs) =>
+            if (_connectMode)
             {
-                if (!eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
-                {
-                    return;
-                }
-
-                UpdateNodeSelection(nodeId, eventArgs.KeyModifiers);
-                Focus();
+                HandleConnectionEndpoint(new RelationshipEndpoint("item", item.ItemId));
                 eventArgs.Handled = true;
-                if (_viewModel?.CanMutateWorkspace != true || !_selectedNodeIds.Contains(nodeId))
-                {
-                    return;
-                }
-
-                _draggedNode = node;
-                _dragStartLayout = CaptureLayout();
-                _dragStartPointer = eventArgs.GetPosition(Surface);
-                _dragStartPositions = _selectedNodeIds
-                    .Where(_positions.ContainsKey)
-                    .ToDictionary(id => id, id => _positions[id]);
-                eventArgs.Pointer.Capture(node);
-            },
-            RoutingStrategies.Tunnel);
-        node.PointerMoved += (_, eventArgs) =>
-        {
-            if (_viewModel?.CanMutateWorkspace != true
-                || _draggedNode != node
-                || !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
-            {
                 return;
             }
-
-            var pointer = eventArgs.GetPosition(Surface);
-            var requestedDelta = pointer - _dragStartPointer;
-            var selectedBounds = GetNodeBounds(_dragStartPositions);
-            var constrained = CanvasSelectionService.ConstrainMove(
-                selectedBounds,
-                requestedDelta.X,
-                requestedDelta.Y,
-                Surface.Width,
-                Surface.Height);
-            MoveNodesFromOrigins(_dragStartPositions, constrained.DeltaX, constrained.DeltaY);
-            RenderAlignmentGuides();
-        };
-        node.PointerReleased += (_, eventArgs) =>
-        {
-            if (_draggedNode == node)
+            SelectItem(item, eventArgs.KeyModifiers);
+            if (eventArgs.GetCurrentPoint(shell).Properties.IsLeftButtonPressed &&
+                _viewModel?.CanEditItems == true)
             {
-                _draggedNode = null;
-                eventArgs.Pointer.Capture(null);
-                if (_dragStartLayout is not null
-                    && _layoutHistory.Record(_dragStartLayout, CaptureLayout()))
+                _draggedItemVersion = version;
+                _draggedItem = item;
+                eventArgs.Pointer.Capture(shell);
+            }
+            eventArgs.Handled = true;
+        };
+        shell.PointerReleased += (_, eventArgs) =>
+        {
+            if (_draggedItem?.ItemId == item.ItemId && _draggedItemVersion is not null)
+            {
+                var point = eventArgs.GetPosition(Surface);
+                var frameX = _positions.GetValueOrDefault(version.VersionId).X;
+                var width = _frameSizes.GetValueOrDefault(version.VersionId, new Size(FrameWidth, 0)).Width;
+                var targetIndex = Math.Clamp(
+                    (int)((point.X - frameX - 14) / Math.Max(1, width - 28) * 4),
+                    0,
+                    3);
+                var targetState = (WorkItemLifecycle)targetIndex;
+                if (targetState != item.WorkflowState)
                 {
-                    NotifyHistoryStateChanged();
-                    PersistLayout();
+                    _viewModel?.ChangeItemLifecycleCommand.Execute(
+                        new WorkItemLifecycleChangeRequest(version.VersionId, item.ItemId, targetState));
                 }
-
-                _dragStartLayout = null;
-                _dragStartPositions = new Dictionary<Guid, Point>();
-                ClearAlignmentGuides();
             }
+            _draggedItem = null;
+            _draggedItemVersion = null;
+            eventArgs.Pointer.Capture(null);
+            RenderGraph();
+        };
+        return shell;
+    }
+
+    private void RenderDependencies(CanvasBoardProjection projection)
+    {
+        foreach (var node in projection.DependencyNodes.Select((value, index) => (value, index)))
+        {
+            var fallback = DependencyPosition(node.index);
+            var point = GetPosition(node.value.EntityId, fallback);
+            var control = CreateDependencyNode(node.value);
+            Place(control, point);
+            Surface.Children.Add(control);
+            _nodes[(node.value.NodeType, node.value.EntityId)] = control;
+            _nodeBounds[(node.value.NodeType, node.value.EntityId)] =
+                new Rect(point, new Size(DependencyNodeWidth, DependencyNodeHeight));
+            AddFreeNodeDrag(control, (node.value.NodeType, node.value.EntityId));
+        }
+        SizeSurface();
+    }
+
+    private Control CreateDependencyNode(CanvasDependencyNode node)
+    {
+        var selected = IsSelected(node.EntityId);
+        var content = new StackPanel { Spacing = 7 };
+        var heading = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions(_connectMode ? "*,Auto,Auto" : "*,Auto"),
+            ColumnSpacing = 5,
+        };
+        heading.Children.Add(Text(node.Key, 10, FontWeight.Bold, ResourceBrush("CanvasAccentBrush", "#6254D9")));
+        if (node.WorkflowState is WorkItemLifecycle state)
+        {
+            var badge = Badge(CanvasBoardProjectionService.Format(state), LifecycleBackground(state), LifecycleColor(state));
+            Grid.SetColumn(badge, 1);
+            heading.Children.Add(badge);
+        }
+        if (_connectMode)
+        {
+            var handle = Text("●", 15, FontWeight.Bold, ResourceBrush("CanvasAccentBrush", "#6254D9"));
+            Grid.SetColumn(handle, 2);
+            heading.Children.Add(handle);
+        }
+        content.Children.Add(heading);
+        var title = Text(node.Title, 15, FontWeight.SemiBold);
+        title.TextWrapping = TextWrapping.Wrap;
+        title.MaxLines = 2;
+        content.Children.Add(title);
+        content.Children.Add(Text(node.Subtitle, 10, FontWeight.Normal, ResourceBrush("CanvasMutedBrush", "#66697A")));
+        var shell = new Border
+        {
+            Width = DependencyNodeWidth,
+            Height = DependencyNodeHeight,
+            Padding = new Thickness(13, 11),
+            Background = ResourceBrush("CanvasCardBackgroundBrush", "#FFFFFF"),
+            BorderBrush = selected
+                ? ResourceBrush("CanvasSelectionBrush", "#6254D9")
+                : ResourceBrush("CanvasCardBorderBrush", "#D8DAE4"),
+            BorderThickness = new Thickness(selected ? 2 : 1),
+            CornerRadius = new CornerRadius(6),
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Child = content,
+            Tag = new NodeTag(node.NodeType, node.EntityId),
+        };
+        shell.PointerPressed += (_, eventArgs) =>
+        {
+            if (_connectMode)
+            {
+                HandleConnectionEndpoint(new RelationshipEndpoint(node.NodeType, node.EntityId));
+                eventArgs.Handled = true;
+                return;
+            }
+            SelectProjectedNode(node, eventArgs.KeyModifiers);
+        };
+        AutomationProperties.SetName(shell, $"{node.Key}, {node.Title}");
+        return shell;
+    }
+
+    private void RenderReleaseNotes(CanvasBoardProjection projection)
+    {
+        var categories = projection.Frames
+            .SelectMany(static frame => frame.Columns)
+            .SelectMany(static column => column.Items)
+            .GroupBy(static item => item.CategoryId, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var x = 70d;
+        foreach (var category in categories)
+        {
+            var panel = new StackPanel { Spacing = 10 };
+            panel.Children.Add(Text(category.Key.ToUpperInvariant(), 11, FontWeight.Bold, ResourceBrush("CanvasAccentBrush", "#6254D9")));
+            foreach (var item in category)
+            {
+                panel.Children.Add(CreateReleaseNoteCard(item));
+            }
+            var root = new Border
+            {
+                Width = 330,
+                Padding = new Thickness(14),
+                Background = ResourceBrush("CanvasColumnBackgroundBrush", "#F2F3F7"),
+                BorderBrush = ResourceBrush("CanvasColumnBorderBrush", "#E1E2E9"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(6),
+                Child = panel,
+            };
+            Place(root, new Point(x, 70));
+            Surface.Children.Add(root);
+            x += 360;
+        }
+        SizeSurface();
+    }
+
+    private Control CreateReleaseNoteCard(WorkspaceItemCard item)
+    {
+        var content = new StackPanel { Spacing = 5 };
+        content.Children.Add(Text($"{item.ItemKey} · {item.Title}", 13, FontWeight.SemiBold));
+        content.Children.Add(Text(
+            $"{item.ItemTypeId} · {CanvasBoardProjectionService.Format(item.WorkflowState)}",
+            10,
+            FontWeight.Normal,
+            ResourceBrush("CanvasMutedBrush", "#66697A")));
+        return new Border
+        {
+            Padding = new Thickness(11),
+            Background = ResourceBrush("CanvasCardBackgroundBrush", "#FFFFFF"),
+            BorderBrush = ResourceBrush("CanvasCardBorderBrush", "#D8DAE4"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(5),
+            Child = content,
         };
     }
 
-    private void UpdateNodeSelection(Guid nodeId, KeyModifiers modifiers)
+    private void RenderRelationships(IReadOnlyList<CanvasRelationshipProjection> relationships)
     {
-        var additive = modifiers.HasFlag(KeyModifiers.Control)
-            || modifiers.HasFlag(KeyModifiers.Shift);
-        if (additive)
+        foreach (var relationship in relationships)
         {
-            if (!_selectedNodeIds.Add(nodeId))
-            {
-                _selectedNodeIds.Remove(nodeId);
-            }
-        }
-        else if (!_selectedNodeIds.Contains(nodeId))
-        {
-            _selectedNodeIds.Clear();
-            _selectedNodeIds.Add(nodeId);
-        }
-
-        UpdateSelectionVisuals();
-        NotifySelectionStateChanged();
-    }
-
-    private IReadOnlyList<CanvasNodeBounds> GetNodeBounds(
-        IReadOnlyDictionary<Guid, Point>? positions = null) =>
-        _nodes
-            .Where(pair => positions is null || positions.ContainsKey(pair.Key))
-            .Select(pair =>
-            {
-                var point = positions is null ? _positions[pair.Key] : positions[pair.Key];
-                return new CanvasNodeBounds(
-                    pair.Key,
-                    point.X,
-                    point.Y,
-                    pair.Value.Width,
-                    pair.Value.Height);
-            })
-            .ToArray();
-
-    private void MoveNodesFromOrigins(
-        IReadOnlyDictionary<Guid, Point> origins,
-        double deltaX,
-        double deltaY)
-    {
-        foreach (var (id, origin) in origins)
-        {
-            if (!_nodes.TryGetValue(id, out var selectedNode))
+            if (!_nodeBounds.TryGetValue(
+                    (relationship.Edge.Source.NodeType, relationship.Edge.Source.EntityId),
+                    out var source) ||
+                !_nodeBounds.TryGetValue(
+                    (relationship.Edge.Target.NodeType, relationship.Edge.Target.EntityId),
+                    out var target))
             {
                 continue;
             }
 
-            var point = new Point(origin.X + deltaX, origin.Y + deltaY);
-            Place(selectedNode, point);
-            _positions[id] = point;
-            UpdateConnections(selectedNode);
+            var start = Anchor(source, target.Center);
+            var end = Anchor(target, source.Center);
+            var selected = _viewModel?.SelectedRelationship?.RelationshipId == relationship.Edge.RelationshipId;
+            var related = _selectedNodeIds.Count == 0 ||
+                _selectedNodeIds.Contains(relationship.Edge.Source.EntityId) ||
+                _selectedNodeIds.Contains(relationship.Edge.Target.EntityId);
+            Border? label = null;
+            void ShowLabel()
+            {
+                if (label is not null)
+                {
+                    return;
+                }
+                label = Badge(
+                    string.IsNullOrWhiteSpace(relationship.Edge.Label)
+                        ? relationship.Type.Name
+                        : relationship.Edge.Label!,
+                    "#F7F7FA",
+                    relationship.Type.ColorHex);
+                label.IsHitTestVisible = false;
+                Place(label, new Point((start.X + end.X) / 2 - 35, (start.Y + end.Y) / 2 - 12));
+                Surface.Children.Add(label);
+            }
+            var line = new Line
+            {
+                StartPoint = start,
+                EndPoint = end,
+                Stroke = Brush.Parse(relationship.Type.ColorHex),
+                StrokeThickness = selected ? 5 : 3,
+                Opacity = related ? .9 : .16,
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = relationship.Edge,
+            };
+            line.PointerPressed += (_, eventArgs) =>
+            {
+                if (_viewModel is not null)
+                {
+                    _selectedNodeIds.Clear();
+                    _viewModel.SelectedRelationship = relationship.Edge;
+                    _viewModel.InspectorTabIndex = 1;
+                    SelectionStateChanged?.Invoke(this, EventArgs.Empty);
+                    RenderGraph();
+                }
+                eventArgs.Handled = true;
+            };
+            line.PointerEntered += (_, _) => ShowLabel();
+            line.PointerExited += (_, _) =>
+            {
+                if (!selected && !(_selectedNodeIds.Count > 0 && related) && label is not null)
+                {
+                    Surface.Children.Remove(label);
+                    label = null;
+                }
+            };
+            AutomationProperties.SetName(
+                line,
+                $"{relationship.Type.Name} relationship{(string.IsNullOrWhiteSpace(relationship.Edge.Label) ? string.Empty : $", {relationship.Edge.Label}")}");
+            Surface.Children.Insert(GridVisualCount(), line);
+
+            Polygon? arrow = null;
+            if (relationship.Type.IsDirectional)
+            {
+                arrow = CreateArrow(start, end, relationship.Type.ColorHex, related ? .9 : .16);
+                Surface.Children.Insert(GridVisualCount(), arrow);
+            }
+
+            if (selected || related && _selectedNodeIds.Count > 0)
+            {
+                ShowLabel();
+            }
+        }
+    }
+
+    private void DrawGrid()
+    {
+        var insert = 0;
+        for (var x = 0d; x <= Surface.Width; x += 32)
+        {
+            Surface.Children.Insert(insert++, GridLine(new Point(x, 0), new Point(x, Surface.Height), x % 160 == 0));
+        }
+        for (var y = 0d; y <= Surface.Height; y += 32)
+        {
+            Surface.Children.Insert(insert++, GridLine(new Point(0, y), new Point(Surface.Width, y), y % 160 == 0));
+        }
+    }
+
+    private void RenderEmptyState(CanvasBoardProjection projection)
+    {
+        if (projection.Frames.Count > 0 || projection.DependencyNodes.Count > 0)
+        {
+            return;
+        }
+        var empty = new StackPanel { Spacing = 7 };
+        empty.Children.Add(Text("No work matches this view", 20, FontWeight.Bold));
+        empty.Children.Add(Text(
+            _viewModel?.Versions.Count == 0
+                ? "Add a version to begin shaping the blueprint."
+                : "Clear search or filters to bring work back into view.",
+            12,
+            FontWeight.Normal,
+            ResourceBrush("CanvasMutedBrush", "#66697A")));
+        Place(empty, new Point(90, 100));
+        Surface.Children.Add(empty);
+    }
+
+    private void HandleConnectionEndpoint(RelationshipEndpoint endpoint)
+    {
+        if (_viewModel?.CanMutateWorkspace != true || _viewModel.RelationshipTypes.Count == 0)
+        {
+            return;
+        }
+        if (_connectionSource is null)
+        {
+            _connectionSource = endpoint;
+            return;
+        }
+        if (_connectionSource == endpoint)
+        {
+            return;
         }
 
-        RenderMiniMap();
+        _viewModel.BeginNewRelationshipCommand.Execute(null);
+        _viewModel.SelectedRelationshipSource = _viewModel.RelationshipEndpoints.FirstOrDefault(
+            option => option.Endpoint == _connectionSource);
+        _viewModel.SelectedRelationshipTarget = _viewModel.RelationshipEndpoints.FirstOrDefault(
+            option => option.Endpoint == endpoint);
+        _viewModel.InspectorTabIndex = 1;
+        _connectionSource = null;
+        _connectMode = false;
+        ConnectModeChanged?.Invoke(this, EventArgs.Empty);
+        RenderGraph();
+    }
+
+    private void SelectProjectedNode(CanvasDependencyNode node, KeyModifiers modifiers)
+    {
+        UpdateSelection(node.EntityId, modifiers);
+        if (_viewModel is null)
+        {
+            return;
+        }
+        if (node.NodeType == "version")
+        {
+            var version = _viewModel.Versions.FirstOrDefault(value => value.VersionId == node.EntityId);
+            if (version is not null)
+            {
+                _viewModel.SelectVersionNodeCommand.Execute(version);
+            }
+        }
+        else if (node.NodeType == "item")
+        {
+            var item = _viewModel.Versions.SelectMany(static version => version.Items)
+                .FirstOrDefault(value => value.ItemId == node.EntityId);
+            if (item is not null)
+            {
+                _viewModel.SelectItemNodeCommand.Execute(item);
+            }
+        }
+    }
+
+    private void SelectVersion(WorkspaceVersionCard version, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        UpdateSelection(version.VersionId, modifiers);
+        _viewModel?.SelectVersionNodeCommand.Execute(version);
+    }
+
+    private void SelectItem(WorkspaceItemCard item, KeyModifiers modifiers)
+    {
+        UpdateSelection(item.ItemId, modifiers);
+        _viewModel?.SelectItemNodeCommand.Execute(item);
+    }
+
+    private void UpdateSelection(Guid id, KeyModifiers modifiers)
+    {
+        var additive = modifiers.HasFlag(KeyModifiers.Control) || modifiers.HasFlag(KeyModifiers.Shift);
+        if (additive)
+        {
+            if (!_selectedNodeIds.Add(id))
+            {
+                _selectedNodeIds.Remove(id);
+            }
+        }
+        else
+        {
+            _selectedNodeIds.Clear();
+            _selectedNodeIds.Add(id);
+        }
+        UpdateSelectionVisuals();
+        SelectionStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void UpdateSelectionVisuals()
+    {
+        foreach (var (identity, control) in _nodes)
+        {
+            if (control is not Border border)
+            {
+                continue;
+            }
+            var selected = _selectedNodeIds.Contains(identity.Id) ||
+                identity.Type == "version" && _viewModel?.SelectedVersion?.VersionId == identity.Id ||
+                identity.Type == "item" && _viewModel?.SelectedItem?.ItemId == identity.Id;
+            border.BorderThickness = new Thickness(selected ? 2.5 : 1);
+            border.BorderBrush = selected
+                ? ResourceBrush("CanvasSelectionBrush", "#6254D9")
+                : identity.Type == "version"
+                    ? ResourceBrush("CanvasFrameBorderBrush", "#D6D8E2")
+                    : IsBlocked(identity.Id)
+                        ? ResourceBrush("CanvasWarningBrush", "#C64D42")
+                        : ResourceBrush("CanvasCardBorderBrush", "#D8DAE4");
+        }
+    }
+
+    private void AddFreeNodeDrag(Control node, (string Type, Guid Id) identity)
+    {
+        node.PointerPressed += (_, eventArgs) =>
+        {
+            if (eventArgs.Handled)
+            {
+                return;
+            }
+            BeginNodeDrag(node, identity, eventArgs);
+        };
+        AddNodeDragContinuation(node);
+    }
+
+    private void BeginNodeDrag(Control node, (string Type, Guid Id) identity, PointerPressedEventArgs eventArgs)
+    {
+        if (_viewModel?.CanMutateWorkspace != true ||
+            !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        _draggedNode = node;
+        _draggedIdentity = identity;
+        _dragStartPointer = eventArgs.GetPosition(Surface);
+        _dragStartPosition = _positions.GetValueOrDefault(identity.Id);
+        _dragStartLayout = CaptureLayout();
+        eventArgs.Pointer.Capture(node);
+        eventArgs.Handled = true;
+    }
+
+    private void AddNodeDragContinuation(Control node)
+    {
+        node.PointerMoved += (_, eventArgs) =>
+        {
+            if (_draggedNode != node || _draggedIdentity is null ||
+                !eventArgs.GetCurrentPoint(node).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+            var delta = eventArgs.GetPosition(Surface) - _dragStartPointer;
+            var position = new Point(
+                Math.Max(0, _dragStartPosition.X + delta.X),
+                Math.Max(0, _dragStartPosition.Y + delta.Y));
+            _positions[_draggedIdentity.Value.Id] = position;
+            Place(node, position);
+        };
+        node.PointerReleased += (_, eventArgs) =>
+        {
+            if (_draggedNode != node)
+            {
+                return;
+            }
+            _draggedNode = null;
+            _draggedIdentity = null;
+            eventArgs.Pointer.Capture(null);
+            RenderGraph();
+            if (_dragStartLayout is not null && _layoutHistory.Record(_dragStartLayout, CaptureLayout()))
+            {
+                PersistLayout();
+                HistoryStateChanged?.Invoke(this, EventArgs.Empty);
+            }
+            _dragStartLayout = null;
+        };
+    }
+
+    private void AddResizeHandlers(Control handle, Control frame, Guid versionId)
+    {
+        Point start = default;
+        Size size = default;
+        var resizing = false;
+        handle.PointerPressed += (_, eventArgs) =>
+        {
+            if (_viewModel?.CanMutateWorkspace != true)
+            {
+                return;
+            }
+            resizing = true;
+            start = eventArgs.GetPosition(Surface);
+            size = new Size(frame.Width, frame.Height);
+            eventArgs.Pointer.Capture(handle);
+            eventArgs.Handled = true;
+        };
+        handle.PointerMoved += (_, eventArgs) =>
+        {
+            if (!resizing)
+            {
+                return;
+            }
+            var delta = eventArgs.GetPosition(Surface) - start;
+            frame.Width = Math.Clamp(size.Width + delta.X, FrameWidth, 1800);
+            frame.Height = Math.Clamp(size.Height + delta.Y, 360, 2400);
+        };
+        handle.PointerReleased += (_, eventArgs) =>
+        {
+            if (!resizing)
+            {
+                return;
+            }
+            resizing = false;
+            _frameSizes[versionId] = new Size(frame.Width, frame.Height);
+            eventArgs.Pointer.Capture(null);
+            RenderGraph();
+            eventArgs.Handled = true;
+        };
+    }
+
+    private void HandleSurfacePointerPressed(object? sender, PointerPressedEventArgs eventArgs)
+    {
+        Focus();
+        var properties = eventArgs.GetCurrentPoint(Surface).Properties;
+        if (properties.IsMiddleButtonPressed)
+        {
+            _isPanning = true;
+            _panStart = eventArgs.GetPosition(Viewport);
+            _panOrigin = Viewport.Offset;
+            eventArgs.Pointer.Capture(Surface);
+            return;
+        }
+        if (!properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        _isBoxSelecting = true;
+        _boxStart = eventArgs.GetPosition(Surface);
+        if (!eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control) &&
+            !eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            _selectedNodeIds.Clear();
+        }
+        _boxVisual = new Rectangle
+        {
+            Fill = ResourceBrush("CanvasSelectionFillBrush", "#226254D9"),
+            Stroke = ResourceBrush("CanvasSelectionBrush", "#6254D9"),
+            StrokeThickness = 1.5,
+            IsHitTestVisible = false,
+        };
+        Place(_boxVisual, _boxStart);
+        Surface.Children.Add(_boxVisual);
+        eventArgs.Pointer.Capture(Surface);
+    }
+
+    private void HandleSurfacePointerMoved(object? sender, PointerEventArgs eventArgs)
+    {
+        if (_isPanning)
+        {
+            var delta = eventArgs.GetPosition(Viewport) - _panStart;
+            Viewport.Offset = new Vector(
+                Math.Max(0, _panOrigin.X - delta.X),
+                Math.Max(0, _panOrigin.Y - delta.Y));
+            return;
+        }
+        if (!_isBoxSelecting || _boxVisual is null)
+        {
+            return;
+        }
+        var point = eventArgs.GetPosition(Surface);
+        var selection = new Rect(
+            Math.Min(_boxStart.X, point.X),
+            Math.Min(_boxStart.Y, point.Y),
+            Math.Abs(point.X - _boxStart.X),
+            Math.Abs(point.Y - _boxStart.Y));
+        Place(_boxVisual, selection.Position);
+        _boxVisual.Width = selection.Width;
+        _boxVisual.Height = selection.Height;
+        foreach (var pair in _nodeBounds.Where(pair => pair.Value.Intersects(selection)))
+        {
+            _selectedNodeIds.Add(pair.Key.Id);
+        }
+        SelectionStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void HandleSurfacePointerReleased(object? sender, PointerReleasedEventArgs eventArgs)
+    {
+        if (_isPanning)
+        {
+            _isPanning = false;
+            PersistViewState();
+        }
+        if (_isBoxSelecting)
+        {
+            _isBoxSelecting = false;
+            if (_boxVisual is not null)
+            {
+                Surface.Children.Remove(_boxVisual);
+                _boxVisual = null;
+            }
+            RenderGraph();
+        }
+        eventArgs.Pointer.Capture(null);
+    }
+
+    private void HandlePointerWheel(object? sender, PointerWheelEventArgs eventArgs)
+    {
+        if (!eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            return;
+        }
+        var pointer = eventArgs.GetPosition(Viewport);
+        var content = new Point(
+            (Viewport.Offset.X + pointer.X) / _zoom,
+            (Viewport.Offset.Y + pointer.Y) / _zoom);
+        SetZoom(_zoom + Math.Sign(eventArgs.Delta.Y) * .1);
+        Viewport.Offset = new Vector(
+            Math.Max(0, content.X * _zoom - pointer.X),
+            Math.Max(0, content.Y * _zoom - pointer.Y));
+        PersistViewState();
+        eventArgs.Handled = true;
+    }
+
+    private void HandleKeyDown(object? sender, KeyEventArgs eventArgs)
+    {
+        var command = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control) ||
+            eventArgs.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (command && eventArgs.Key == Key.S) SaveLayout();
+        else if (command && eventArgs.Key == Key.Z && eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift)) RedoLayout();
+        else if (command && eventArgs.Key == Key.Z) UndoLayout();
+        else if (command && eventArgs.Key == Key.Y) RedoLayout();
+        else if (command && eventArgs.Key == Key.D0) FitView();
+        else if (command && eventArgs.Key is Key.Add or Key.OemPlus) ZoomIn();
+        else if (command && eventArgs.Key is Key.Subtract or Key.OemMinus) ZoomOut();
+        else if (command && eventArgs.Key == Key.F) SearchRequested?.Invoke(this, EventArgs.Empty);
+        else if (command && eventArgs.Key == Key.L) ToggleConnectMode();
+        else if (command && eventArgs.Key == Key.J) ZoomToSelection();
+        else if (command && eventArgs.Key == Key.V &&
+                 eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            _viewModel?.CreateVersionCommand.Execute(null);
+        else if (command && eventArgs.Key == Key.I &&
+                 eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            _viewModel?.BeginNewItemCommand.Execute(null);
+        else if (command && eventArgs.Key == Key.D7) SetViewMode(CanvasViewMode.Plan);
+        else if (command && eventArgs.Key == Key.D8) SetViewMode(CanvasViewMode.Dependencies);
+        else if (command && eventArgs.Key == Key.D9) SetViewMode(CanvasViewMode.ReleaseNotes);
+        else if (eventArgs.Key == Key.Enter && _selectedNodeIds.Count > 0) OpenSelectedInspector();
+        else if (eventArgs.Key == Key.Escape)
+        {
+            _connectMode = false;
+            _connectionSource = null;
+            _selectedNodeIds.Clear();
+            RenderGraph();
+        }
+        else if (!command && eventArgs.Key is Key.Left or Key.Right or Key.Up or Key.Down)
+        {
+            MoveSelected(eventArgs.Key, eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift) ? 10 : 1);
+        }
+        else return;
+        eventArgs.Handled = true;
+    }
+
+    public event EventHandler? SearchRequested;
+
+    private void OpenSelectedInspector()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+        var selected = _selectedNodeIds.FirstOrDefault();
+        var node = _nodes.Keys.FirstOrDefault(key => key.Id == selected);
+        if (node.Id != Guid.Empty)
+        {
+            var projected = _viewModel.Versions
+                .SelectMany(version => version.Items.Select(item => (version, item)))
+                .FirstOrDefault(pair => pair.item.ItemId == node.Id);
+            if (projected.item is not null)
+            {
+                SelectItem(projected.item, KeyModifiers.None);
+            }
+        }
+    }
+
+    private void MoveSelected(Key key, double amount)
+    {
+        if (_viewModel?.CanMutateWorkspace != true || _selectedNodeIds.Count == 0)
+        {
+            return;
+        }
+        if (_viewMode == CanvasViewMode.Plan && (key is Key.Left or Key.Right))
+        {
+            var selectedItems = _viewModel.Versions
+                .SelectMany(version => version.Items.Select(item => (version, item)))
+                .Where(pair => _selectedNodeIds.Contains(pair.item.ItemId))
+                .ToArray();
+            foreach (var (version, item) in selectedItems)
+            {
+                var offset = key == Key.Left ? -1 : 1;
+                var next = (WorkItemLifecycle)Math.Clamp(
+                    (int)item.WorkflowState + offset,
+                    (int)WorkItemLifecycle.Planned,
+                    (int)WorkItemLifecycle.Complete);
+                if (next != item.WorkflowState)
+                {
+                    _viewModel.ChangeItemLifecycleCommand.Execute(
+                        new WorkItemLifecycleChangeRequest(version.VersionId, item.ItemId, next));
+                }
+            }
+            return;
+        }
+        var previous = CaptureLayout();
+        var delta = key switch
+        {
+            Key.Left => new Vector(-amount, 0),
+            Key.Right => new Vector(amount, 0),
+            Key.Up => new Vector(0, -amount),
+            _ => new Vector(0, amount),
+        };
+        foreach (var id in _selectedNodeIds)
+        {
+            if (_positions.TryGetValue(id, out var point))
+            {
+                _positions[id] = new Point(Math.Max(0, point.X + delta.X), Math.Max(0, point.Y + delta.Y));
+            }
+        }
+        RenderGraph();
+        if (_layoutHistory.Record(previous, CaptureLayout()))
+        {
+            PersistLayout();
+            HistoryStateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private void HandleMiniMapPointerPressed(object? sender, PointerPressedEventArgs eventArgs)
+    {
+        if (!eventArgs.GetCurrentPoint(MiniMapSurface).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        var point = eventArgs.GetPosition(MiniMapSurface);
+        Viewport.Offset = new Vector(
+            Math.Max(0, point.X / MiniMapSurface.Width * Surface.Width * _zoom - Viewport.Viewport.Width / 2),
+            Math.Max(0, point.Y / MiniMapSurface.Height * Surface.Height * _zoom - Viewport.Viewport.Height / 2));
+        PersistViewState();
+    }
+
+    private void RenderMiniMap()
+    {
+        if (MiniMapSurface is null)
+        {
+            return;
+        }
+        MiniMapPanel.IsVisible = _minimapVisible;
+        MiniMapSurface.Children.Clear();
+        var scale = Math.Min(MiniMapSurface.Width / Surface.Width, MiniMapSurface.Height / Surface.Height);
+        var minimapNodes = CanvasMiniMapProjectionService.Project(
+            _nodeBounds.Select(pair => new CanvasNodeBounds(
+                pair.Key.Id,
+                pair.Value.X,
+                pair.Value.Y,
+                pair.Value.Width,
+                pair.Value.Height)).ToArray(),
+            _selectedNodeIds,
+            Surface.Width,
+            Surface.Height,
+            MiniMapSurface.Width,
+            MiniMapSurface.Height);
+        var versionIds = _nodeBounds.Keys
+            .Where(static key => key.Type == "version")
+            .Select(static key => key.Id)
+            .ToHashSet();
+        foreach (var node in minimapNodes)
+        {
+            var preview = new Rectangle
+            {
+                Width = node.Width,
+                Height = node.Height,
+                Fill = node.IsSelected
+                    ? ResourceBrush("CanvasMinimapSelectionBrush", "#F1C96A")
+                    : versionIds.Contains(node.EntityId)
+                        ? ResourceBrush("CanvasMinimapFrameBrush", "#8D83DF")
+                        : ResourceBrush("CanvasMinimapNodeBrush", "#56AFA2"),
+                IsHitTestVisible = false,
+            };
+            Place(preview, new Point(node.X, node.Y));
+            MiniMapSurface.Children.Add(preview);
+        }
+        var viewport = new Rectangle
+        {
+            Width = Math.Clamp(Viewport.Viewport.Width / _zoom * scale, 2, MiniMapSurface.Width),
+            Height = Math.Clamp(Viewport.Viewport.Height / _zoom * scale, 2, MiniMapSurface.Height),
+            Stroke = ResourceBrush("CanvasSelectionBrush", "#6254D9"),
+            StrokeThickness = 1.5,
+            Fill = ResourceBrush("CanvasViewportFillBrush", "#166254D9"),
+            IsHitTestVisible = false,
+        };
+        Place(viewport, new Point(
+            Math.Clamp(Viewport.Offset.X / _zoom * scale, 0, Math.Max(0, MiniMapSurface.Width - viewport.Width)),
+            Math.Clamp(Viewport.Offset.Y / _zoom * scale, 0, Math.Max(0, MiniMapSurface.Height - viewport.Height))));
+        MiniMapSurface.Children.Add(viewport);
     }
 
     private void RestoreLayout()
     {
-        _viewportSaveTimer.Stop();
-        _isRestoringLayout = true;
-        if (_viewModel?.CanvasLayout is not { } layout)
-        {
-            _positions.Clear();
-            Dispatcher.UIThread.Post(
-                () => _isRestoringLayout = false,
-                DispatcherPriority.Loaded);
-            return;
-        }
-
         _positions.Clear();
-        foreach (var node in layout.Nodes)
+        foreach (var node in _viewModel?.CanvasLayout?.Nodes ?? [])
         {
             _positions[node.EntityId] = new Point(node.X, node.Y);
         }
-
-        Dispatcher.UIThread.Post(
-            () => _isRestoringLayout = false,
-            DispatcherPriority.Loaded);
     }
 
     private void RestoreViewState()
@@ -822,395 +1492,61 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             return;
         }
-
-        _viewportSaveTimer.Stop();
-        _isRestoringLayout = true;
-        SetZoom(_viewModel.CanvasViewState.Zoom);
-        Dispatcher.UIThread.Post(
-            () =>
-            {
-                Viewport.Offset = new Vector(
-                    _viewModel.CanvasViewState.HorizontalOffset,
-                    _viewModel.CanvasViewState.VerticalOffset);
-                _isRestoringLayout = false;
-            },
-            DispatcherPriority.Loaded);
+        var state = _viewModel.CanvasViewState;
+        _isRestoring = true;
+        _viewMode = state.ViewMode;
+        _searchText = state.SearchText;
+        _lifecycleFilter = state.LifecycleFilter;
+        _versionFilter = state.VersionFilter;
+        _itemTypeFilter = state.ItemTypeFilter;
+        _categoryFilter = state.CategoryFilter;
+        _warningsOnly = state.WarningsOnly;
+        _minimapVisible = state.MinimapVisible;
+        _collapsedVersionIds.Clear();
+        _collapsedVersionIds.UnionWith(state.ParseCollapsedVersionIds());
+        SetZoom(state.Zoom);
+        Dispatcher.UIThread.Post(() =>
+        {
+            Viewport.Offset = new Vector(state.HorizontalOffset, state.VerticalOffset);
+            _isRestoring = false;
+        }, DispatcherPriority.Loaded);
     }
 
-    private void HandleViewportScrollChanged(object? sender, ScrollChangedEventArgs eventArgs)
+    private void PersistViewState()
     {
-        RenderMiniMap();
-        if (_isRestoringLayout || _viewModel is null)
+        if (_isRestoring || _viewModel is null)
         {
             return;
         }
-
-        _viewportSaveTimer.Stop();
-        _viewportSaveTimer.Start();
-    }
-
-    private void HandleViewportSaveTimerTick(object? sender, EventArgs eventArgs)
-    {
-        _viewportSaveTimer.Stop();
-        PersistViewState();
-    }
-
-    private void HandleSurfacePointerPressed(object? sender, PointerPressedEventArgs eventArgs)
-    {
-        var properties = eventArgs.GetCurrentPoint(Surface).Properties;
-        Focus();
-        if (properties.IsMiddleButtonPressed)
-        {
-            _isPanning = true;
-            _panStart = eventArgs.GetPosition(Viewport);
-            _panOrigin = Viewport.Offset;
-            Surface.Cursor = new Cursor(StandardCursorType.SizeAll);
-            eventArgs.Pointer.Capture(Surface);
-            eventArgs.Handled = true;
-            return;
-        }
-
-        if (!properties.IsLeftButtonPressed)
-        {
-            return;
-        }
-
-        var additive = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control)
-            || eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift);
-        _selectionBeforeBox = additive
-            ? _selectedNodeIds.ToHashSet()
-            : new HashSet<Guid>();
-        if (!additive)
-        {
-            _selectedNodeIds.Clear();
-        }
-
-        _isBoxSelecting = true;
-        _boxSelectionStart = eventArgs.GetPosition(Surface);
-        _boxSelectionVisual = new Rectangle
-        {
-            Fill = Brush.Parse("#336B5CE7"),
-            Stroke = Brush.Parse("#A9A2EC"),
-            StrokeThickness = 1.5,
-            IsHitTestVisible = false,
-        };
-        Place(_boxSelectionVisual, _boxSelectionStart);
-        Surface.Children.Add(_boxSelectionVisual);
-        eventArgs.Pointer.Capture(Surface);
-        UpdateSelectionVisuals();
-        NotifySelectionStateChanged();
-        eventArgs.Handled = true;
-    }
-
-    private void HandleSurfacePointerMoved(object? sender, PointerEventArgs eventArgs)
-    {
-        if (_isPanning)
-        {
-            var current = eventArgs.GetPosition(Viewport);
-            var delta = current - _panStart;
-            Viewport.Offset = new Vector(
-                Math.Max(0, _panOrigin.X - delta.X),
-                Math.Max(0, _panOrigin.Y - delta.Y));
-            eventArgs.Handled = true;
-            return;
-        }
-
-        if (!_isBoxSelecting || _boxSelectionVisual is null)
-        {
-            return;
-        }
-
-        var currentSelectionPoint = eventArgs.GetPosition(Surface);
-        var selection = new CanvasSelectionBounds(
-            _boxSelectionStart.X,
-            _boxSelectionStart.Y,
-            currentSelectionPoint.X,
-            currentSelectionPoint.Y);
-        Canvas.SetLeft(_boxSelectionVisual, selection.Left);
-        Canvas.SetTop(_boxSelectionVisual, selection.Top);
-        _boxSelectionVisual.Width = selection.Right - selection.Left;
-        _boxSelectionVisual.Height = selection.Bottom - selection.Top;
-
-        _selectedNodeIds.Clear();
-        _selectedNodeIds.UnionWith(_selectionBeforeBox);
-        _selectedNodeIds.UnionWith(
-            CanvasSelectionService.SelectIntersecting(GetNodeBounds(), selection));
-        UpdateSelectionVisuals();
-        NotifySelectionStateChanged();
-        eventArgs.Handled = true;
-    }
-
-    private void HandleSurfacePointerReleased(object? sender, PointerReleasedEventArgs eventArgs)
-    {
-        if (_isPanning)
-        {
-            _isPanning = false;
-            Surface.Cursor = Cursor.Default;
-            eventArgs.Pointer.Capture(null);
-            PersistViewState();
-            eventArgs.Handled = true;
-            return;
-        }
-
-        if (!_isBoxSelecting)
-        {
-            return;
-        }
-
-        _isBoxSelecting = false;
-        if (_boxSelectionVisual is not null)
-        {
-            Surface.Children.Remove(_boxSelectionVisual);
-            _boxSelectionVisual = null;
-        }
-
-        eventArgs.Pointer.Capture(null);
-        _selectionBeforeBox = new HashSet<Guid>();
-        eventArgs.Handled = true;
-    }
-
-    private void HandleSurfacePointerWheelChanged(object? sender, PointerWheelEventArgs eventArgs)
-    {
-        if (!eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control))
-        {
-            return;
-        }
-
-        var pointer = eventArgs.GetPosition(Viewport);
-        var contentX = (Viewport.Offset.X + pointer.X) / _zoom;
-        var contentY = (Viewport.Offset.Y + pointer.Y) / _zoom;
-        SetZoom(_zoom + Math.Sign(eventArgs.Delta.Y) * 0.1);
-        Viewport.Offset = new Vector(
-            Math.Max(0, contentX * _zoom - pointer.X),
-            Math.Max(0, contentY * _zoom - pointer.Y));
-        PersistViewState();
-        eventArgs.Handled = true;
-    }
-
-    private void HandleKeyDown(object? sender, KeyEventArgs eventArgs)
-    {
-        var control = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Control);
-        if (control && eventArgs.Key == Key.S)
-        {
-            SaveLayout();
-        }
-        else if (control
-                 && eventArgs.Key == Key.Z
-                 && eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
-        {
-            RedoLayout();
-        }
-        else if (control && eventArgs.Key == Key.Z)
-        {
-            UndoLayout();
-        }
-        else if (control && eventArgs.Key == Key.Y)
-        {
-            RedoLayout();
-        }
-        else if (control && eventArgs.Key == Key.D0)
-        {
-            FitView();
-        }
-        else if (control && eventArgs.Key is Key.Add or Key.OemPlus)
-        {
-            ZoomIn();
-        }
-        else if (control && eventArgs.Key is Key.Subtract or Key.OemMinus)
-        {
-            ZoomOut();
-        }
-        else if (control && eventArgs.Key == Key.A)
-        {
-            _selectedNodeIds.Clear();
-            _selectedNodeIds.UnionWith(_nodes.Keys);
-            UpdateSelectionVisuals();
-            NotifySelectionStateChanged();
-        }
-        else if (!control && eventArgs.Key is Key.Left or Key.Right or Key.Up or Key.Down)
-        {
-            var distance = eventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift) ? 10 : 1;
-            var delta = eventArgs.Key switch
-            {
-                Key.Left => new Vector(-distance, 0),
-                Key.Right => new Vector(distance, 0),
-                Key.Up => new Vector(0, -distance),
-                _ => new Vector(0, distance),
-            };
-            MoveSelectedNodes(delta);
-        }
-        else if (eventArgs.Key == Key.Escape)
-        {
-            _selectedNodeIds.Clear();
-            UpdateSelectionVisuals();
-            NotifySelectionStateChanged();
-        }
-        else
-        {
-            return;
-        }
-
-        eventArgs.Handled = true;
-    }
-
-    private void MoveSelectedNodes(Vector requestedDelta)
-    {
-        if (_viewModel?.CanMutateWorkspace != true || _selectedNodeIds.Count == 0)
-        {
-            return;
-        }
-
-        var previous = CaptureLayout();
-        var origins = _selectedNodeIds
-            .Where(id => _nodes.ContainsKey(id) && _positions.ContainsKey(id))
-            .ToDictionary(id => id, id => _positions[id]);
-        var selectedBounds = GetNodeBounds(origins);
-        var constrained = CanvasSelectionService.ConstrainMove(
-            selectedBounds,
-            requestedDelta.X,
-            requestedDelta.Y,
-            Surface.Width,
-            Surface.Height);
-        MoveNodesFromOrigins(origins, constrained.DeltaX, constrained.DeltaY);
-        if (_layoutHistory.Record(previous, CaptureLayout()))
-        {
-            NotifyHistoryStateChanged();
-            PersistLayout();
-        }
-    }
-
-    private void RenderAlignmentGuides()
-    {
-        ClearAlignmentGuides();
-        var allBounds = GetNodeBounds();
-        var moving = allBounds
-            .Where(node => _selectedNodeIds.Contains(node.EntityId))
-            .ToArray();
-        var stationary = allBounds
-            .Where(node => !_selectedNodeIds.Contains(node.EntityId))
-            .ToArray();
-        var guides = CanvasSelectionService.FindAlignmentGuides(moving, stationary);
-        foreach (var x in guides.Vertical)
-        {
-            AddAlignmentGuide(new Point(x, 0), new Point(x, Surface.Height));
-        }
-
-        foreach (var y in guides.Horizontal)
-        {
-            AddAlignmentGuide(new Point(0, y), new Point(Surface.Width, y));
-        }
-    }
-
-    private void AddAlignmentGuide(Point start, Point end)
-    {
-        var line = new Line
-        {
-            StartPoint = start,
-            EndPoint = end,
-            Stroke = Brush.Parse("#F1C96A"),
-            StrokeThickness = 1,
-            StrokeDashArray = [5, 4],
-            IsHitTestVisible = false,
-        };
-        _alignmentGuideVisuals.Add(line);
-        Surface.Children.Add(line);
-    }
-
-    private void ClearAlignmentGuides()
-    {
-        foreach (var line in _alignmentGuideVisuals)
-        {
-            Surface.Children.Remove(line);
-        }
-
-        _alignmentGuideVisuals.Clear();
-    }
-
-    private void RenderMiniMap()
-    {
-        if (MiniMapSurface is null || Surface is null)
-        {
-            return;
-        }
-
-        MiniMapSurface.Children.Clear();
-        if (Surface.Width <= 0 || Surface.Height <= 0)
-        {
-            return;
-        }
-
-        var scale = Math.Min(MiniMapSurface.Width / Surface.Width, MiniMapSurface.Height / Surface.Height);
-        foreach (var (id, node) in _nodes)
-        {
-            if (!_positions.TryGetValue(id, out var point))
-            {
-                continue;
-            }
-
-            var tag = node.Tag as NodeTag;
-            var preview = new Rectangle
-            {
-                Width = Math.Max(3, node.Width * scale),
-                Height = Math.Max(2, node.Height * scale),
-                Fill = Brush.Parse(
-                    _selectedNodeIds.Contains(id)
-                        ? "#F1C96A"
-                        : tag?.Type switch
-                        {
-                            "project" => "#B8B2F4",
-                            "version" => "#9187E8",
-                            _ => "#55C8B5",
-                        }),
-                IsHitTestVisible = false,
-            };
-            Place(preview, new Point(point.X * scale, point.Y * scale));
-            MiniMapSurface.Children.Add(preview);
-        }
-
-        var viewport = new Rectangle
-        {
-            Width = Math.Clamp(Viewport.Viewport.Width / _zoom * scale, 2, MiniMapSurface.Width),
-            Height = Math.Clamp(Viewport.Viewport.Height / _zoom * scale, 2, MiniMapSurface.Height),
-            Stroke = Brushes.White,
-            StrokeThickness = 1,
-            Fill = Brush.Parse("#16FFFFFF"),
-            IsHitTestVisible = false,
-        };
-        Place(
-            viewport,
-            new Point(
-                Math.Clamp(Viewport.Offset.X / _zoom * scale, 0, MiniMapSurface.Width - viewport.Width),
-                Math.Clamp(Viewport.Offset.Y / _zoom * scale, 0, MiniMapSurface.Height - viewport.Height)));
-        MiniMapSurface.Children.Add(viewport);
+        _viewModel.SaveCanvasViewStateCommand.Execute(new CanvasViewState(
+            _zoom,
+            Math.Max(0, Viewport.Offset.X),
+            Math.Max(0, Viewport.Offset.Y),
+            _viewMode,
+            _searchText,
+            _lifecycleFilter,
+            _versionFilter,
+            _minimapVisible,
+            string.Join(',', _collapsedVersionIds.Order()),
+            _itemTypeFilter,
+            _categoryFilter,
+            _warningsOnly));
     }
 
     private void PersistLayout()
     {
-        if (_isRestoringLayout || _viewModel?.CanMutateWorkspace != true)
+        if (_isRestoring || _viewModel?.CanMutateWorkspace != true)
         {
             return;
         }
-
-        var nodes = new List<CanvasNodeLayoutEdit>();
-        AddLayoutNode(nodes, "project", _viewModel.CurrentProject.ProjectId);
-        foreach (var version in _viewModel.Versions)
-        {
-            AddLayoutNode(nodes, "version", version.VersionId);
-            foreach (var item in version.Items)
-            {
-                AddLayoutNode(nodes, "item", item.ItemId);
-            }
-        }
-
-        _isPersistingLayout = true;
+        _isPersisting = true;
         try
         {
-            _viewModel.SaveCanvasLayoutCommand.Execute(
-                new CanvasLayoutEditRequest(nodes));
+            _viewModel.SaveCanvasLayoutCommand.Execute(new CanvasLayoutEditRequest(CaptureLayout()));
         }
         finally
         {
-            _isPersistingLayout = false;
+            _isPersisting = false;
         }
     }
 
@@ -1220,19 +1556,32 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             return [];
         }
-
-        var nodes = new List<CanvasNodeLayoutEdit>();
-        AddLayoutNode(nodes, "project", _viewModel.CurrentProject.ProjectId);
+        var result = new List<CanvasNodeLayoutEdit>();
+        if (_viewModel.CurrentProject.ProjectId != Guid.Empty)
+        {
+            AddLayout(result, "project", _viewModel.CurrentProject.ProjectId);
+        }
         foreach (var version in _viewModel.Versions)
         {
-            AddLayoutNode(nodes, "version", version.VersionId);
+            AddLayout(result, "version", version.VersionId);
             foreach (var item in version.Items)
             {
-                AddLayoutNode(nodes, "item", item.ItemId);
+                AddLayout(result, "item", item.ItemId);
             }
         }
+        return result;
+    }
 
-        return nodes;
+    private void AddLayout(ICollection<CanvasNodeLayoutEdit> result, string type, Guid id)
+    {
+        if (!_positions.TryGetValue(id, out var position))
+        {
+            position = type == "version"
+                ? new Point(70, 70 + result.Count * 80)
+                : DependencyPosition(result.Count);
+            _positions[id] = position;
+        }
+        result.Add(new CanvasNodeLayoutEdit(type, id, position.X, position.Y));
     }
 
     private void ApplyLayout(IReadOnlyList<CanvasNodeLayoutEdit> layout)
@@ -1242,97 +1591,172 @@ public partial class BlueprintCanvasSurface : UserControl
         {
             _positions[node.EntityId] = new Point(node.X, node.Y);
         }
-
         RenderGraph();
-    }
-
-    private void ClearLayoutHistory()
-    {
-        _layoutHistory.Clear();
-        NotifyHistoryStateChanged();
-    }
-
-    private void NotifyHistoryStateChanged() =>
         HistoryStateChanged?.Invoke(this, EventArgs.Empty);
-
-    private void NotifySelectionStateChanged() =>
-        SelectionStateChanged?.Invoke(this, EventArgs.Empty);
-
-    private void PersistViewState()
-    {
-        if (_isRestoringLayout || _viewModel is null)
-        {
-            return;
-        }
-
-        _viewModel.SaveCanvasViewStateCommand.Execute(
-            new CanvasViewState(
-                _zoom,
-                Math.Max(0, Viewport.Offset.X),
-                Math.Max(0, Viewport.Offset.Y)));
     }
 
-    private void AddLayoutNode(
-        ICollection<CanvasNodeLayoutEdit> nodes,
-        string nodeType,
-        Guid entityId)
+    private void SetZoom(double value, bool persist = false)
     {
-        if (entityId == Guid.Empty || !_positions.TryGetValue(entityId, out var point))
-        {
-            return;
-        }
-
-        nodes.Add(new CanvasNodeLayoutEdit(nodeType, entityId, point.X, point.Y));
+        _zoom = Math.Clamp(value, .25, 2.5);
+        ZoomHost.Width = Surface.Width * _zoom;
+        ZoomHost.Height = Surface.Height * _zoom;
+        Surface.RenderTransform = new ScaleTransform(_zoom, _zoom);
+        Surface.RenderTransformOrigin = RelativePoint.TopLeft;
+        RenderMiniMap();
+        ZoomChanged?.Invoke(this, EventArgs.Empty);
+        if (persist) PersistViewState();
     }
 
-    private void AddConnection(
-        Control source,
-        Control target,
-        string color,
-        double thickness,
-        double opacity = 0.85)
+    private void SizeSurface()
     {
-        _connections.Add(
-            new ConnectionVisual(
-                source,
-                target,
-                new Line
-                {
-                    Stroke = Brush.Parse(color),
-                    StrokeThickness = thickness,
-                    Opacity = opacity,
-                    IsHitTestVisible = false,
-                }));
+        var bounds = GetContentBounds();
+        Surface.Width = Math.Max(1400, bounds.Right + 120);
+        Surface.Height = Math.Max(900, bounds.Bottom + 120);
     }
 
-    private void UpdateConnections(Control node)
-    {
-        foreach (var connection in _connections.Where(connection => connection.Source == node || connection.Target == node))
-        {
-            UpdateConnection(connection);
-        }
-    }
+    private Rect GetContentBounds() =>
+        _nodeBounds.Count == 0
+            ? new Rect(0, 0, 1200, 760)
+            : Union(_nodeBounds.Values);
 
-    private static void UpdateConnection(ConnectionVisual connection)
+    private static Rect Union(IEnumerable<Rect> rectangles)
     {
-        connection.Line.StartPoint = new Point(
-            Canvas.GetLeft(connection.Source) + connection.Source.Bounds.Width,
-            Canvas.GetTop(connection.Source) + connection.Source.Bounds.Height / 2);
-        connection.Line.EndPoint = new Point(
-            Canvas.GetLeft(connection.Target),
-            Canvas.GetTop(connection.Target) + connection.Target.Bounds.Height / 2);
+        var values = rectangles.ToArray();
+        var left = values.Min(static rect => rect.Left);
+        var top = values.Min(static rect => rect.Top);
+        var right = values.Max(static rect => rect.Right);
+        var bottom = values.Max(static rect => rect.Bottom);
+        return new Rect(left, top, right - left, bottom - top);
     }
 
     private Point GetPosition(Guid id, Point fallback)
     {
-        if (_positions.TryGetValue(id, out var position))
+        if (_positions.TryGetValue(id, out var value))
         {
-            return position;
+            return value;
         }
-
         _positions[id] = fallback;
         return fallback;
     }
+
+    private bool IsSelected(Guid id) => _selectedNodeIds.Contains(id);
+
+    private bool IsBlocked(Guid id) =>
+        _viewModel?.RelationshipDocument is { } document &&
+        document.Relationships.Any(edge =>
+            edge.Target.EntityId == id &&
+            document.Types.Any(type =>
+                type.TypeId == edge.TypeId &&
+                (type.TypeId.Contains("block", StringComparison.OrdinalIgnoreCase) ||
+                 type.Name.Contains("block", StringComparison.OrdinalIgnoreCase))));
+
+    private int GridVisualCount() =>
+        Surface.Children.TakeWhile(child => child.Tag as string == "grid").Count();
+
+    private static Point DependencyPosition(int index) =>
+        new(80 + index % 4 * 310, 80 + index / 4 * 170);
+
+    private static Point Anchor(Rect source, Point toward)
+    {
+        var dx = toward.X - source.Center.X;
+        var dy = toward.Y - source.Center.Y;
+        if (Math.Abs(dx) * source.Height > Math.Abs(dy) * source.Width)
+        {
+            return new Point(dx > 0 ? source.Right : source.Left, source.Center.Y);
+        }
+        return new Point(source.Center.X, dy > 0 ? source.Bottom : source.Top);
+    }
+
+    private static Polygon CreateArrow(Point start, Point end, string color, double opacity)
+    {
+        var direction = start - end;
+        var length = Math.Max(1, Math.Sqrt(direction.X * direction.X + direction.Y * direction.Y));
+        var unit = new Vector(direction.X / length, direction.Y / length);
+        var normal = new Vector(-unit.Y, unit.X);
+        return new Polygon
+        {
+            Points =
+            [
+                end,
+                end + unit * 14 + normal * 7,
+                end + unit * 14 - normal * 7,
+            ],
+            Fill = Brush.Parse(color),
+            Opacity = opacity,
+            IsHitTestVisible = false,
+        };
+    }
+
+    private static Line GridLine(Point start, Point end, bool major) =>
+        new()
+        {
+            StartPoint = start,
+            EndPoint = end,
+            Stroke = Brush.Parse(major ? "#DFDFE8" : "#ECECF2"),
+            StrokeThickness = major ? 1 : .5,
+            IsHitTestVisible = false,
+            Tag = "grid",
+        };
+
+    private static Border Badge(string value, string background, string foreground) =>
+        new()
+        {
+            Background = Brush.Parse(background),
+            CornerRadius = new CornerRadius(5),
+            Padding = new Thickness(7, 3),
+            Child = Text(value, 9, FontWeight.SemiBold, Brush.Parse(foreground)),
+        };
+
+    private static Button SmallButton(string text, string tooltip)
+    {
+        var button = new Button
+        {
+            Content = text,
+            Padding = new Thickness(9, 5),
+            MinHeight = 28,
+            FontSize = 10,
+        };
+        ToolTip.SetTip(button, tooltip);
+        AutomationProperties.SetName(button, tooltip);
+        return button;
+    }
+
+    private static TextBlock Text(
+        string value,
+        double size,
+        FontWeight weight,
+        IBrush? foreground = null) =>
+        new()
+        {
+            Text = value,
+            FontSize = size,
+            FontWeight = weight,
+            Foreground = foreground,
+        };
+
+    private IBrush ResourceBrush(string key, string fallback) =>
+        this.TryFindResource(key, ActualThemeVariant, out var value) && value is IBrush brush
+            ? brush
+            : Brush.Parse(fallback);
+
+    private IBrush LifecycleBrush(WorkItemLifecycle state) =>
+        Brush.Parse(LifecycleColor(state));
+
+    private static string LifecycleColor(WorkItemLifecycle state) => state switch
+    {
+        WorkItemLifecycle.Planned => "#5E6270",
+        WorkItemLifecycle.InProgress => "#4C56B8",
+        WorkItemLifecycle.Review => "#8A5D15",
+        _ => "#25715F",
+    };
+
+    private static string LifecycleBackground(WorkItemLifecycle state) => state switch
+    {
+        WorkItemLifecycle.Planned => "#ECEEF2",
+        WorkItemLifecycle.InProgress => "#E8E9FA",
+        WorkItemLifecycle.Review => "#FAF0D9",
+        _ => "#E1F3ED",
+    };
 
     private static void Place(Control control, Point point)
     {
@@ -1340,11 +1764,5 @@ public partial class BlueprintCanvasSurface : UserControl
         Canvas.SetTop(control, point.Y);
     }
 
-    private sealed record ConnectionVisual(Control Source, Control Target, Line Line);
-
-    private sealed record CanvasItemGroup(
-        string Label,
-        IReadOnlyList<(WorkspaceVersionCard Version, WorkspaceItemCard Item)> Items);
-
-    private sealed record NodeTag(string Type, Guid? Id);
+    private sealed record NodeTag(string Type, Guid Id);
 }

--- a/Blueprints.App/Views/Components/OverviewView.axaml
+++ b/Blueprints.App/Views/Components/OverviewView.axaml
@@ -7,259 +7,356 @@
              xmlns:automation="using:Avalonia.Automation"
              x:Class="Blueprints.App.Views.Components.OverviewView"
              x:DataType="vm:MainWindowViewModel">
-  <Grid RowDefinitions="72,*">
-    <Border Background="#FFFFFF" BorderBrush="#E2E4EC" BorderThickness="0,0,0,1" Padding="16,12">
-      <Grid ColumnDefinitions="Auto,18,Auto,*,Auto" ColumnSpacing="8">
-        <StackPanel Orientation="Horizontal" Spacing="7">
-          <Button Classes="tool active" Content="Select" ToolTip.Tip="Select and move blueprint cards" />
-          <TextBox Text="{Binding NewVersionName}"
-                   PlaceholderText="0.2.0"
-                   Width="86"
+  <Grid RowDefinitions="82,*">
+    <Border Background="{DynamicResource CanvasToolbarBrush}"
+            BorderBrush="{DynamicResource LineBrush}"
+            BorderThickness="0,0,0,1"
+            Padding="14,10">
+      <Grid RowDefinitions="Auto,Auto" RowSpacing="7">
+        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto" ColumnSpacing="10">
+          <StackPanel Orientation="Horizontal" Spacing="2">
+            <Button x:Name="PlanModeButton"
+                    Classes="tool active"
+                    Content="Plan"
+                    Click="PlanModeClick"
+                    ToolTip.Tip="Plan view: version frames and lifecycle columns (Ctrl/Command+7)" />
+            <Button x:Name="DependenciesModeButton"
+                    Classes="tool"
+                    Content="Dependencies"
+                    Click="DependenciesModeClick"
+                    ToolTip.Tip="Dependency graph (Ctrl/Command+8)" />
+            <Button x:Name="ReleaseNotesModeButton"
+                    Classes="tool"
+                    Content="Release Notes"
+                    Click="ReleaseNotesModeClick"
+                    ToolTip.Tip="Changelog-category projection (Ctrl/Command+9)" />
+            <Button Classes="tool"
+                    Content="Timeline"
+                    IsEnabled="False"
+                    ToolTip.Tip="Timeline requires a future target-date contract." />
+          </StackPanel>
+
+          <Border Grid.Column="1" Width="1" Background="{DynamicResource LineBrush}" Margin="2,2" />
+
+          <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="5">
+            <TextBox Text="{Binding NewVersionName}"
+                     PlaceholderText="Version"
+                     Width="86"
+                     MinHeight="32"
+                     Padding="8,4"
+                     IsEnabled="{Binding CanMutateWorkspace}"
+                     automation:AutomationProperties.Name="New version name" />
+            <Button Classes="tool" Content="+ Version" Command="{Binding CreateVersionCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+            <Button Classes="tool" Content="+ Work item" Command="{Binding BeginNewItemCommand}" IsEnabled="{Binding CanEditItems}" />
+            <Button x:Name="ConnectButton"
+                    Classes="tool"
+                    Content="Connect"
+                    Click="ConnectClick"
+                    IsEnabled="{Binding CanMutateWorkspace}"
+                    ToolTip.Tip="Connect two entities with a signed typed relationship (Ctrl/Command+L)" />
+          </StackPanel>
+
+          <TextBox x:Name="SearchBox"
+                   Grid.Column="3"
+                   HorizontalAlignment="Right"
+                   Width="230"
                    MinHeight="32"
-                   Padding="8,4"
-                   VerticalContentAlignment="Center"
-                   IsEnabled="{Binding CanMutateWorkspace}" />
-          <Button Classes="tool" Content="＋ Version" Command="{Binding CreateVersionCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
-          <Button Classes="tool" Content="＋ Work" Command="{Binding BeginNewItemCommand}" IsEnabled="{Binding CanEditItems}" />
-        </StackPanel>
+                   Padding="10,4"
+                   PlaceholderText="Search key, title, type…"
+                   TextChanged="SearchTextChanged"
+                   automation:AutomationProperties.Name="Search blueprint" />
 
-        <Border Grid.Column="1" Width="1" Background="#E2E4EC" Margin="8,0" />
+          <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="6">
+            <Border Classes="status-pill">
+              <TextBlock Text="{Binding TrustBadge}" FontSize="10" FontWeight="Bold" />
+            </Border>
+            <Border Classes="status-pill">
+              <TextBlock Text="{Binding SyncStatus}" FontSize="10" TextTrimming="CharacterEllipsis" MaxWidth="150" />
+            </Border>
+            <Border Classes="status-pill">
+              <TextBlock Text="{Binding ReleaseReadinessSummary}" FontSize="10" TextTrimming="CharacterEllipsis" MaxWidth="190" />
+            </Border>
+          </StackPanel>
+        </Grid>
 
-        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="7">
-          <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl+Z)" automation:AutomationProperties.Name="Undo layout change" />
-          <Button x:Name="RedoButton" Classes="tool square" Content="↷" Click="RedoClick" ToolTip.Tip="Redo layout change (Ctrl+Shift+Z or Ctrl+Y)" automation:AutomationProperties.Name="Redo layout change" />
-          <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" automation:AutomationProperties.Name="Zoom out" />
-          <Border Background="#F3F2F8" CornerRadius="8" Padding="8,5" MinWidth="52">
-            <TextBlock x:Name="ZoomLevelText"
-                       Text="100%"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       FontSize="11"
-                       FontWeight="Bold" />
-          </Border>
-          <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" automation:AutomationProperties.Name="Zoom in" />
-          <Button Classes="tool" Content="Fit" Click="FitViewClick" ToolTip.Tip="Fit the whole blueprint in view (Ctrl+0)" />
-          <ComboBox ItemsSource="{Binding CanvasGroupingOptions}"
-                    SelectedItem="{Binding CanvasGroupingSelection}"
-                    MinWidth="145"
-                    MinHeight="34"
-                    ToolTip.Tip="Choose how related work is grouped" />
-          <Button Classes="tool" Content="Organize" Click="AutoArrangeClick" IsEnabled="{Binding CanMutateWorkspace}" />
-          <Button Classes="tool" Content="Find work" Command="{Binding NavigateToIntegrationsCommand}" />
-        </StackPanel>
+        <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="10">
+          <StackPanel Orientation="Horizontal" Spacing="5">
+            <Button x:Name="UndoButton" Classes="tool square" Content="↶" Click="UndoClick" ToolTip.Tip="Undo layout change (Ctrl/Command+Z)" automation:AutomationProperties.Name="Undo layout change" />
+            <Button x:Name="RedoButton" Classes="tool square" Content="↷" Click="RedoClick" ToolTip.Tip="Redo layout change (Ctrl/Command+Shift+Z)" automation:AutomationProperties.Name="Redo layout change" />
+            <Button Classes="tool" Content="Auto arrange" Click="AutoArrangeClick" IsEnabled="{Binding CanMutateWorkspace}" />
+            <Button Classes="tool" Content="Fit view" Click="FitViewClick" ToolTip.Tip="Fit the complete board (Ctrl/Command+0)" />
+            <Button Classes="tool" Content="Selection" Click="ZoomSelectionClick" ToolTip.Tip="Zoom to selected entities" />
+            <Button x:Name="FocusButton" Classes="tool" Content="Focus" Click="FocusClick" ToolTip.Tip="Show only the selected item or version" />
+          </StackPanel>
 
-        <Button Grid.Column="4"
-                Classes="tool square"
-                Content="↻"
-                Command="{Binding RefreshWorkspaceCommand}"
-                ToolTip.Tip="Refresh workspace"
-                automation:AutomationProperties.Name="Refresh workspace" />
+          <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
+            <Button Classes="tool square" Content="−" Click="ZoomOutClick" ToolTip.Tip="Zoom out" automation:AutomationProperties.Name="Zoom out" />
+            <Border Background="{DynamicResource CanvasControlBackgroundBrush}" CornerRadius="6" Padding="8,5" MinWidth="54">
+              <TextBlock x:Name="ZoomLevelText" Text="100%" HorizontalAlignment="Center" FontSize="11" FontWeight="Bold" />
+            </Border>
+            <Button Classes="tool square" Content="＋" Click="ZoomInClick" ToolTip.Tip="Zoom in" automation:AutomationProperties.Name="Zoom in" />
+          </StackPanel>
+
+          <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="5">
+            <ComboBox x:Name="VersionFilter"
+                      Width="150"
+                      MinHeight="32"
+                      SelectionChanged="VersionFilterChanged"
+                      ToolTip.Tip="Filter by version">
+              <ComboBoxItem Content="All versions" Tag="All" IsSelected="True" />
+            </ComboBox>
+            <ComboBox x:Name="LifecycleFilter"
+                      Width="140"
+                      MinHeight="32"
+                      SelectionChanged="LifecycleFilterChanged"
+                      ToolTip.Tip="Filter by lifecycle state">
+              <ComboBoxItem Content="All states" Tag="All" IsSelected="True" />
+              <ComboBoxItem Content="Planned" Tag="Planned" />
+              <ComboBoxItem Content="In Progress" Tag="In Progress" />
+              <ComboBoxItem Content="Review" Tag="Review" />
+              <ComboBoxItem Content="Complete" Tag="Complete" />
+            </ComboBox>
+            <Button Classes="tool" Content="More filters">
+              <Button.Flyout>
+                <Flyout>
+                  <StackPanel Width="240" Spacing="9">
+                    <TextBlock Classes="eyebrow" Text="FILTER BOARD" />
+                    <TextBlock Text="Work type" FontWeight="SemiBold" FontSize="11" />
+                    <ComboBox x:Name="ItemTypeFilter"
+                              SelectionChanged="ItemTypeFilterChanged">
+                      <ComboBoxItem Content="All work types" Tag="All" IsSelected="True" />
+                    </ComboBox>
+                    <TextBlock Text="Changelog category" FontWeight="SemiBold" FontSize="11" />
+                    <ComboBox x:Name="CategoryFilter"
+                              SelectionChanged="CategoryFilterChanged">
+                      <ComboBoxItem Content="All categories" Tag="All" IsSelected="True" />
+                    </ComboBox>
+                    <CheckBox x:Name="WarningsOnlyFilter"
+                              Content="Only work needing attention"
+                              Click="WarningsOnlyChanged" />
+                    <TextBlock Text="Filters change only this computer's view. They never edit signed project documents."
+                               Classes="muted"
+                               FontSize="10"
+                               TextWrapping="Wrap" />
+                  </StackPanel>
+                </Flyout>
+              </Button.Flyout>
+            </Button>
+            <Button Classes="tool" Content="Minimap" Click="ToggleMiniMapClick" />
+          </StackPanel>
+
+          <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <TextBlock x:Name="CanvasSelectionSummary" Classes="muted" FontSize="10" />
+            <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Classes="muted" FontSize="10" />
+          </StackPanel>
+        </Grid>
       </Grid>
     </Border>
 
-    <Grid Grid.Row="1" ColumnDefinitions="*,342">
+    <Grid Grid.Row="1" ColumnDefinitions="*,360">
       <views:BlueprintCanvasSurface x:Name="BlueprintSurface" />
 
       <Border Grid.Column="1"
-              Background="#FFFFFF"
-              BorderBrush="#E2E4EC"
+              Background="{DynamicResource CanvasInspectorBrush}"
+              BorderBrush="{DynamicResource LineBrush}"
               BorderThickness="1,0,0,0">
         <Grid RowDefinitions="Auto,*,Auto">
-          <Border Background="#FAFAFD" BorderBrush="#E2E4EC" BorderThickness="0,0,0,1" Padding="16,12">
-            <StackPanel Spacing="3">
-              <TextBlock Classes="eyebrow" Text="DETAILS" />
-              <TextBlock Text="{Binding InspectorSelectionSummary}" Classes="mono" FontWeight="Bold" FontSize="12" />
-            </StackPanel>
+          <Border Background="{DynamicResource CanvasInspectorHeaderBrush}"
+                  BorderBrush="{DynamicResource LineBrush}"
+                  BorderThickness="0,0,0,1"
+                  Padding="16,11">
+            <Grid ColumnDefinitions="*,Auto">
+              <StackPanel Spacing="2">
+                <TextBlock Classes="eyebrow" Text="INSPECTOR" />
+                <TextBlock Text="{Binding InspectorSelectionSummary}" Classes="mono" FontWeight="Bold" FontSize="12" />
+              </StackPanel>
+              <Border Grid.Column="1" Classes="status-pill">
+                <TextBlock Text="{Binding SelectedVersion.Status}" FontSize="10" FontWeight="Bold" />
+              </Border>
+            </Grid>
           </Border>
 
-          <ScrollViewer Grid.Row="1">
-            <StackPanel Margin="16" Spacing="18">
-              <StackPanel Spacing="10">
-                <Grid ColumnDefinitions="*,Auto">
-                  <StackPanel Spacing="2">
-                    <TextBlock Classes="eyebrow" Text="RELEASE VERSION" />
-                    <TextBlock Text="{Binding SelectedVersion.Name}" FontSize="21" FontWeight="Bold" />
+          <TabControl Grid.Row="1" SelectedIndex="{Binding InspectorTabIndex}">
+            <TabItem Header="Details">
+              <ScrollViewer>
+                <StackPanel Margin="16" Spacing="18">
+                  <StackPanel Spacing="9">
+                    <TextBlock Classes="eyebrow" Text="VERSION" />
+                    <Grid ColumnDefinitions="*,130" ColumnSpacing="8">
+                      <TextBox Text="{Binding VersionEditorName}"
+                               PlaceholderText="Version name"
+                               IsEnabled="{Binding CanEditSelectedVersion}" />
+                      <ComboBox Grid.Column="1"
+                                ItemsSource="{Binding AvailableStatuses}"
+                                SelectedItem="{Binding VersionEditorStatus}"
+                                IsEnabled="{Binding CanEditSelectedVersion}" />
+                    </Grid>
+                    <TextBox Text="{Binding VersionEditorNotes}"
+                             PlaceholderText="What does this release accomplish?"
+                             AcceptsReturn="True"
+                             Height="70"
+                             IsEnabled="{Binding CanEditSelectedVersion}" />
+                    <Button Classes="secondary"
+                            Content="Save version"
+                            Command="{Binding SaveVersionDetailsCommand}"
+                            IsEnabled="{Binding CanEditSelectedVersion}" />
                   </StackPanel>
-                  <Border Grid.Column="1" Background="#DCEEF7" CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding SelectedVersion.Status}" Foreground="#0B4F8A" FontSize="11" FontWeight="Bold" />
-                  </Border>
-                </Grid>
 
-                <TextBox PlaceholderText="Version label"
-                         Text="{Binding VersionEditorName}"
-                         IsEnabled="{Binding CanEditSelectedVersion}" />
-                <ComboBox ItemsSource="{Binding AvailableStatuses}"
-                          SelectedItem="{Binding VersionEditorStatus}"
-                          IsEnabled="{Binding CanEditSelectedVersion}" />
-                <TextBox PlaceholderText="Milestone accomplishment"
-                         Text="{Binding VersionEditorNotes}"
-                         AcceptsReturn="True"
-                         Height="74"
-                         IsEnabled="{Binding CanEditSelectedVersion}" />
-                <Button Classes="secondary"
-                        Content="Apply version changes"
-                        Command="{Binding SaveVersionDetailsCommand}"
-                        IsEnabled="{Binding CanEditSelectedVersion}" />
-              </StackPanel>
+                  <Border Height="1" Background="{DynamicResource LineBrush}" />
 
-              <Border Height="1" Background="#C7DDE8" />
-
-              <StackPanel Spacing="10">
-                <Grid ColumnDefinitions="*,Auto">
-                  <StackPanel Spacing="2">
-                    <TextBlock Classes="eyebrow" Text="WORK ITEM" />
-                    <TextBlock Text="{Binding ItemEditorTitle}" FontSize="17" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
+                  <StackPanel Spacing="9">
+                    <Grid ColumnDefinitions="*,Auto">
+                      <TextBlock Classes="eyebrow" Text="WORK ITEM" />
+                      <TextBlock Grid.Column="1" Text="{Binding SelectedItem.ItemKey}" Classes="mono" FontWeight="Bold" Foreground="{DynamicResource CanvasAccentBrush}" />
+                    </Grid>
+                    <ComboBox ItemsSource="{Binding AvailableWorkflowStates}"
+                              SelectedItem="{Binding ItemEditorWorkflowState}"
+                              IsEnabled="{Binding CanEditItems}"
+                              automation:AutomationProperties.Name="Work item lifecycle state" />
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                      <ComboBox ItemsSource="{Binding AvailableItemTypes}"
+                                SelectedItem="{Binding SelectedItemTypeId}"
+                                IsEnabled="{Binding CanEditItems}" />
+                      <ComboBox Grid.Column="1"
+                                ItemsSource="{Binding AvailableCategories}"
+                                SelectedItem="{Binding SelectedCategoryId}"
+                                IsEnabled="{Binding CanEditItems}" />
+                    </Grid>
+                    <TextBox Text="{Binding ItemEditorTitle}"
+                             PlaceholderText="Clear outcome"
+                             IsEnabled="{Binding CanEditItems}" />
+                    <TextBox Text="{Binding ItemEditorDescription}"
+                             PlaceholderText="Useful context and evidence"
+                             AcceptsReturn="True"
+                             Height="86"
+                             IsEnabled="{Binding CanEditItems}" />
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                      <Button Classes="primary" Content="Add item" Command="{Binding AddItemCommand}" IsEnabled="{Binding CanEditItems}" />
+                      <Button Grid.Column="1" Classes="secondary" Content="Save selected" Command="{Binding SaveItemDetailsCommand}" IsEnabled="{Binding HasSelectedItem}" />
+                    </Grid>
                   </StackPanel>
-                  <Border Grid.Column="1" Background="#E6F5EF" CornerRadius="10" Padding="8,3" VerticalAlignment="Center" IsVisible="{Binding HasSelectedItem}">
-                    <TextBlock Text="{Binding SelectedItem.ItemKey}" Classes="mono" Foreground="#277A67" FontSize="10" FontWeight="Bold" />
-                  </Border>
-                </Grid>
+                </StackPanel>
+              </ScrollViewer>
+            </TabItem>
 
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                  <ComboBox ItemsSource="{Binding AvailableItemTypes}"
-                            SelectedItem="{Binding SelectedItemTypeId}"
-                            IsEnabled="{Binding CanEditItems}" />
-                  <ComboBox Grid.Column="1"
-                            ItemsSource="{Binding AvailableCategories}"
-                            SelectedItem="{Binding SelectedCategoryId}"
-                            IsEnabled="{Binding CanEditItems}" />
-                </Grid>
-                <TextBox PlaceholderText="What changed?"
-                         Text="{Binding ItemEditorTitle}"
-                         IsEnabled="{Binding CanEditItems}" />
-                <TextBox PlaceholderText="Context visible in release notes"
-                         Text="{Binding ItemEditorDescription}"
-                         AcceptsReturn="True"
-                         Height="84"
-                         IsEnabled="{Binding CanEditItems}" />
-                <CheckBox Content="Completed"
-                          IsChecked="{Binding ItemEditorIsDone}"
-                          IsEnabled="{Binding CanEditItems}" />
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                  <Button Classes="primary"
-                          Content="Connect new"
-                          Command="{Binding AddItemCommand}"
-                          IsEnabled="{Binding CanEditItems}" />
-                  <Button Grid.Column="1"
-                          Classes="secondary"
-                          Content="Apply selected"
-                          Command="{Binding SaveItemDetailsCommand}"
-                          IsEnabled="{Binding HasSelectedItem}" />
-                </Grid>
-              </StackPanel>
-
-              <Border Height="1" Background="#C7DDE8" />
-
-              <StackPanel Spacing="10">
-                <Grid ColumnDefinitions="*,Auto">
-                  <StackPanel Spacing="2">
-                    <TextBlock Classes="eyebrow" Text="TYPED RELATIONSHIPS" />
-                    <TextBlock Text="{Binding RelationshipRevisionSummary}" FontSize="11" Foreground="#4E7184" />
-                  </StackPanel>
-                  <Button Grid.Column="1"
-                          Classes="tool square"
-                          Content="＋"
-                          Command="{Binding BeginNewRelationshipTypeCommand}"
-                          ToolTip.Tip="Create a relationship type" />
-                </Grid>
-
-                <ComboBox ItemsSource="{Binding RelationshipTypes}"
-                          SelectedItem="{Binding SelectedRelationshipType}">
-                  <ComboBox.ItemTemplate>
-                    <DataTemplate x:DataType="core:RelationshipTypeDefinition">
-                      <TextBlock Text="{Binding Name}" />
-                    </DataTemplate>
-                  </ComboBox.ItemTemplate>
-                </ComboBox>
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                  <TextBox PlaceholderText="type-id"
-                           Text="{Binding RelationshipTypeId}"
-                           IsEnabled="{Binding CanMutateWorkspace}" />
-                  <TextBox Grid.Column="1"
-                           PlaceholderText="#52C7E8"
-                           Text="{Binding RelationshipTypeColor}"
-                           IsEnabled="{Binding CanMutateWorkspace}" />
-                </Grid>
-                <TextBox PlaceholderText="Relationship name"
-                         Text="{Binding RelationshipTypeName}"
-                         IsEnabled="{Binding CanMutateWorkspace}" />
-                <TextBox PlaceholderText="Meaning and usage"
-                         Text="{Binding RelationshipTypeDescription}"
-                         IsEnabled="{Binding CanMutateWorkspace}" />
-                <CheckBox Content="Directional"
-                          IsChecked="{Binding RelationshipTypeIsDirectional}"
-                          IsEnabled="{Binding CanMutateWorkspace}" />
-                <Button Classes="secondary"
-                        Content="Save relationship type"
-                        Command="{Binding SaveRelationshipTypeCommand}"
-                        IsEnabled="{Binding CanMutateWorkspace}" />
-
-                <ListBox ItemsSource="{Binding Relationships}"
-                         SelectedItem="{Binding SelectedRelationship}"
-                         MaxHeight="112">
-                  <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="core:RelationshipEdge">
-                      <StackPanel Margin="2,4">
-                        <TextBlock Text="{Binding TypeId}" Classes="mono" FontWeight="Bold" />
-                        <TextBlock Text="{Binding Label}" FontSize="10" Foreground="#537487" TextTrimming="CharacterEllipsis" />
-                      </StackPanel>
-                    </DataTemplate>
-                  </ListBox.ItemTemplate>
-                </ListBox>
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                  <ComboBox ItemsSource="{Binding RelationshipEndpoints}"
-                            SelectedItem="{Binding SelectedRelationshipSource}">
+            <TabItem Header="Relationships">
+              <ScrollViewer>
+                <StackPanel Margin="16" Spacing="10">
+                  <TextBlock Text="{Binding RelationshipRevisionSummary}" Classes="muted" TextWrapping="Wrap" />
+                  <ListBox ItemsSource="{Binding Relationships}"
+                           SelectedItem="{Binding SelectedRelationship}"
+                           MaxHeight="170">
+                    <ListBox.ItemTemplate>
+                      <DataTemplate x:DataType="core:RelationshipEdge">
+                        <StackPanel Margin="4" Spacing="2">
+                          <TextBlock Text="{Binding TypeId}" Classes="mono" FontWeight="Bold" />
+                          <TextBlock Text="{Binding Label}" Classes="muted" FontSize="10" TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+                      </DataTemplate>
+                    </ListBox.ItemTemplate>
+                  </ListBox>
+                  <ComboBox ItemsSource="{Binding RelationshipTypes}" SelectedItem="{Binding SelectedRelationshipType}">
                     <ComboBox.ItemTemplate>
-                      <DataTemplate x:DataType="models:RelationshipEndpointOption">
-                        <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                      <DataTemplate x:DataType="core:RelationshipTypeDefinition">
+                        <TextBlock Text="{Binding Name}" />
                       </DataTemplate>
                     </ComboBox.ItemTemplate>
                   </ComboBox>
-                  <ComboBox Grid.Column="1"
-                            ItemsSource="{Binding RelationshipEndpoints}"
-                            SelectedItem="{Binding SelectedRelationshipTarget}">
-                    <ComboBox.ItemTemplate>
-                      <DataTemplate x:DataType="models:RelationshipEndpointOption">
-                        <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
-                      </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                  </ComboBox>
-                </Grid>
-                <TextBox PlaceholderText="Optional relationship label"
-                         Text="{Binding RelationshipLabel}"
-                         IsEnabled="{Binding CanMutateWorkspace}" />
-                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="6">
-                  <Button Classes="secondary"
-                          Content="New"
-                          Command="{Binding BeginNewRelationshipCommand}"
-                          IsEnabled="{Binding CanMutateWorkspace}" />
-                  <Button Grid.Column="1"
-                          Classes="primary"
-                          Content="Save"
-                          Command="{Binding SaveRelationshipCommand}"
-                          IsEnabled="{Binding CanSaveRelationship}" />
-                  <Button Grid.Column="2"
-                          Classes="secondary"
-                          Content="Remove"
-                          Command="{Binding RemoveSelectedRelationshipCommand}"
-                          IsEnabled="{Binding CanRemoveRelationship}" />
-                </Grid>
-              </StackPanel>
-            </StackPanel>
-          </ScrollViewer>
+                  <Grid ColumnDefinitions="*,*" ColumnSpacing="7">
+                    <ComboBox ItemsSource="{Binding RelationshipEndpoints}" SelectedItem="{Binding SelectedRelationshipSource}">
+                      <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:RelationshipEndpointOption">
+                          <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                        </DataTemplate>
+                      </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <ComboBox Grid.Column="1" ItemsSource="{Binding RelationshipEndpoints}" SelectedItem="{Binding SelectedRelationshipTarget}">
+                      <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:RelationshipEndpointOption">
+                          <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                        </DataTemplate>
+                      </ComboBox.ItemTemplate>
+                    </ComboBox>
+                  </Grid>
+                  <TextBox Text="{Binding RelationshipLabel}" PlaceholderText="Optional edge label" IsEnabled="{Binding CanMutateWorkspace}" />
+                  <Grid ColumnDefinitions="*,*,*" ColumnSpacing="6">
+                    <Button Classes="secondary" Content="New" Command="{Binding BeginNewRelationshipCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+                    <Button Grid.Column="1" Classes="primary" Content="Save" Command="{Binding SaveRelationshipCommand}" IsEnabled="{Binding CanSaveRelationship}" />
+                    <Button Grid.Column="2" Classes="danger" Content="Remove" Command="{Binding RemoveSelectedRelationshipCommand}" IsEnabled="{Binding CanRemoveRelationship}" />
+                  </Grid>
 
-          <Border Grid.Row="2" Background="#202238" Padding="14,11">
-            <StackPanel Spacing="4">
-              <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="12" TextWrapping="Wrap" />
-              <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Foreground="#B8B2F4" FontSize="10" />
-              <TextBlock x:Name="CanvasSelectionSummary"
-                         Foreground="#F1F0FF"
-                         FontSize="10"
-                         FontWeight="Bold" />
-              <TextBlock Text="Drag empty space to box-select · Ctrl/Shift-click adds nodes · arrows move · Shift+arrows move 10px · Ctrl+A selects all · Esc clears"
-                         Foreground="#A6A8BA"
-                         FontSize="10"
-                         TextWrapping="Wrap" />
+                  <Border Height="1" Background="{DynamicResource LineBrush}" Margin="0,6" />
+                  <TextBlock Classes="eyebrow" Text="RELATIONSHIP TYPE" />
+                  <Grid ColumnDefinitions="*,110" ColumnSpacing="7">
+                    <TextBox Text="{Binding RelationshipTypeName}" PlaceholderText="Name" IsEnabled="{Binding CanMutateWorkspace}" />
+                    <TextBox Grid.Column="1" Text="{Binding RelationshipTypeColor}" PlaceholderText="#6254D9" IsEnabled="{Binding CanMutateWorkspace}" />
+                  </Grid>
+                  <TextBox Text="{Binding RelationshipTypeId}" PlaceholderText="lowercase-id" IsEnabled="{Binding CanMutateWorkspace}" />
+                  <TextBox Text="{Binding RelationshipTypeDescription}" PlaceholderText="Meaning" IsEnabled="{Binding CanMutateWorkspace}" />
+                  <CheckBox Content="Directional (draw arrowhead)" IsChecked="{Binding RelationshipTypeIsDirectional}" IsEnabled="{Binding CanMutateWorkspace}" />
+                  <Button Classes="secondary" Content="Save relationship type" Command="{Binding SaveRelationshipTypeCommand}" IsEnabled="{Binding CanMutateWorkspace}" />
+                </StackPanel>
+              </ScrollViewer>
+            </TabItem>
+
+            <TabItem Header="Evidence">
+              <ScrollViewer>
+                <StackPanel Margin="16" Spacing="10">
+                  <TextBlock Classes="eyebrow" Text="READINESS" />
+                  <TextBlock Text="{Binding ReleaseReadinessSummary}" FontSize="16" FontWeight="Bold" TextWrapping="Wrap" />
+                  <ItemsControl ItemsSource="{Binding ReleaseReadinessDiagnostics}">
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate x:DataType="models:ReleaseReadinessDiagnostic">
+                        <Border Classes="blueprint-card" Margin="0,0,0,7">
+                          <StackPanel Spacing="4">
+                            <TextBlock Text="{Binding Title}" FontWeight="Bold" />
+                            <TextBlock Text="{Binding Detail}" Classes="muted" FontSize="11" TextWrapping="Wrap" />
+                            <TextBlock Text="{Binding Guidance}" Foreground="{DynamicResource CanvasAccentBrush}" FontSize="11" TextWrapping="Wrap" />
+                          </StackPanel>
+                        </Border>
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                  <TextBlock Classes="eyebrow" Text="SOURCE / PROVENANCE" Margin="0,8,0,0" />
+                  <TextBlock Text="{Binding VersionSourceChangeSummary}" Classes="muted" TextWrapping="Wrap" />
+                  <TextBlock Text="{Binding SelectedItem.SourceReference}" Classes="mono muted" FontSize="10" TextWrapping="Wrap" />
+                </StackPanel>
+              </ScrollViewer>
+            </TabItem>
+
+            <TabItem Header="History">
+              <StackPanel Margin="16" Spacing="10">
+                <TextBlock Classes="eyebrow" Text="SIGNED HISTORY" />
+                <TextBlock Text="{Binding SyncAuditSummary}" FontWeight="Bold" TextWrapping="Wrap" />
+                <TextBlock Text="{Binding CanvasLayoutRevisionSummary}" Classes="muted" />
+                <TextBlock Text="{Binding RelationshipRevisionSummary}" Classes="muted" />
+                <TextBlock Text="Every content, lifecycle, layout, and relationship change is saved through the signed workspace workflow and appended to the audit chain."
+                           Classes="muted"
+                           TextWrapping="Wrap" />
+                <ScrollViewer MaxHeight="420">
+                  <ItemsControl ItemsSource="{Binding AuditHistory}">
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <Border Classes="blueprint-card" Margin="0,0,0,7">
+                          <StackPanel Spacing="3">
+                            <TextBlock Text="{Binding Operation}" Classes="mono" FontWeight="Bold" />
+                            <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+                            <TextBlock Text="{Binding AuthorDisplayName}" Classes="muted" FontSize="10" />
+                            <TextBlock Text="{Binding TimestampUtc}" Classes="muted" FontSize="10" />
+                          </StackPanel>
+                        </Border>
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                </ScrollViewer>
+              </StackPanel>
+            </TabItem>
+          </TabControl>
+
+          <Border Grid.Row="2" Background="{DynamicResource CanvasStatusBarBrush}" Padding="14,10">
+            <StackPanel Spacing="3">
+              <TextBlock Text="{Binding WorkspaceMessage}" Foreground="White" FontSize="11" TextWrapping="Wrap" />
+              <TextBlock Text="{Binding WorkspaceModeSummary}" Foreground="#C9C8D8" FontSize="10" TextWrapping="Wrap" />
             </StackPanel>
           </Border>
         </Grid>

--- a/Blueprints.App/Views/Components/OverviewView.axaml.cs
+++ b/Blueprints.App/Views/Components/OverviewView.axaml.cs
@@ -1,5 +1,8 @@
+using System.Collections.Specialized;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Blueprints.App.Models;
+using Blueprints.App.ViewModels;
 
 namespace Blueprints.App.Views.Components;
 
@@ -11,9 +14,15 @@ public partial class OverviewView : UserControl
         BlueprintSurface.HistoryStateChanged += (_, _) => UpdateHistoryButtons();
         BlueprintSurface.SelectionStateChanged += (_, _) => UpdateSelectionSummary();
         BlueprintSurface.ZoomChanged += (_, _) => UpdateZoomSummary();
+        BlueprintSurface.ViewModeChanged += (_, _) => UpdateViewModeButtons();
+        BlueprintSurface.ConnectModeChanged += (_, _) => UpdateConnectButton();
+        BlueprintSurface.SearchRequested += (_, _) => SearchBox.Focus();
+        DataContextChanged += HandleDataContextChanged;
         UpdateHistoryButtons();
         UpdateSelectionSummary();
         UpdateZoomSummary();
+        UpdateViewModeButtons();
+        UpdateConnectButton();
     }
 
     private void UndoClick(object? sender, RoutedEventArgs eventArgs) =>
@@ -34,8 +43,73 @@ public partial class OverviewView : UserControl
     private void AutoArrangeClick(object? sender, RoutedEventArgs eventArgs) =>
         BlueprintSurface.AutoArrange();
 
-    private void SaveLayoutClick(object? sender, RoutedEventArgs eventArgs) =>
-        BlueprintSurface.SaveLayout();
+    private void ZoomSelectionClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ZoomToSelection();
+
+    private void FocusClick(object? sender, RoutedEventArgs eventArgs)
+    {
+        BlueprintSurface.ToggleFocusMode();
+        FocusButton.Classes.Set("active", BlueprintSurface.IsFocusMode);
+        FocusButton.Content = BlueprintSurface.IsFocusMode ? "Exit focus" : "Focus";
+    }
+
+    private void PlanModeClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.SetViewMode(CanvasViewMode.Plan);
+
+    private void DependenciesModeClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.SetViewMode(CanvasViewMode.Dependencies);
+
+    private void ReleaseNotesModeClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.SetViewMode(CanvasViewMode.ReleaseNotes);
+
+    private void ConnectClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ToggleConnectMode();
+
+    private void ToggleMiniMapClick(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.ToggleMiniMap();
+
+    private void SearchTextChanged(object? sender, TextChangedEventArgs eventArgs)
+    {
+        if (sender is TextBox textBox)
+        {
+            BlueprintSurface.SetSearch(textBox.Text);
+        }
+    }
+
+    private void LifecycleFilterChanged(object? sender, SelectionChangedEventArgs eventArgs)
+    {
+        if (sender is ComboBox { SelectedItem: ComboBoxItem item })
+        {
+            BlueprintSurface.SetLifecycleFilter(item.Tag?.ToString());
+        }
+    }
+
+    private void VersionFilterChanged(object? sender, SelectionChangedEventArgs eventArgs)
+    {
+        if (sender is ComboBox { SelectedItem: ComboBoxItem item })
+        {
+            BlueprintSurface.SetVersionFilter(item.Tag?.ToString());
+        }
+    }
+
+    private void ItemTypeFilterChanged(object? sender, SelectionChangedEventArgs eventArgs)
+    {
+        if (sender is ComboBox { SelectedItem: ComboBoxItem item })
+        {
+            BlueprintSurface.SetItemTypeFilter(item.Tag?.ToString());
+        }
+    }
+
+    private void CategoryFilterChanged(object? sender, SelectionChangedEventArgs eventArgs)
+    {
+        if (sender is ComboBox { SelectedItem: ComboBoxItem item })
+        {
+            BlueprintSurface.SetCategoryFilter(item.Tag?.ToString());
+        }
+    }
+
+    private void WarningsOnlyChanged(object? sender, RoutedEventArgs eventArgs) =>
+        BlueprintSurface.SetWarningsOnly(WarningsOnlyFilter.IsChecked == true);
 
     private void UpdateHistoryButtons()
     {
@@ -48,4 +122,68 @@ public partial class OverviewView : UserControl
 
     private void UpdateZoomSummary() =>
         ZoomLevelText.Text = BlueprintSurface.ZoomSummary;
+
+    private void UpdateViewModeButtons()
+    {
+        PlanModeButton.Classes.Set("active", BlueprintSurface.ViewMode == CanvasViewMode.Plan);
+        DependenciesModeButton.Classes.Set("active", BlueprintSurface.ViewMode == CanvasViewMode.Dependencies);
+        ReleaseNotesModeButton.Classes.Set("active", BlueprintSurface.ViewMode == CanvasViewMode.ReleaseNotes);
+    }
+
+    private void UpdateConnectButton()
+    {
+        ConnectButton.Classes.Set("active", BlueprintSurface.IsConnectMode);
+        ConnectButton.Content = BlueprintSurface.IsConnectMode ? "Connecting…" : "Connect";
+    }
+
+    private void RefreshVersionFilter()
+    {
+        while (VersionFilter.Items.Count > 1)
+        {
+            VersionFilter.Items.RemoveAt(VersionFilter.Items.Count - 1);
+        }
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+        foreach (var version in viewModel.Versions)
+        {
+            VersionFilter.Items.Add(new ComboBoxItem
+            {
+                Content = version.Name,
+                Tag = version.Name,
+            });
+        }
+        PopulateFilter(ItemTypeFilter, viewModel.AvailableItemTypes);
+        PopulateFilter(CategoryFilter, viewModel.AvailableCategories);
+    }
+
+    private static void PopulateFilter(ComboBox comboBox, IEnumerable<string> values)
+    {
+        while (comboBox.Items.Count > 1)
+        {
+            comboBox.Items.RemoveAt(comboBox.Items.Count - 1);
+        }
+        foreach (var value in values)
+        {
+            comboBox.Items.Add(new ComboBoxItem
+            {
+                Content = value,
+                Tag = value,
+            });
+        }
+    }
+
+    private void HandleDataContextChanged(object? sender, EventArgs eventArgs)
+    {
+        if (DataContext is MainWindowViewModel viewModel)
+        {
+            viewModel.Versions.CollectionChanged -= HandleVersionsChanged;
+            viewModel.Versions.CollectionChanged += HandleVersionsChanged;
+        }
+        RefreshVersionFilter();
+    }
+
+    private void HandleVersionsChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs) =>
+        RefreshVersionFilter();
 }

--- a/Blueprints.Collaboration/Services/FileSystemAuditLogService.cs
+++ b/Blueprints.Collaboration/Services/FileSystemAuditLogService.cs
@@ -128,6 +128,49 @@ public sealed class FileSystemAuditLogService
                 : $"Audit log validation failed for {distinctInvalidPaths.Length} entries.");
     }
 
+    public IReadOnlyList<AuditLogEntry> ReadVerifiedEntries(
+        string workspaceRoot,
+        IReadOnlyDictionary<string, SignaturePublicKey> publicKeys,
+        int maximumCount = 200)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(publicKeys);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumCount, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maximumCount, 1_000);
+
+        var validation = Validate(workspaceRoot, publicKeys);
+        if (!validation.IsValid)
+        {
+            throw new InvalidOperationException(
+                "Audit history cannot be displayed because its signature or hash chain is invalid.");
+        }
+
+        var logRoot = GetLogRoot(workspaceRoot);
+        if (!Directory.Exists(logRoot))
+        {
+            return [];
+        }
+
+        var entries = new List<AuditLogEntry>();
+        foreach (var path in Directory.EnumerateFiles(logRoot, "*.json")
+                     .OrderByDescending(static path => path, StringComparer.Ordinal)
+                     .Take(maximumCount))
+        {
+            var read = _signedDocumentStore.Read<AuditLogEntry>(path, publicKeys);
+            if (!read.IsSignatureValid)
+            {
+                throw new InvalidOperationException(
+                    "Audit history changed while it was being read.");
+            }
+            entries.Add(read.Document);
+        }
+
+        return entries
+            .OrderByDescending(static entry => entry.TimestampUtc)
+            .ThenByDescending(static entry => entry.ChangeId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
     private static string? GetLatestEntryHash(string workspaceRoot)
     {
         var logRoot = GetLogRoot(workspaceRoot);

--- a/Blueprints.Core/Enums/WorkItemLifecycle.cs
+++ b/Blueprints.Core/Enums/WorkItemLifecycle.cs
@@ -1,0 +1,9 @@
+namespace Blueprints.Core.Enums;
+
+public enum WorkItemLifecycle
+{
+    Planned = 0,
+    InProgress = 1,
+    Review = 2,
+    Complete = 3,
+}

--- a/Blueprints.Core/Models/ItemDocument.cs
+++ b/Blueprints.Core/Models/ItemDocument.cs
@@ -1,3 +1,5 @@
+using Blueprints.Core.Enums;
+
 namespace Blueprints.Core.Models;
 
 public sealed record ItemDocument(
@@ -15,4 +17,9 @@ public sealed record ItemDocument(
     DateTimeOffset CreatedUtc,
     DateTimeOffset UpdatedUtc,
     Guid LastModifiedByUserId,
-    string LastModifiedByName);
+    string LastModifiedByName,
+    WorkItemLifecycle? WorkflowState = null)
+{
+    public WorkItemLifecycle EffectiveWorkflowState =>
+        IsDone ? WorkItemLifecycle.Complete : WorkflowState ?? WorkItemLifecycle.Planned;
+}

--- a/Blueprints.Core/Services/ItemDocumentValidator.cs
+++ b/Blueprints.Core/Services/ItemDocumentValidator.cs
@@ -1,0 +1,34 @@
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+
+namespace Blueprints.Core.Services;
+
+public static class ItemDocumentValidator
+{
+    public static void Validate(ItemDocument item, Guid projectId, Guid versionId)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        if (item.SchemaVersion != 1)
+        {
+            throw new InvalidOperationException($"Item schema {item.SchemaVersion} is not supported.");
+        }
+        if (item.ProjectId != projectId || item.VersionId != versionId ||
+            item.ItemId == Guid.Empty)
+        {
+            throw new InvalidOperationException("Item identity does not match its workspace location.");
+        }
+        if (item.WorkflowState is WorkItemLifecycle state && !Enum.IsDefined(state))
+        {
+            throw new InvalidOperationException("Item workflow state is not supported.");
+        }
+        if (item.WorkflowState == WorkItemLifecycle.Complete && !item.IsDone)
+        {
+            throw new InvalidOperationException("A Complete item must also be marked done.");
+        }
+        if (item.IsDone &&
+            item.WorkflowState is not null and not WorkItemLifecycle.Complete)
+        {
+            throw new InvalidOperationException("A done item cannot use an incomplete workflow state.");
+        }
+    }
+}

--- a/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
+++ b/Blueprints.Storage/Services/FileSystemProjectWorkspaceStore.cs
@@ -109,6 +109,10 @@ public sealed class FileSystemProjectWorkspaceStore : IProjectWorkspaceStore
                         foreach (var itemPath in Directory.EnumerateFiles(itemsRoot, "*.json").OrderBy(static path => path, StringComparer.Ordinal))
                         {
                             var itemResult = _signedDocumentStore.Read<ItemDocument>(itemPath, publicKeys);
+                            ItemDocumentValidator.Validate(
+                                itemResult.Document,
+                                projectResult.Document.ProjectId,
+                                versionResult.Document.VersionId);
                             totalDocuments++;
                             if (!itemResult.IsSignatureValid)
                             {

--- a/Blueprints.Tests/CanvasBoardProjectionServiceTests.cs
+++ b/Blueprints.Tests/CanvasBoardProjectionServiceTests.cs
@@ -1,0 +1,171 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+
+namespace Blueprints.Tests;
+
+public sealed class CanvasBoardProjectionServiceTests
+{
+    [Fact]
+    public void Plan_ProjectsVersionFramesAndLifecycleColumnsWithoutOwnershipEdges()
+    {
+        var versionId = Guid.NewGuid();
+        var items = Enum.GetValues<WorkItemLifecycle>()
+            .Select((state, index) => new WorkspaceItemCard(
+                Guid.NewGuid(),
+                $"BP-{index + 1}",
+                "feature",
+                index % 2 == 0 ? "added" : "fixed",
+                $"{state} work",
+                null,
+                state == WorkItemLifecycle.Complete,
+                state))
+            .ToArray();
+        var version = new WorkspaceVersionCard(
+            versionId,
+            "1.0.0",
+            ReleaseStatus.InProgress,
+            null,
+            items.Length,
+            1,
+            items);
+
+        var projection = CanvasBoardProjectionService.Build(
+            CanvasViewMode.Plan,
+            [version],
+            relationshipDocument: null);
+
+        var frame = Assert.Single(projection.Frames);
+        Assert.Equal(4, frame.Columns.Count);
+        Assert.All(frame.Columns, static column => Assert.Single(column.Items));
+        Assert.Empty(projection.Relationships);
+        Assert.Equal(25, frame.CompletionPercentage);
+    }
+
+    [Fact]
+    public void Dependencies_ProjectsOnlyTypedRelationshipsWithDirectionAndLabel()
+    {
+        var source = CreateItem("BP-1", WorkItemLifecycle.InProgress);
+        var target = CreateItem("BP-2", WorkItemLifecycle.Review);
+        var version = new WorkspaceVersionCard(
+            Guid.NewGuid(),
+            "1.0.0",
+            ReleaseStatus.InProgress,
+            null,
+            2,
+            0,
+            [source, target]);
+        var type = new RelationshipTypeDefinition(
+            "blocks",
+            "Blocks",
+            "Must finish first",
+            "#C64D42",
+            true);
+        var edge = new RelationshipEdge(
+            Guid.NewGuid(),
+            type.TypeId,
+            new RelationshipEndpoint("item", source.ItemId),
+            new RelationshipEndpoint("item", target.ItemId),
+            "Release gate");
+        var relationships = new RelationshipDocument(
+            1,
+            Guid.NewGuid(),
+            1,
+            [type],
+            [edge],
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Tester");
+
+        var projection = CanvasBoardProjectionService.Build(
+            CanvasViewMode.Dependencies,
+            [version],
+            relationships);
+
+        var projected = Assert.Single(projection.Relationships);
+        Assert.True(projected.Type.IsDirectional);
+        Assert.Equal("Release gate", projected.Edge.Label);
+        Assert.Equal("#C64D42", projected.Type.ColorHex);
+        Assert.Equal(3, projection.DependencyNodes.Count);
+    }
+
+    [Fact]
+    public void Filters_AreViewOnlyAndRetainOriginalCards()
+    {
+        var planned = CreateItem("BP-1", WorkItemLifecycle.Planned);
+        var review = CreateItem("BP-2", WorkItemLifecycle.Review);
+        var version = new WorkspaceVersionCard(
+            Guid.NewGuid(),
+            "2.0.0",
+            ReleaseStatus.Planned,
+            null,
+            2,
+            0,
+            [planned, review]);
+
+        var projection = CanvasBoardProjectionService.Build(
+            CanvasViewMode.Plan,
+            [version],
+            null,
+            new CanvasBoardFilter(Lifecycle: "Review"));
+
+        Assert.Single(projection.Frames.Single().Columns.Single(column =>
+            column.State == WorkItemLifecycle.Review).Items);
+        Assert.Equal(2, version.Items.Count);
+        Assert.Equal(WorkItemLifecycle.Planned, planned.WorkflowState);
+    }
+
+    [Fact]
+    public void Dependencies_ProjectsLargeBoardsWithinConfiguredDomainLimits()
+    {
+        var items = Enumerable.Range(1, 600)
+            .Select(index => CreateItem($"BP-{index}", (WorkItemLifecycle)(index % 4)))
+            .ToArray();
+        var version = new WorkspaceVersionCard(
+            Guid.NewGuid(),
+            "3.0.0",
+            ReleaseStatus.InProgress,
+            null,
+            items.Length,
+            items.Count(static item => item.IsDone),
+            items);
+        var type = new RelationshipTypeDefinition("relates", "Relates", null, "#6254D9", false);
+        var edges = Enumerable.Range(0, 1_200)
+            .Select(index => new RelationshipEdge(
+                Guid.NewGuid(),
+                type.TypeId,
+                new RelationshipEndpoint("item", items[index % items.Length].ItemId),
+                new RelationshipEndpoint("item", items[(index + index / items.Length + 1) % items.Length].ItemId),
+                null))
+            .ToArray();
+        var document = new RelationshipDocument(
+            1,
+            Guid.NewGuid(),
+            1,
+            [type],
+            edges,
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid(),
+            "Tester");
+
+        var projection = CanvasBoardProjectionService.Build(
+            CanvasViewMode.Dependencies,
+            [version],
+            document);
+
+        Assert.Equal(601, projection.DependencyNodes.Count);
+        Assert.Equal(1_200, projection.Relationships.Count);
+    }
+
+    private static WorkspaceItemCard CreateItem(string key, WorkItemLifecycle state) =>
+        new(
+            Guid.NewGuid(),
+            key,
+            "feature",
+            "added",
+            $"{key} title",
+            null,
+            state == WorkItemLifecycle.Complete,
+            state);
+}

--- a/Blueprints.Tests/CanvasMiniMapProjectionServiceTests.cs
+++ b/Blueprints.Tests/CanvasMiniMapProjectionServiceTests.cs
@@ -1,0 +1,34 @@
+using Blueprints.App.Models;
+using Blueprints.App.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class CanvasMiniMapProjectionServiceTests
+{
+    [Fact]
+    public void Project_ScalesFramesNodesAndSelectionIntoMapBounds()
+    {
+        var selected = Guid.NewGuid();
+        var nodes = new[]
+        {
+            new CanvasNodeBounds(selected, 100, 50, 400, 200),
+            new CanvasNodeBounds(Guid.NewGuid(), 900, 700, 80, 60),
+        };
+
+        var result = CanvasMiniMapProjectionService.Project(
+            nodes,
+            new HashSet<Guid> { selected },
+            1000,
+            800,
+            200,
+            100);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result.Single(node => node.EntityId == selected).IsSelected);
+        Assert.All(result, node =>
+        {
+            Assert.InRange(node.X, 0, 200);
+            Assert.InRange(node.Y, 0, 100);
+        });
+    }
+}

--- a/Blueprints.Tests/FileSystemCanvasViewStateStoreTests.cs
+++ b/Blueprints.Tests/FileSystemCanvasViewStateStoreTests.cs
@@ -25,7 +25,17 @@ public sealed class FileSystemCanvasViewStateStoreTests : IDisposable
     public void SaveAndLoad_RoundTripsMachineLocalViewport()
     {
         var store = new FileSystemCanvasViewStateStore();
-        var expected = new CanvasViewState(0.8, 125, 240);
+        var collapsed = Guid.NewGuid();
+        var expected = new CanvasViewState(
+            0.8,
+            125,
+            240,
+            CanvasViewMode.Dependencies,
+            "security",
+            "Review",
+            "1.0.0",
+            false,
+            collapsed.ToString("D"));
 
         store.Save(_workspaceRoot, expected);
         var actual = store.Load(_workspaceRoot);

--- a/Blueprints.Tests/ItemDocumentValidatorTests.cs
+++ b/Blueprints.Tests/ItemDocumentValidatorTests.cs
@@ -1,0 +1,90 @@
+using Blueprints.Core.Enums;
+using Blueprints.Core.Models;
+using Blueprints.Core.Services;
+using Blueprints.Storage.Services;
+
+namespace Blueprints.Tests;
+
+public sealed class ItemDocumentValidatorTests
+{
+    [Fact]
+    public void Validate_AllowsLegacyItemWithoutWorkflowState()
+    {
+        var item = CreateItem(null, false);
+
+        ItemDocumentValidator.Validate(item, item.ProjectId, item.VersionId);
+
+        Assert.Equal(WorkItemLifecycle.Planned, item.EffectiveWorkflowState);
+    }
+
+    [Fact]
+    public void Deserialize_LegacyItemWithoutWorkflowState_RemainsCompatible()
+    {
+        var projectId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var json = $$"""
+            {
+              "schemaVersion":1,
+              "projectId":"{{projectId}}",
+              "versionId":"{{versionId}}",
+              "itemId":"{{itemId}}",
+              "itemKey":"BP-1",
+              "itemKeyTypeId":"feature",
+              "categoryId":"added",
+              "title":"Legacy",
+              "description":null,
+              "isDone":true,
+              "tags":[],
+              "createdUtc":"2026-01-01T00:00:00+00:00",
+              "updatedUtc":"2026-01-01T00:00:00+00:00",
+              "lastModifiedByUserId":"{{userId}}",
+              "lastModifiedByName":"Tester"
+            }
+            """;
+
+        var item = new CanonicalJsonSerializer().Deserialize<ItemDocument>(json);
+
+        Assert.Null(item.WorkflowState);
+        Assert.Equal(WorkItemLifecycle.Complete, item.EffectiveWorkflowState);
+        ItemDocumentValidator.Validate(item, projectId, versionId);
+    }
+
+    [Fact]
+    public void Validate_RejectsInvalidOrContradictoryWorkflowState()
+    {
+        var invalid = CreateItem((WorkItemLifecycle)99, false);
+        var contradictory = CreateItem(WorkItemLifecycle.Complete, false);
+
+        Assert.Throws<InvalidOperationException>(
+            () => ItemDocumentValidator.Validate(invalid, invalid.ProjectId, invalid.VersionId));
+        Assert.Throws<InvalidOperationException>(
+            () => ItemDocumentValidator.Validate(
+                contradictory,
+                contradictory.ProjectId,
+                contradictory.VersionId));
+    }
+
+    private static ItemDocument CreateItem(WorkItemLifecycle? state, bool isDone)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ItemDocument(
+            1,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "BP-1",
+            "feature",
+            "added",
+            "Test",
+            null,
+            isDone,
+            [],
+            now,
+            now,
+            Guid.NewGuid(),
+            "Tester",
+            state);
+    }
+}

--- a/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
+++ b/Blueprints.Tests/ProjectWorkspaceCoordinatorServiceTests.cs
@@ -77,6 +77,9 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         var auditEntries = Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json").ToArray();
         Assert.Single(auditEntries);
         Assert.True(File.Exists(Path.ChangeExtension(auditEntries.Single(), ".sig")));
+        var history = service.GetAuditHistory(localRoot);
+        Assert.Single(history);
+        Assert.Equal("project.create", history[0].Operation);
     }
 
     [Fact]
@@ -238,6 +241,48 @@ public sealed class ProjectWorkspaceCoordinatorServiceTests : IDisposable
         var item = updated.LoadResult.Workspace.Versions[0].Items.Single();
         Assert.Equal("BP-151", item.ItemKey);
         Assert.Equal("Ship create and open workflow", item.Title);
+    }
+
+    [Fact]
+    public void SaveItem_PersistsLifecycleThroughSignedItemWorkflow()
+    {
+        var localRoot = Path.Combine(_rootDirectory, "item-lifecycle-local", "BP");
+        var sharedRoot = Path.Combine(_rootDirectory, "item-lifecycle-shared", "BP");
+        var service = CreateService();
+        service.CreateProject(
+            new ProjectCreateRequest("Blueprints", "BP", "SemVer", localRoot, sharedRoot));
+        var versionSession = service.SaveVersion(
+            localRoot,
+            sharedRoot,
+            new VersionEditRequest(null, "1.0.0", ReleaseStatus.InProgress, null));
+        var versionId = versionSession.LoadResult.Workspace.Versions.Single().Version.VersionId;
+
+        var updated = service.SaveItem(
+            localRoot,
+            sharedRoot,
+            new ItemEditRequest(
+                versionId,
+                null,
+                "feature",
+                "added",
+                "Review signed lifecycle",
+                null,
+                false,
+                WorkItemLifecycle.Review));
+
+        var item = updated.LoadResult.Workspace.Versions.Single().Items.Single();
+        Assert.Equal(WorkItemLifecycle.Review, item.WorkflowState);
+        Assert.Equal(WorkItemLifecycle.Review, item.EffectiveWorkflowState);
+        Assert.False(item.IsDone);
+        Assert.True(File.Exists(Path.Combine(
+            localRoot,
+            "versions",
+            versionId.ToString("N"),
+            "items",
+            $"{item.ItemId:N}.sig")));
+        Assert.Contains(
+            Directory.EnumerateFiles(Path.Combine(localRoot, "log"), "*.json"),
+            path => File.ReadAllText(path).Contains("item.save", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ Notable changes to Blueprints are documented here. The project follows semantic 
 
 ## Unreleased
 
+## 0.8.0 — 2026-07-31
+
+Interactive-blueprint-board milestone. This release replaces the changelog-like canvas with version frames, item lifecycle columns, focused dependency rendering, and direct signed relationship authoring.
+
+### Added
+
+- Plan view with movable, resizable, collapsible version frames and Planned, In Progress, Review, and Complete columns.
+- Dependencies view with automatic node placement, selectable typed edges, directional arrowheads, hover/selection labels, and incoming/outgoing focus.
+- Release Notes category projection plus an explicitly disabled Timeline mode pending a target-date contract.
+- Compact toolbar with mode switching, search, local filters, focus, direct Connect mode, zoom-to-selection, clickable/collapsible minimap, and trust/sync/readiness status.
+- Details, Relationships, Evidence, and History inspector tabs.
+- Backward-compatible signed item lifecycle state, lifecycle validation, signed drag/keyboard transitions, and legacy Planned/Complete mapping.
+- Projection and minimap services with lifecycle, filter, relationship, compatibility, and large-board tests.
+- Light and dark canvas theme resources plus expanded accessible names, help text, focus, and shortcuts.
+
+### Changed
+
+- Completed release builds identify themselves as `0.8.0`.
+- Plan communicates ownership by containment and no longer draws a connector from every version to every owned item.
+- Cards use readable multi-line titles and compact lifecycle, type, changelog, source, warning, and blocker metadata.
+- Relationship creation starts from two visible canvas endpoints but requires review in the existing relationship editor before saving.
+- View mode, search, filters, minimap visibility, viewport, zoom, and collapsed frames are retained as bounded machine-local preferences.
+
+### Security
+
+- Lifecycle changes use the existing trusted, conflict-free, immutable-aware signed item transaction and audit workflow.
+- Direct connections reuse existing endpoint/type/self-link/duplicate/count validation and signed relationship persistence.
+- Invalid or contradictory persisted lifecycle values make workspace loading fail closed as corrupt.
+- No view mode, filter, focus, collapse, or viewport state enters signed project truth or collaboration exchange.
+
+### Workspace compatibility
+
+- Signed workspace schema remains version 1.
+- `workflowState` is an optional item field. Missing incomplete items map to Planned; missing completed items map to Complete; opening does not rewrite them.
+- Existing signed layout and relationship documents remain compatible and retain whole-document conflict behavior.
+
+### Known limitations
+
+- Timeline remains disabled because versions do not yet have an authoritative target-date field.
+- Frame size is session-local; coordinates remain the only shared signed layout geometry.
+- Dependency auto-layout is deterministic rather than a graph-optimization engine.
+- Distribution remains deferred.
+
 ## 0.7.0 — 2026-07-31
 
 Repository-workflow and blueprint-clarity milestone. This release overhauls the planning canvas around automatic related-work lanes and turns local Git repositories into browsable, actionable project inputs without weakening signed Blueprints workspace boundaries.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latestmajor</LangVersion>
     <RollForward>LatestPatch</RollForward>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
 Release notes often live in scattered issues, commit messages, and private documents. Blueprints keeps release intent in a portable workspace that remains readable without a server:
 
 - plan versions and categorized release items;
-- arrange versions and work items on a persistent signed blueprint canvas;
-- automatically organize related work by changelog category, work type, or version;
+- plan inside movable version frames with Planned, In Progress, Review, and Complete lifecycle columns;
+- switch between an interactive planning board, dependency graph, and release-note projection;
+- create, select, label, and edit signed typed relationships directly from the canvas;
 - generate stable human-readable item keys;
 - freeze and release versions with immutable released content;
 - export Markdown changelogs, optionally enriched by local Git history;
@@ -42,6 +43,7 @@ Release notes often live in scattered issues, commit messages, and private docum
 | --- | --- |
 | Local project, version, and item workflow | Working |
 | Persistent signed canvas layout | Working |
+| Interactive Plan and Dependencies views | Working |
 | Signed persistence and trust validation | Working |
 | Markdown changelog export | Working |
 | Shared-folder push/pull | Working with distinct signed identities and staged validation |

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -140,6 +140,28 @@ Exit criteria:
 - large planning documents are no longer truncated at 100 proposals;
 - related work is visibly grouped and the complete plan can be navigated from 25% through 250% zoom.
 
+## Completed — v0.8: interactive blueprint board
+
+Goal: make the primary canvas readable as a release plan and expose its direct-manipulation capabilities without weakening signed project truth.
+
+- [x] Replace version ownership fans with movable, resizable version frames.
+- [x] Organize work by Planned, In Progress, Review, and Complete lifecycle columns while retaining changelog categories.
+- [x] Add a backward-compatible signed item lifecycle field with legacy Planned/Complete mapping and validation.
+- [x] Add Plan, Dependencies, and Release Notes projections; keep Timeline visibly deferred until target dates exist.
+- [x] Render only meaningful typed relationships in Plan, including direction arrowheads, labels, selection, and related-edge focus.
+- [x] Add direct two-endpoint connection mode backed by the existing relationship editor, validator, signing, and audit flow.
+- [x] Replace permanent instruction strips with a compact toolbar, shortcut help, search, filters, focus, zoom-to-selection, and a clickable minimap.
+- [x] Reorganize the inspector into Details, Relationships, Evidence, and History.
+- [x] Persist view mode, filters, search, minimap visibility, viewport, zoom, and collapsed frames as bounded machine-local preferences.
+- [x] Add light/dark canvas resources and projection, lifecycle, minimap, compatibility, and large-board tests.
+
+Exit criteria:
+
+- containment, rather than ownership lines, communicates version ownership in Plan;
+- Plan and Dependencies are usable projections of the same signed documents;
+- lifecycle movement uses the normal signed item command and remains blocked for immutable or unsafe workspaces;
+- existing schema-1 workspaces open without rewriting and old incomplete/completed items map predictably.
+
 ## In progress — v1.0: dependable small-team release planner
 
 Goal: supported installers and documented recovery for small teams.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -9,6 +9,11 @@ Blueprints is designed so the release-planning workflow does not depend on recog
 - Standard `Tab` and `Shift+Tab` navigation reaches form fields and actions.
 - All icon-only canvas controls expose text tooltips and accessible names.
 - Canvas nodes support keyboard selection and movement; the on-screen footer lists the available keys.
+- Version frames and work-item cards expose descriptive accessible names and help text; relationship edges identify their type and label.
+- `Ctrl`/Command+`7`, `8`, and `9` switch Plan, Dependencies, and Release Notes views.
+- `Ctrl`/Command+`F` focuses search, `Ctrl`/Command+`L` enters connection mode, and `Ctrl`/Command+`J` zooms to selection.
+- `Ctrl`/Command+Shift+`V` creates the named version and `Ctrl`/Command+Shift+`I` opens a new work item for the selected version.
+- In Plan, Left/Right moves selected editable work between lifecycle columns through the signed workflow. In graph views, arrow keys move selected nodes; Shift changes the step to ten pixels.
 - Destructive and irreversible actions use text labels and explain their consequences.
 - Color is supplemented by labels, counts, status text, and guidance.
 - Default Fluent focus presentation is retained rather than hidden by custom styling.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,16 @@ Opening a workspace first processes any bounded transaction marker. Marker paths
 
 Zoom and scroll offsets follow a separate local-preference flow: validate bounded values, atomically replace `.blueprints/canvas-view.json`, and never include it in signatures, audit entries, manifests, or exchange analysis.
 
+### Canvas projection and lifecycle
+
+1. Map signed versions, items, layout positions, and typed relationships into a transient board projection.
+2. In Plan, project each version as a frame and place its items in lifecycle columns; do not project ownership edges because containment already communicates ownership.
+3. In Dependencies, project the same entities as graph nodes and emphasize only signed typed relationships.
+4. Treat changelog category as item metadata and keep Markdown export based on the existing category/completion contracts.
+5. When an item moves between lifecycle columns, call the normal item save workflow. The coordinator validates mutability, updates the signed item, appends audit evidence transactionally, and reloads from disk.
+
+The optional schema-1 item lifecycle field is backward compatible. Legacy incomplete items project as Planned and legacy completed items as Complete. Mode, search, filters, focus, collapse, minimap, zoom, and viewport are presentation state, not a competing graph store.
+
 ### Source discovery and approval
 
 1. Resolve the linked local Git worktree.

--- a/docs/canvas-engine.md
+++ b/docs/canvas-engine.md
@@ -1,139 +1,131 @@
 # Canvas engine
 
-The canvas is the primary Blueprints workspace. It visualizes signed project entities without replacing them with a second source of truth.
+The canvas is Blueprints' primary workspace. It is a projection of canonical signed project documents, never a parallel graph store.
 
-## Graph projection
-
-The current graph is derived from existing domain relationships:
+## Authoritative data
 
 ```text
-project
-└── version
-    └── work item
+signed project
+├── versions
+│   └── work items
+├── canvas layout (shared coordinates)
+└── typed relationships
+
+machine-local view
+└── mode, viewport, zoom, search, filters, minimap and collapsed frames
 ```
 
-- The project node uses `ProjectConfigurationDocument.ProjectId`.
-- A version node uses `VersionDocument.VersionId`.
-- A work-item node uses `ItemDocument.ItemId`.
-- Ownership connector lines are derived from version ownership; they are not persisted separately.
-- User-created typed connectors are projected from the optional signed relationship graph.
+Version-to-item ownership remains authoritative in each item and version document. In Plan, the version frame visually contains its items, so ownership connector lines are deliberately omitted. Typed user-created relationships remain visible.
 
-Changing a node title, state, category, or completion value uses the existing version and item workflows. Moving a node changes only the layout document.
+## Lifecycle semantics
 
-## Typed relationships
+Plan uses four item states:
 
-The inspector can define a relationship type with a stable lowercase ID, display name, optional description, `#RRGGBB` canvas color, and directional flag. A relationship then connects any two different existing project, version, or item nodes and may carry a short label. Its color is projected on the canvas alongside the built-in ownership lines.
+| Lifecycle | Meaning |
+| --- | --- |
+| Planned | Accepted into the release plan but not started |
+| In Progress | Actively being implemented |
+| Review | Awaiting review, validation, or release acceptance |
+| Complete | Finished and eligible for normal completed-item release-note behavior |
 
-Relationship types and edges are stored together in `project/relationships.json`. Every edit increments the document revision, writes canonical signed JSON, and adds a specific audit action. A type cannot change between directional and undirected while an edge uses it. Archiving a version or item removes dangling edges in the same signed archive operation.
+`ItemDocument.WorkflowState` is optional in schema 1. For compatibility, an older incomplete item maps to Planned and an older completed item maps to Complete. Opening a legacy workspace does not rewrite it. Saving or dragging a card writes the explicit lifecycle through the normal item command; Complete and the established `IsDone` field stay consistent.
 
-The validator permits at most 100 types and 5,000 edges, rejects unknown types and entities, empty or duplicate IDs, self-links, malformed colors, and duplicate logical edges. For an undirected type, reversing endpoints does not create a distinct edge.
+The version's `ReleaseStatus` is a separate release-level lifecycle (Planned, In Progress, Frozen, Released). It is not silently reused as item workflow.
 
-## Interaction model
+## View modes
+
+- **Plan** renders movable/resizable version frames with lifecycle columns and neutral metadata-rich cards.
+- **Dependencies** uses a readable automatic graph arrangement, deemphasizes ownership, and emphasizes typed relationships.
+- **Release Notes** groups work by the authoritative changelog category.
+- **Timeline** is disabled until a target-date contract exists. Blueprints does not invent dates.
+
+Changing a view never changes ownership, changelog category, item type, or relationships.
+
+## Version frames and cards
+
+A frame header shows the version, release state, completed count/percentage, readiness summary, and blocker/open count. The header selects and moves the frame; the lower-right handle resizes it for the session; Collapse is a machine-local preference.
+
+Cards show key, a multi-line title, lifecycle, item type, changelog category, source indicator, and blocker state. Click selects; Ctrl/Shift-click adds/removes selection. Horizontal drag or Left/Right changes lifecycle. Details remain editable in the inspector when trust, conflict, and immutability rules allow it.
+
+Shared coordinates remain in signed `project/canvas-layout.json`. Frame size is currently session-local and intentionally does not expand the signed layout schema. This preserves schema-1 compatibility while the team evaluates whether size is shared structural intent.
+
+## Relationships
+
+Plan and Dependencies render only relationships from signed `project/relationships.json`. Colors come from their type; directional types draw arrowheads. Hovering or selecting an edge reveals its label/type. Selecting an entity emphasizes its incoming/outgoing edges and dims unrelated links.
+
+Connect mode:
+
+1. requires a trusted, conflict-free mutable workspace and an existing type;
+2. captures two existing entity endpoints from visible handles;
+3. opens/populates the existing relationship editor without committing;
+4. requires the user to review type and label;
+5. saves through `ProjectWorkspaceCoordinatorService.SaveRelationship`;
+6. reuses self-link, duplicate logical edge, type, endpoint, count, signing, transaction, and audit validation.
+
+Edge selection populates the same editor for type/label/source/target changes or removal. There is no second relationship store.
+
+## Inspector and toolbar
+
+The compact toolbar exposes view switching, version/item creation, Connect, search, undo/redo, arrange, fit, zoom-to-selection, zoom controls, filters, minimap, trust, sync, and readiness.
+
+The inspector has:
+
+- **Details:** version and item fields, including lifecycle and changelog category;
+- **Relationships:** type and edge editing;
+- **Evidence:** readiness and source provenance;
+- **History:** signed audit status and layout/relationship revisions.
+
+Instructions live in tooltips, accessible help, and shortcut documentation rather than permanently covering the canvas.
+
+## Navigation and keyboard
 
 | Action | Result |
 | --- | --- |
-| Click a version | Select it and open version fields in the inspector |
-| Click a work item | Select it, its owning version, and its item fields |
-| Drag empty canvas | Draw a box that selects every intersecting node |
-| Ctrl/Shift-click a node | Add or remove it from the canvas selection |
-| Drag a selected node | Move the complete selection and save a new signed layout revision on release |
-| Arrow keys | Move selected nodes by one pixel and save the layout |
-| Shift+arrow keys | Move selected nodes by ten pixels and save the layout |
-| Ctrl+A / Escape | Select every node / clear the canvas selection |
-| Middle-drag empty canvas | Pan without changing shared node positions |
-| Scroll the canvas | Save machine-local viewport offsets after a short debounce |
-| Ctrl+mouse wheel or zoom buttons | Change and save machine-local zoom |
-| Fit view | Calculate a zoom that fits the complete blueprint and return to the origin |
-| Group selector | Choose category, work type, or version lanes for related work |
-| Organize | Rebuild deterministic positions in the selected lanes and save them |
-| Undo / redo | Restore the previous or next arrangement and save it as a new signed revision |
-| Save layout | Explicitly write the current shared node positions |
-| Ctrl+S | Save shared node positions |
-| Ctrl+Z | Undo the latest node drag or auto-arrangement |
-| Ctrl+Shift+Z or Ctrl+Y | Redo the latest undone layout change |
-| Ctrl+0 | Fit the local view |
-| Ctrl+plus/minus | Zoom the local view |
+| Ctrl/Command+7, 8, 9 | Plan, Dependencies, Release Notes |
+| Ctrl/Command+F | Focus search |
+| Ctrl/Command+L | Enter/exit Connect |
+| Ctrl/Command+J | Zoom to selection |
+| Ctrl/Command+0 | Fit complete board |
+| Ctrl/Command+plus/minus | Zoom |
+| Ctrl/Command+S | Save shared coordinates |
+| Ctrl/Command+Z / Shift+Z / Y | Undo/redo layout |
+| Ctrl/Command+Shift+V | Create the named version |
+| Ctrl/Command+Shift+I | Start a work item for the selected version |
+| Left/Right in Plan | Move selected editable items through lifecycle |
+| Arrows in graph views | Move selected nodes one pixel |
+| Shift+arrows | Use a ten-pixel graph movement step |
+| Enter | Open the selected work item in the inspector |
+| Escape | Clear selection and leave Connect |
 
-Category grouping is the default because it matches changelog output. Switching grouping mode automatically organizes the canvas when mutation is allowed; the resulting node positions use the normal signed layout workflow. The grouping choice itself is a local presentation preference and does not change item categories, types, version ownership, or relationship semantics.
+The minimap is collapsible and click-to-navigate. Search and filters are view-only. Focus temporarily narrows the board to the selected item or version.
 
-Live guides appear when the edge or center of a moving node approaches another node's edge or center. The minimap shows the full graph, selected nodes, and the current viewport. Selection, guides, lane headers, and minimap visuals are session-local UI state; only resulting node coordinates are persisted.
+## Persistence and trust
 
-Editing and layout controls are disabled when the workspace is untrusted or has unresolved sync conflicts.
+Shared:
 
-## Persistence
+- entity coordinates in signed `project/canvas-layout.json`;
+- relationship types and edges in signed `project/relationships.json`;
+- lifecycle/category/type/title/content in signed item documents.
 
-Shared node positions are stored in:
+Machine-local:
 
-```text
-project/canvas-layout.json
-project/canvas-layout.sig
-```
+- persisted locally: mode, viewport, zoom, search, filters, minimap visibility, and collapsed version IDs;
+- session-local: selected inspector tab, temporary focus, and frame size.
 
-The signed layout document contains:
+Local view state is bounded and atomically replaced in `.blueprints/canvas-view.json`; it is unsigned, unaudited, unsynchronized, and cannot establish trust.
 
-- schema and project identity;
-- monotonically increasing layout revision;
-- node type, entity ID, and coordinates;
-- update time and last-modifier identity.
+Every shared mutation reopens and validates the workspace, requires trusted/conflict-free mutable state, writes canonical JSON and Ed25519 signatures, appends signed audit evidence inside the transaction, and reloads display state from disk. Frozen/released versions reject item lifecycle changes. Untrusted, corrupt, or conflict-blocked workspaces remain read-only.
 
-The document is optional for schema-1 compatibility. An older workspace without it opens normally and receives deterministic default positions. The first layout save creates revision 1.
+## Limits and performance
 
-Each successful save:
+Layout remains bounded to 10,000 entity positions and coordinates from 0 through 100,000. Relationships remain bounded to 100 types and 5,000 edges. Local zoom remains 25%–250%.
 
-1. reopens and validates the workspace;
-2. requires trusted, conflict-free mutable state;
-3. verifies every layout node refers to an existing project entity;
-4. validates coordinate, uniqueness, and size limits;
-5. writes canonical JSON and an Ed25519 detached signature;
-6. appends a signed `canvas.layout.save` audit entry;
-7. reloads displayed state from disk.
+Projection and minimap calculations are isolated in testable services. Pointer movement updates the dragged visual rather than rebuilding the graph on every event; persistence and full rerender happen on release. Filtering and mode changes rebuild projections deliberately.
 
-Layout writes do not rewrite version or item documents.
+Current limitations:
 
-Undo and redo history is held only for the current application session, is capped at 50 layout changes, and is cleared when the workspace or graph structure changes. History snapshots are not a hidden source of truth. Applying one creates a normal signed layout revision and audit entry, preserving the same validation and collaboration guarantees as a direct drag.
-
-Zoom and viewport offsets are machine-local preferences stored in:
-
-```text
-.blueprints/canvas-view.json
-```
-
-This file is not signed, audited, synchronized, or authoritative. Invalid local values fall back to the default view. Keeping viewport preferences local prevents ordinary scrolling from creating audit noise or collaboration conflicts.
-
-## Validation limits
-
-The schema-1 validator enforces:
-
-- supported node types: `project`, `version`, and `item`;
-- non-empty and unique `(nodeType, entityId)` pairs;
-- entity membership in the current workspace;
-- finite coordinates from `0` through `100000`;
-- no more than `10000` nodes;
-- matching non-empty project identity;
-- schema version `1` and revision of at least `1`.
-
-These limits prevent malformed, non-finite, or unbounded layout input from reaching Avalonia rendering.
-
-The local view-state store separately accepts zoom from `0.25` through `2.5` and non-negative offsets through `100000`.
-
-## Sync and conflicts
-
-The layout lives under `project/`, so the exchange snapshot, manifest, signature validator, push, pull, and conflict analyzer include it automatically.
-
-Two collaborators moving the same canvas from a common baseline may produce a conflict in `project/canvas-layout.json`. Blueprints deliberately treats the complete layout as one document in schema 1. Conflict resolution therefore chooses the local or shared arrangement as a whole.
-
-Version and work-item content remain separate documents. A layout conflict does not imply that their content has conflicted.
-
-The relationship graph follows the same whole-document rule. A conflict in `project/relationships.json` compares revision, types, edges, update time, and author for diagnosis, then requires choosing the complete local or shared graph. Schema 1 deliberately does not attempt an unsafe automatic edge merge.
-
-## Current limits
-
-- There is one shared release-planning canvas per project.
-- Node positions are shared project state, not per-user preferences.
-- Directional typed relationships use distinct type semantics and color, but the canvas does not yet draw arrowheads or edit labels directly on an edge.
-- Multi-selection groups nodes for movement only; lane headers are projections and do not create persistent group entities.
-- Automatic organization is deterministic but not a graph-optimization engine.
-- Layout conflict resolution is whole-document.
-- Relationship conflict resolution is whole-document.
-
-These are product limitations, not hidden behavior. Planned work belongs in the canonical [roadmap](../Roadmap.md).
+- frame size is session-local;
+- Timeline has no target-date model and is disabled;
+- relationship and layout conflicts remain whole-document;
+- automatic dependency placement is deterministic, not a general graph optimizer;
+- no automated desktop pixel suite replaces platform accessibility qualification.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,7 @@ Blueprints uses versions as durable milestone checkpoints. Each entry links a Gi
 
 | Version | Date | Milestone | Accomplishments |
 | --- | --- | --- | --- |
+| `v0.8.0` | 2026-07-31 | Interactive blueprint board | Version frames, lifecycle columns, Plan and Dependencies projections, direct typed-relationship creation, compact toolbar, tabbed inspector, search/filter/focus navigation, clickable minimap, dark canvas resources, and backward-compatible signed item lifecycle |
 | `v0.7.0` | 2026-07-31 | Repository workflow and blueprint clarity | Automatic related-work lanes, visible wide-range zoom, native repository browsing, safe clone/pull/commit/push workflows, upstream status, and removal of the former 100-proposal import cutoff |
 | `v0.6.0` | 2026-07-31 | Stable foundations and approachable desktop | Beginner-first desktop redesign, atomic signed workspace and archive mutations, migration and compatibility infrastructure, encrypted identity recovery, stable bounded provider contracts, accessibility shortcuts, threat modeling, and support targets |
 | `v0.5.0` | 2026-07-31 | VaultSync recovery integration | Passive bounded backup-health awareness, explicit project-specific exchange registration, advisory release-safety diagnostics, atomic local integration settings, and an end-to-end local/exchange restore drill |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,6 +22,8 @@ v0.3 milestone -> v0.3.0
 v0.4 milestone -> v0.4.0
 v0.5 milestone -> v0.5.0
 v0.6 milestone -> v0.6.0
+v0.7 milestone -> v0.7.0
+v0.8 milestone -> v0.8.0
 ```
 
 Use SemVer prerelease identifiers for honest intermediate checkpoints, for example `v0.2.0-alpha.2`. Use the clean `v0.x.0` form only when that roadmap milestone's exit criteria are complete. GitHub records remain marked as prereleases until v1.0.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -26,7 +26,7 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 | Source Lens proposals | Untrusted transient suggestions; no persistence before explicit approval |
 | UI input | Validated by application workflows before persistence |
 | Canvas layout | Signed shared node positions; entity references and coordinate bounds validated before rendering or saving |
-| Canvas viewport | Unsigned machine-local preference; bounded and excluded from sync and trust decisions |
+| Canvas view state | Unsigned machine-local mode, viewport, search, filters, minimap, and collapse preferences; bounded and excluded from sync and trust decisions |
 
 ## Cryptography
 
@@ -52,10 +52,12 @@ Blueprints uses signatures and explicit validation to detect unauthorized or inc
 - Only an active Admin may change membership.
 - At least one active Admin must remain.
 - Released versions reject further version and item edits.
+- Lifecycle transitions use the signed item workflow and reject untrusted, corrupt, conflicted, or immutable targets.
 - Local and shared roots may not overlap.
 - A persisted canvas node must reference an existing signed project entity.
 - Canvas coordinates, node count, project identity, schema, and uniqueness are bounded and validated.
 - Local viewport values are bounded but cannot affect signed project truth or workspace trust.
+- Direct canvas connections are proposals until the relationship editor commits through existing type, endpoint, duplicate, trust, signature, and audit validation.
 - Invalid canvas signatures place the workspace in read-only untrusted state.
 - Source discovery is read-only and enforces file, response, count, and text bounds.
 - Git write operations are explicit, use structured arguments, suppress hooks and submodule recursion, reject unsafe transports and executable repository-local configuration, cap output, and time out.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # User guide
 
-Blueprints is a desktop application for planning releases in signed local files. The main workspace is a hands-on blueprint canvas: versions and work items are visible as connected nodes, while a compact tool rail opens evidence, trust, and exchange tools.
+Blueprints is a desktop application for planning releases in signed local files. The main workspace is a hands-on blueprint board: versions contain work moving through a lifecycle, while dependency and release-note views project the same trusted documents for different tasks.
 
 ## Concepts
 
@@ -9,7 +9,7 @@ Blueprints is a desktop application for planning releases in signed local files.
 - **Identity:** a local Ed25519 key pair and display name used to sign project data.
 - **Trust:** whether required files and signatures validate.
 - **Version:** a planned release in one of four states: Planned, In Progress, Frozen, or Released.
-- **Item:** one release-note entry with an item key, type, changelog category, title, and completion state.
+- **Item:** one release-plan entry with an item key, lifecycle state, type, changelog category, title, and completion state.
 
 ## Create a project
 
@@ -25,25 +25,35 @@ A new teammate can export a signed identity invitation directly from the setup s
 
 ## Plan a release
 
-1. Enter a version name in the canvas toolbar and select **Version**.
-2. Select the version node to edit its name, state, and accomplishment notes in the inspector.
-3. Select **Work item**, enter its type, changelog group, title, and context, then select **Connect new**.
-4. Select any work-item node to edit it directly in the inspector.
-5. Drag nodes to arrange the working view, and use zoom or **Fit view** to navigate larger plans.
-6. Mark completed items as ready for release notes.
+1. Enter a version name in the compact toolbar and select **+ Version**.
+2. Select the version frame to edit its name, release state, and accomplishment notes in **Details**.
+3. Select **+ Work item**, choose Planned, In Progress, Review, or Complete, then enter type, changelog category, title, and context.
+4. Drag a work card horizontally into another lifecycle column, or use Left/Right while the card is selected.
+5. Move a version by its header, resize it from the lower-right handle, or collapse it when concentrating elsewhere.
+6. Use search, version/lifecycle filters, **Focus**, **Selection**, **Fit view**, and the clickable minimap on larger plans.
 
-The standard lines on the canvas represent ownership: a work item belongs to its version. Item keys are generated from project rules. Released versions are immutable.
+Containment is the ownership cue in Plan, so Blueprints does not draw a line from every version to every item. Changelog category stays visible as a badge and remains authoritative for release-note export. Released and Frozen versions remain immutable.
+
+## Canvas views
+
+- **Plan:** the default interactive version-frame and lifecycle-column board.
+- **Dependencies:** a graph layout that emphasizes typed relationships, direction, and labels.
+- **Release Notes:** a cleaned category projection for reviewing changelog structure.
+- **Timeline:** visibly unavailable until Blueprints has a signed target-date contract; no dates are inferred.
+
+View mode, search, filters, focus, collapsed frames, minimap visibility, zoom, and viewport are local presentation preferences. They do not modify project documents or create collaboration conflicts.
 
 ## Connect typed relationships
 
-Use **Typed relationships** in the canvas inspector when the ownership hierarchy is not enough:
+Use **Connect** in the toolbar when containment is not enough:
 
-1. Select **+**, enter a lowercase type ID such as `blocks`, a name, color, and optional meaning.
-2. Choose whether the type is directional, then save it.
-3. Choose a source and target node, add an optional label, and select **Save**.
-4. Select an existing relationship to edit or remove it.
+1. Define at least one relationship type in the **Relationships** inspector tab, including whether it is directional.
+2. Select **Connect**, then choose the visible handle on two entities.
+3. Review the populated source, target, type, and optional label in the compact relationship editor.
+4. Select **Save** to commit, or change the fields before saving.
+5. Select an edge to edit or remove it. Hover or select an edge to reveal its type/label.
 
-Typed connectors appear in their configured color. Their definitions and endpoints are signed shared project state, so changes participate in audit, push, pull, trust checks, and whole-document conflict resolution. An endpoint must exist in the current project and cannot point to itself. Archiving a node also removes relationships that would otherwise dangle.
+Directional types draw arrowheads and every type uses its configured color. Selecting a node highlights incoming/outgoing links and dims unrelated edges. Definitions and endpoints are signed shared project state, so changes participate in audit, push, pull, trust checks, duplicate/self-link validation, and whole-document conflict resolution. Connection mode is disabled when the workspace cannot mutate.
 
 ## Arrange and share the canvas
 

--- a/docs/workspace-format.md
+++ b/docs/workspace-format.md
@@ -148,7 +148,7 @@ The file is signed, audited, synchronized, and optional for schema-1 compatibili
 
 ### `.blueprints/canvas-view.json`
 
-Contains machine-local zoom and scroll offsets. It is deliberately unsigned and excluded from exchange snapshots. Invalid or missing view state falls back to zoom `1` and zero offsets without changing workspace trust.
+Contains bounded machine-local zoom and scroll offsets plus the selected canvas mode, search, filters, minimap visibility, and collapsed version-frame IDs. It is deliberately unsigned and excluded from exchange snapshots. Invalid or missing view state falls back to Plan mode, zoom `1`, zero offsets, and no filters without changing workspace trust.
 
 ### `version.json`
 
@@ -158,7 +158,9 @@ Statuses are Planned, In Progress, Frozen, and Released.
 
 ### item document
 
-Contains project/version/item IDs, stable item key, type, category, title, optional description, completion state, tags, timestamps, and last-modifier identity.
+Contains project/version/item IDs, stable item key, type, category, title, optional description, completion state, optional lifecycle state, tags, timestamps, and last-modifier identity.
+
+The optional `workflowState` uses Planned, In Progress, Review, or Complete. It was added compatibly to schema 1: a missing value maps to Planned when `isDone` is false and Complete when `isDone` is true. Blueprints does not rewrite an old item merely by opening it. New edits keep `isDone` and Complete consistent so changelog export retains its established completion behavior.
 
 ### audit entry
 


### PR DESCRIPTION
## Milestone

Promotes the verified v0.8.0 interactive-blueprint-board tree from `develop` onto `main`.

## What changed

- version frames with Planned, In Progress, Review, and Complete columns
- Plan, Dependencies, and Release Notes projections
- selectable directional typed edges and review-before-save canvas connection mode
- compact toolbar, search, filters, focus, zoom-to-selection, clickable minimap, and tabbed inspector
- backward-compatible signed item lifecycle state with fail-closed validation
- signed audit history, accessibility updates, theme resources, tests, roadmap, changelog, and release documentation

## Compatibility and security

- signed workspace schema remains version 1
- legacy incomplete/completed items map to Planned/Complete without rewrite
- lifecycle and relationship edits retain trust, conflict, immutability, signing, transactional audit, and collaboration checks
- view mode, viewport, search, filters, minimap, and collapse preferences remain machine-local

## Verification

- source tree is identical to verified `develop` commit `2b9e6b1`
- `./scripts/verify.sh`
- `dotnet format Blueprints.sln --verify-no-changes --no-restore`
- 190 tests passing, Release build with zero warnings